### PR TITLE
Relay Browser functionality

### DIFF
--- a/src-bex/background.ts
+++ b/src-bex/background.ts
@@ -119,6 +119,8 @@ declare module '@quasar/app-vite' {
       },
       BridgeResponsePayload<'blossom.upload'>,
     ];
+    'relay.browser.list': [undefined, BridgeResponsePayload<'relay.browser.list'>];
+    'relay.browser.getStatus': [undefined, BridgeResponsePayload<'relay.browser.getStatus'>];
   }
 }
 
@@ -424,4 +426,12 @@ bridge.on('nostr.nip04.decrypt', async ({ payload }: { payload: BridgeRequest<'n
 bridge.on('blossom.upload', async ({ payload }: { payload: BridgeRequest<'blossom.upload'> }) => {
   resetAutoLockTimer();
   return await dispatchMessage('blossom.upload', payload, '');
+});
+
+bridge.on('relay.browser.list', async () => {
+  return await dispatchMessage('relay.browser.list', {}, '');
+});
+
+bridge.on('relay.browser.getStatus', async () => {
+  return await dispatchMessage('relay.browser.getStatus', {}, '');
 });

--- a/src-bex/background.ts
+++ b/src-bex/background.ts
@@ -46,6 +46,7 @@ import {
   handleGetPublicKey,
   handleSignEvent,
 } from './handlers/nip07';
+import { loadSeedRelays } from 'src/services/relay-catalog';
 import { dispatchMessage } from './dispatcher';
 
 async function getActiveAlias() {
@@ -238,6 +239,10 @@ async function initialize() {
       startAutoLockTimer();
       checkAutoLock();
     }
+    // Seed relay catalog on startup
+    void loadSeedRelays().then(result => {
+      console.log(`[BEX] Seeded relay catalog: ${result.added} added, ${result.updated} updated`);
+    });
   } catch (e) {
     console.error('[BEX] Initialization error:', e);
   }

--- a/src-bex/background.ts
+++ b/src-bex/background.ts
@@ -122,6 +122,7 @@ declare module '@quasar/app-vite' {
     ];
     'relay.browser.list': [undefined, BridgeResponsePayload<'relay.browser.list'>];
     'relay.browser.getStatus': [undefined, BridgeResponsePayload<'relay.browser.getStatus'>];
+    'relay.browser.refresh': [{ force?: boolean }, BridgeResponsePayload<'relay.browser.refresh'>];
   }
 }
 
@@ -439,4 +440,8 @@ bridge.on('relay.browser.list', async () => {
 
 bridge.on('relay.browser.getStatus', async () => {
   return await dispatchMessage('relay.browser.getStatus', {}, '');
+});
+
+bridge.on('relay.browser.refresh', async ({ payload }: { payload: BridgeRequest<'relay.browser.refresh'> }) => {
+  return await dispatchMessage('relay.browser.refresh', payload, '');
 });

--- a/src-bex/dispatcher.ts
+++ b/src-bex/dispatcher.ts
@@ -19,11 +19,12 @@ import type { HandlerResult } from './types/background';
 import { handleGetPublicKey, handleSignEvent } from './handlers/nip07';
 import { handleBlossomUpload } from './handlers/blossom-handler';
 import { handleNip04Encrypt, handleNip04Decrypt } from './handlers/nip04';
+import { handleRelayBrowserList, handleRelayBrowserGetStatus } from './handlers/relay-browser-handler';
 
 /**
  * Dispatches messages to the appropriate handlers.
  * This is used by both the Quasar BEX bridge and the direct chrome.runtime.onMessage listener.
- * 
+ *
  * @param type The message type/event name
  * @param payload The message payload
  * @param origin The origin of the request (if applicable)
@@ -154,6 +155,22 @@ export async function dispatchMessage<K extends BridgeAction>(
     case 'activity.mark': {
       resetAutoLockTimer();
       return true as BridgeResponsePayload<K>;
+    }
+
+    case 'relay.browser.list': {
+      const result = await handleRelayBrowserList();
+      if (result.success) {
+        return result.data as BridgeResponsePayload<K>;
+      }
+      return [] as unknown as BridgeResponsePayload<K>;
+    }
+
+    case 'relay.browser.getStatus': {
+      const result = await handleRelayBrowserGetStatus();
+      if (result.success) {
+        return result.data as BridgeResponsePayload<K>;
+      }
+      return null as BridgeResponsePayload<K>;
     }
 
     default:

--- a/src-bex/dispatcher.ts
+++ b/src-bex/dispatcher.ts
@@ -19,7 +19,7 @@ import type { HandlerResult } from './types/background';
 import { handleGetPublicKey, handleSignEvent } from './handlers/nip07';
 import { handleBlossomUpload } from './handlers/blossom-handler';
 import { handleNip04Encrypt, handleNip04Decrypt } from './handlers/nip04';
-import { handleRelayBrowserList, handleRelayBrowserGetStatus } from './handlers/relay-browser-handler';
+import { handleRelayBrowserList, handleRelayBrowserGetStatus, handleRelayBrowserRefresh } from './handlers/relay-browser-handler';
 
 /**
  * Dispatches messages to the appropriate handlers.
@@ -171,6 +171,14 @@ export async function dispatchMessage<K extends BridgeAction>(
         return result.data as BridgeResponsePayload<K>;
       }
       return null as BridgeResponsePayload<K>;
+    }
+
+    case 'relay.browser.refresh': {
+      const result = await handleRelayBrowserRefresh(payload as any);
+      if (result.success) {
+        return true as BridgeResponsePayload<K>;
+      }
+      return { success: false, error: result.error } as unknown as BridgeResponsePayload<K>;
     }
 
     default:

--- a/src-bex/handlers/relay-browser-handler.ts
+++ b/src-bex/handlers/relay-browser-handler.ts
@@ -29,10 +29,10 @@ export async function handleRelayBrowserList(): Promise<HandlerResult<RelayCatal
  */
 export async function handleRelayBrowserGetStatus(): Promise<HandlerResult<RelayDiscoveryState | null>> {
   try {
-    const status = await db.relayDiscoveryState.get('global');
+    const status = await relayCatalogService.getDiscoveryState('global');
     return {
       success: true,
-      data: status || null,
+      data: status,
     };
   } catch (error) {
     console.error('[RelayBrowserHandler] Failed to get discovery status:', error);

--- a/src-bex/handlers/relay-browser-handler.ts
+++ b/src-bex/handlers/relay-browser-handler.ts
@@ -1,4 +1,5 @@
 import { relayCatalogService } from 'src/services/relay-catalog';
+import { relayBrowserOrchestrator } from 'src/services/relay-browser-orchestrator';
 import { db } from 'src/services/database';
 import type { RelayCatalogEntry, RelayDiscoveryState } from 'src/types/relay';
 import type { HandlerResult } from '../types/background';
@@ -39,6 +40,32 @@ export async function handleRelayBrowserGetStatus(): Promise<HandlerResult<Relay
     return {
       success: false,
       error: error instanceof Error ? error.message : 'Unknown error fetching discovery status',
+    };
+  }
+}
+
+/**
+ * Handles the 'relay.browser.refresh' action.
+ * Triggers the relay browser refresh flow.
+ */
+export async function handleRelayBrowserRefresh(payload?: { force?: boolean }): Promise<HandlerResult<void>> {
+  try {
+    const force = payload?.force || false;
+    // We don't await the full refresh here to avoid blocking the BEX response,
+    // as it can take a long time. The UI should poll getStatus to see progress.
+    relayBrowserOrchestrator.refreshCatalog(force).catch(err => {
+      console.error('[RelayBrowserHandler] Async refresh failed:', err);
+    });
+
+    return {
+      success: true,
+      data: undefined,
+    };
+  } catch (error) {
+    console.error('[RelayBrowserHandler] Failed to trigger refresh:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error triggering refresh',
     };
   }
 }

--- a/src-bex/handlers/relay-browser-handler.ts
+++ b/src-bex/handlers/relay-browser-handler.ts
@@ -1,0 +1,44 @@
+import { relayCatalogService } from 'src/services/relay-catalog';
+import { db } from 'src/services/database';
+import type { RelayCatalogEntry, RelayDiscoveryState } from 'src/types/relay';
+import type { HandlerResult } from '../types/background';
+
+/**
+ * Handles the 'relay.browser.list' action.
+ * Returns the cached relay catalog entries.
+ */
+export async function handleRelayBrowserList(): Promise<HandlerResult<RelayCatalogEntry[]>> {
+  try {
+    const entries = await relayCatalogService.getEntries();
+    return {
+      success: true,
+      data: entries,
+    };
+  } catch (error) {
+    console.error('[RelayBrowserHandler] Failed to list relays:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error fetching relay list',
+    };
+  }
+}
+
+/**
+ * Handles the 'relay.browser.getStatus' action.
+ * Returns the current relay discovery status from the database.
+ */
+export async function handleRelayBrowserGetStatus(): Promise<HandlerResult<RelayDiscoveryState | null>> {
+  try {
+    const status = await db.relayDiscoveryState.get('global');
+    return {
+      success: true,
+      data: status || null,
+    };
+  } catch (error) {
+    console.error('[RelayBrowserHandler] Failed to get discovery status:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error fetching discovery status',
+    };
+  }
+}

--- a/src/components/RelayBrowserModal.vue
+++ b/src/components/RelayBrowserModal.vue
@@ -1,8 +1,9 @@
 <script lang="ts" setup>
-import { ref, watch, onMounted } from 'vue';
+import { ref, watch, onMounted, computed, onBeforeUnmount } from 'vue';
 import { useI18n } from 'vue-i18n';
 import type { RelayCatalogEntry } from 'src/types/relay';
-import { listRelayCatalog } from 'src/services/relay-service';
+import { listRelayCatalog, refreshRelayCatalog, getRelayDiscoveryStatus } from 'src/services/relay-service';
+import { filterAndSortRelays } from 'src/utils/relay-filters';
 
 const { t } = useI18n();
 
@@ -12,10 +13,19 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: boolean): void;
+  (e: 'select', relay: RelayCatalogEntry): void;
 }>();
 
 const relays = ref<RelayCatalogEntry[]>([]);
 const loading = ref(false);
+const refreshing = ref(false);
+const searchText = ref('');
+const searchOnly = ref(false);
+let statusInterval: ReturnType<typeof setInterval> | null = null;
+
+const filteredRelays = computed(() => {
+  return filterAndSortRelays(relays.value, searchText.value, searchOnly.value);
+});
 
 async function fetchRelays() {
   if (loading.value) return;
@@ -23,6 +33,11 @@ async function fetchRelays() {
   try {
     relays.value = await listRelayCatalog();
     console.log(`[RelayBrowserModal] Fetched ${relays.value.length} relays`);
+
+    // If we have very few relays (only seeds), maybe trigger a refresh
+    if (relays.value.length < 10 && !refreshing.value) {
+       await triggerRefresh();
+    }
   } catch (error) {
     console.error('[RelayBrowserModal] Failed to fetch relays:', error);
     relays.value = [];
@@ -31,10 +46,63 @@ async function fetchRelays() {
   }
 }
 
+async function triggerRefresh(force = false) {
+  if (refreshing.value) return;
+  refreshing.value = true;
+  try {
+    await refreshRelayCatalog(force);
+    startPollingStatus();
+  } catch (error) {
+    console.error('[RelayBrowserModal] Failed to trigger refresh:', error);
+    refreshing.value = false;
+  }
+}
+
+async function checkStatus() {
+  try {
+    const status = await getRelayDiscoveryStatus();
+    if (status) {
+      refreshing.value = status.isDiscoveryInProgress;
+      // Refresh the list if discovery is happening or just finished
+      relays.value = await listRelayCatalog();
+
+      if (!status.isDiscoveryInProgress) {
+        stopPollingStatus();
+      }
+    } else {
+      refreshing.value = false;
+      stopPollingStatus();
+    }
+  } catch (error) {
+    console.error('[RelayBrowserModal] Failed to check status:', error);
+    stopPollingStatus();
+  }
+}
+
+function startPollingStatus() {
+  if (statusInterval) return;
+  statusInterval = setInterval(() => {
+    void checkStatus();
+  }, 2000);
+  void checkStatus();
+}
+
+function stopPollingStatus() {
+  if (statusInterval) {
+    clearInterval(statusInterval);
+    statusInterval = null;
+  }
+}
+
 onMounted(() => {
   if (props.modelValue) {
     void fetchRelays();
+    void checkStatus(); // Check if discovery is already in progress
   }
+});
+
+onBeforeUnmount(() => {
+  stopPollingStatus();
 });
 
 watch(
@@ -42,6 +110,9 @@ watch(
   (newVal) => {
     if (newVal) {
       void fetchRelays();
+      void checkStatus();
+    } else {
+      stopPollingStatus();
     }
   },
 );
@@ -58,6 +129,11 @@ function getDisplayName(relay: RelayCatalogEntry) {
 function close() {
   emit('update:modelValue', false);
 }
+
+function selectRelay(relay: RelayCatalogEntry) {
+  emit('select', relay);
+  close();
+}
 </script>
 
 <template>
@@ -66,20 +142,52 @@ function close() {
       <q-card-section class="row items-center q-pb-none">
         <div class="text-h6">{{ t('relays.browser.title') }}</div>
         <q-spacer />
+        <q-btn
+          flat
+          round
+          dense
+          icon="refresh"
+          :loading="refreshing"
+          class="q-mr-sm"
+          @click="triggerRefresh(true)"
+        >
+          <q-tooltip>{{ t('relays.browser.refresh') }}</q-tooltip>
+        </q-btn>
         <q-btn v-close-popup flat round dense icon="close" />
       </q-card-section>
 
-      <q-card-section class="col scroll q-pt-md">
+      <q-card-section class="q-pt-sm">
+        <q-input
+          v-model="searchText"
+          :label="t('relays.browser.search_placeholder')"
+          dense
+          outlined
+          clearable
+          class="q-mb-sm"
+        >
+          <template #append>
+            <q-icon name="search" />
+          </template>
+        </q-input>
+        <q-toggle v-model="searchOnly" :label="t('relays.browser.search_only')" dense />
+      </q-card-section>
+
+      <q-card-section class="col scroll q-pt-none">
         <div v-if="loading" class="flex justify-center q-my-md">
           <q-spinner color="primary" size="3em" />
           <div class="q-mt-sm full-width text-center">{{ t('relays.browser.loading') }}</div>
         </div>
-        <div v-else-if="relays.length === 0" class="text-center q-pa-lg text-grey">
+        <div v-else-if="filteredRelays.length === 0" class="text-center q-pa-lg text-grey">
           <q-icon name="explore" size="4em" class="q-mb-md" />
           <div>{{ t('relays.browser.empty') }}</div>
         </div>
         <q-list v-else separator>
-          <q-item v-for="relay in relays" :key="relay.url">
+          <q-item
+            v-for="relay in filteredRelays"
+            :key="relay.url"
+            clickable
+            @click="selectRelay(relay)"
+          >
             <q-item-section>
               <q-item-label>{{ getDisplayName(relay) }}</q-item-label>
               <q-item-label caption lines="1">{{ relay.url }}</q-item-label>

--- a/src/components/RelayBrowserModal.vue
+++ b/src/components/RelayBrowserModal.vue
@@ -1,6 +1,8 @@
 <script lang="ts" setup>
-import { ref } from 'vue';
+import { ref, watch, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
+import type { RelayCatalogEntry } from 'src/types/relay';
+import { listRelayCatalog } from 'src/services/relay-service';
 
 const { t } = useI18n();
 
@@ -12,7 +14,46 @@ const emit = defineEmits<{
   (e: 'update:modelValue', value: boolean): void;
 }>();
 
+const relays = ref<RelayCatalogEntry[]>([]);
 const loading = ref(false);
+
+async function fetchRelays() {
+  if (loading.value) return;
+  loading.value = true;
+  try {
+    relays.value = await listRelayCatalog();
+    console.log(`[RelayBrowserModal] Fetched ${relays.value.length} relays`);
+  } catch (error) {
+    console.error('[RelayBrowserModal] Failed to fetch relays:', error);
+    relays.value = [];
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(() => {
+  if (props.modelValue) {
+    void fetchRelays();
+  }
+});
+
+watch(
+  () => props.modelValue,
+  (newVal) => {
+    if (newVal) {
+      void fetchRelays();
+    }
+  },
+);
+
+function getDisplayName(relay: RelayCatalogEntry) {
+  try {
+    return relay.metadata?.name || relay.hostname || relay.url || 'Unknown Relay';
+  } catch (e) {
+    console.error('[RelayBrowserModal] Error in getDisplayName:', e);
+    return relay.url || 'Unknown Relay';
+  }
+}
 
 function close() {
   emit('update:modelValue', false);
@@ -21,11 +62,11 @@ function close() {
 
 <template>
   <q-dialog :model-value="props.modelValue" @update:model-value="emit('update:modelValue', $event)">
-    <q-card style="min-width: 350px; max-height: 80vh" class="column no-wrap">
+    <q-card style="min-width: 400px; max-height: 80vh" class="column no-wrap">
       <q-card-section class="row items-center q-pb-none">
         <div class="text-h6">{{ t('relays.browser.title') }}</div>
         <q-spacer />
-        <q-btn icon="close" flat round dense v-close-popup />
+        <q-btn v-close-popup flat round dense icon="close" />
       </q-card-section>
 
       <q-card-section class="col scroll q-pt-md">
@@ -33,10 +74,27 @@ function close() {
           <q-spinner color="primary" size="3em" />
           <div class="q-mt-sm full-width text-center">{{ t('relays.browser.loading') }}</div>
         </div>
-        <div v-else class="text-center q-pa-lg text-grey">
+        <div v-else-if="relays.length === 0" class="text-center q-pa-lg text-grey">
           <q-icon name="explore" size="4em" class="q-mb-md" />
           <div>{{ t('relays.browser.empty') }}</div>
         </div>
+        <q-list v-else separator>
+          <q-item v-for="relay in relays" :key="relay.url">
+            <q-item-section>
+              <q-item-label>{{ getDisplayName(relay) }}</q-item-label>
+              <q-item-label caption lines="1">{{ relay.url }}</q-item-label>
+              <q-item-label v-if="relay.metadata?.description" caption lines="2">
+                {{ relay.metadata.description }}
+              </q-item-label>
+            </q-item-section>
+            <q-item-section side>
+              <q-badge
+                :color="relay.status === 'online' ? 'positive' : 'grey'"
+                :label="relay.status"
+              />
+            </q-item-section>
+          </q-item>
+        </q-list>
       </q-card-section>
 
       <q-card-actions align="right">

--- a/src/components/RelayBrowserModal.vue
+++ b/src/components/RelayBrowserModal.vue
@@ -188,6 +188,14 @@ function selectRelay(relay: RelayCatalogEntry) {
             clickable
             @click="selectRelay(relay)"
           >
+            <q-item-section v-if="relay.metadata?.icon" avatar>
+              <q-avatar size="32px">
+                <img :src="relay.metadata.icon" alt="Relay Icon" />
+              </q-avatar>
+            </q-item-section>
+            <q-item-section v-else avatar>
+              <q-avatar size="32px" color="primary" text-color="white" icon="hub" />
+            </q-item-section>
             <q-item-section>
               <q-item-label>{{ getDisplayName(relay) }}</q-item-label>
               <q-item-label caption lines="1">{{ relay.url }}</q-item-label>

--- a/src/components/RelayBrowserModal.vue
+++ b/src/components/RelayBrowserModal.vue
@@ -1,0 +1,53 @@
+<script lang="ts" setup>
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
+
+const props = defineProps<{
+  modelValue: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void;
+}>();
+
+const loading = ref(false);
+
+function close() {
+  emit('update:modelValue', false);
+}
+</script>
+
+<template>
+  <q-dialog :model-value="props.modelValue" @update:model-value="emit('update:modelValue', $event)">
+    <q-card style="min-width: 350px; max-height: 80vh" class="column no-wrap">
+      <q-card-section class="row items-center q-pb-none">
+        <div class="text-h6">{{ t('relays.browser.title') }}</div>
+        <q-spacer />
+        <q-btn icon="close" flat round dense v-close-popup />
+      </q-card-section>
+
+      <q-card-section class="col scroll q-pt-md">
+        <div v-if="loading" class="flex justify-center q-my-md">
+          <q-spinner color="primary" size="3em" />
+          <div class="q-mt-sm full-width text-center">{{ t('relays.browser.loading') }}</div>
+        </div>
+        <div v-else class="text-center q-pa-lg text-grey">
+          <q-icon name="explore" size="4em" class="q-mb-md" />
+          <div>{{ t('relays.browser.empty') }}</div>
+        </div>
+      </q-card-section>
+
+      <q-card-actions align="right">
+        <q-btn flat :label="t('relays.browser.close')" color="primary" @click="close" />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<style scoped>
+.scroll {
+  overflow-y: auto;
+}
+</style>

--- a/src/components/RelayEditor.vue
+++ b/src/components/RelayEditor.vue
@@ -3,6 +3,7 @@ import { onMounted, ref, watch } from 'vue';
 import { useQuasar } from 'quasar';
 import { useI18n } from 'vue-i18n';
 import type { NostrRelay, StoredKey } from '../types';
+import type { RelayCatalogEntry } from 'src/types/relay';
 import { SimplePool } from 'nostr-tools';
 import { finalizeEvent } from 'nostr-tools/pure';
 import { hexToBytes } from '@noble/hashes/utils';
@@ -97,6 +98,12 @@ function addRelay() {
 
 function removeRelay(index: number) {
   relays.value.splice(index, 1);
+}
+
+function handleRelaySelected(relay: RelayCatalogEntry) {
+  newRelayUrl.value = relay.url;
+  newRelayRead.value = true;
+  newRelayWrite.value = false;
 }
 
 async function saveRelayList() {
@@ -230,7 +237,7 @@ watch(
       </div>
     </template>
 
-    <relay-browser-modal v-model="showRelayBrowser" />
+    <relay-browser-modal v-model="showRelayBrowser" @select="handleRelaySelected" />
   </div>
 </template>
 

--- a/src/components/RelayEditor.vue
+++ b/src/components/RelayEditor.vue
@@ -6,6 +6,7 @@ import type { NostrRelay, StoredKey } from '../types';
 import { SimplePool } from 'nostr-tools';
 import { finalizeEvent } from 'nostr-tools/pure';
 import { hexToBytes } from '@noble/hashes/utils';
+import RelayBrowserModal from './RelayBrowserModal.vue';
 
 defineOptions({ name: 'RelayEditor' });
 
@@ -30,6 +31,7 @@ const DEFAULT_RELAYS = [
 const newRelayUrl = ref('');
 const newRelayRead = ref(true);
 const newRelayWrite = ref(true);
+const showRelayBrowser = ref(false);
 
 async function fetchRelayList() {
   relays.value = [];
@@ -167,7 +169,13 @@ watch(
               dense
               outlined
               @keyup.enter="addRelay"
-            />
+            >
+              <template #append>
+                <q-btn flat round dense icon="explore" @click="showRelayBrowser = true">
+                  <q-tooltip>{{ $t('relays.browse') }}</q-tooltip>
+                </q-btn>
+              </template>
+            </q-input>
           </div>
           <div class="col-auto">
             <q-checkbox v-model="newRelayRead" :label="$t('relays.read')" dense />
@@ -221,6 +229,8 @@ watch(
         />
       </div>
     </template>
+
+    <relay-browser-modal v-model="showRelayBrowser" />
   </div>
 </template>
 

--- a/src/data/relay-seeds.ts
+++ b/src/data/relay-seeds.ts
@@ -1,0 +1,12 @@
+export const RELAY_SEEDS: string[] = [
+  'wss://relay.damus.io',
+  'wss://nos.lol',
+  'wss://relay.nostr.band',
+  'wss://relay.snort.social',
+  'wss://purplepag.es',
+  'wss://relay.primal.net',
+  'wss://nostr.mom',
+  'wss://offchain.pub',
+  'wss://relay.current.fyi',
+  'wss://nostr.bitcoiner.social',
+];

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -115,8 +115,12 @@ export default {
     browser: {
       title: 'Relay Browser',
       loading: 'Loading relay catalog...',
-      empty: 'No relays found in the catalog.',
+      empty: 'No relays found matching your search.',
       close: 'Close',
+      search_placeholder: 'Search by name, hostname, or URL',
+      search_only: 'Search-capable only (NIP-50)',
+      refresh: 'Refresh List',
+      refreshing: 'Refreshing...',
     },
   },
   approval: {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -104,6 +104,7 @@ export default {
     read: 'Read',
     write: 'Write',
     add: 'Add Relay',
+    browse: 'Browse',
     save: 'Save Relay List',
     fetchError: 'Failed to fetch relay list from relays',
     saveSuccess: 'Relay list updated successfully',
@@ -111,6 +112,12 @@ export default {
     invalidUrl: 'Invalid relay URL (must start with ws:// or wss://)',
     noRelays: 'No relays in the list',
     recommendedSize: 'NIP-65 recommends keeping the list small (2-4 relays per category).',
+    browser: {
+      title: 'Relay Browser',
+      loading: 'Loading relay catalog...',
+      empty: 'No relays found in the catalog.',
+      close: 'Close',
+    },
   },
   approval: {
     title: 'Approval Request',

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -1,4 +1,5 @@
 import Dexie, { type Table } from 'dexie';
+import type { RelayCatalogEntry, RelayDiscoveryState } from 'src/types/relay';
 
 export interface Vault {
   id: string; // 'master' or some unique ID
@@ -26,10 +27,12 @@ export class DiogelDatabase extends Dexie {
   vaults!: Table<Vault, string>;
   exceptions!: Table<ExceptionLog, number>;
   approvals!: Table<ApprovalLog, number>;
+  relayCatalog!: Table<RelayCatalogEntry, string>;
+  relayDiscoveryState!: Table<RelayDiscoveryState, string>;
 
   constructor() {
     super('DiogelDatabase');
-    console.log('[Database] Initializing NostrDatabase v4...');
+    console.log('[Database] Initializing DiogelDatabase v7...');
     this.version(3)
       .stores({
         vaults: 'id',
@@ -55,6 +58,14 @@ export class DiogelDatabase extends Dexie {
       vaults: 'id',
       exceptions: '++id, dateTime, account, hostname',
       approvals: '++id, dateTime, eventKind, hostname, account',
+    });
+
+    this.version(7).stores({
+      vaults: 'id',
+      exceptions: '++id, dateTime, account, hostname',
+      approvals: '++id, dateTime, eventKind, hostname, account',
+      relayCatalog: 'url, hostname, status, lastSeen, createdAt',
+      relayDiscoveryState: 'id, lastGlobalDiscoveryAt',
     });
 
     this.on('ready', () => {

--- a/src/services/relay-browser-orchestrator.ts
+++ b/src/services/relay-browser-orchestrator.ts
@@ -1,0 +1,132 @@
+import { relayCatalogService, loadSeedRelays } from './relay-catalog';
+import { relayDiscoveryService } from './relay-discovery';
+import { fetchRelayMetadata } from './relay-metadata';
+
+/**
+ * Orchestrates the relay browser refresh flow:
+ * - ensures seed relays are loaded if catalog is empty
+ * - guards against duplicate concurrent refresh runs
+ * - triggers discovery based on staleness or force flag
+ * - triggers metadata refresh for stale entries
+ * - updates discovery state (progress, last run, errors)
+ */
+export class RelayBrowserOrchestrator {
+  private isRefreshing = false;
+
+  /**
+   * Main refresh flow entry point.
+   * @param force If true, bypasses staleness checks for discovery and metadata.
+   */
+  async refreshCatalog(force = false): Promise<void> {
+    if (this.isRefreshing) {
+      console.log('[RelayBrowserOrchestrator] Refresh already in progress, skipping.');
+      return;
+    }
+
+    const state = await relayCatalogService.getDiscoveryState('global');
+    if (state?.isDiscoveryInProgress) {
+       console.log('[RelayBrowserOrchestrator] Discovery already marked in progress in DB, skipping.');
+       return;
+    }
+
+    this.isRefreshing = true;
+
+    try {
+      // 1. Initial State Update: Mark in progress
+      await relayCatalogService.updateDiscoveryState({
+        isDiscoveryInProgress: true,
+      }, 'global');
+
+      // 2. Load Seeds if empty
+      const entries = await relayCatalogService.getEntries();
+      if (entries.length === 0) {
+        console.log('[RelayBrowserOrchestrator] Catalog empty, loading seed relays...');
+        await loadSeedRelays();
+      }
+
+      // 3. Discovery Phase
+      const currentState = await relayCatalogService.getDiscoveryState('global');
+      if (force || relayCatalogService.isDiscoveryStale(currentState)) {
+        console.log('[RelayBrowserOrchestrator] Triggering discovery...');
+        const seeds = (await relayCatalogService.getEntries())
+          .filter(e => e.isSeed)
+          .map(e => e.url);
+
+        const discoveryResult = await relayDiscoveryService.discoverFromRelays(seeds);
+
+        // Upsert discovered relays
+        for (const url of discoveryResult.discoveredUrls) {
+          try {
+             const hostname = new URL(url).hostname;
+             await relayCatalogService.upsertEntry({ url, hostname, source: 'discovery' });
+          } catch (e) {
+             console.warn(`[RelayBrowserOrchestrator] Failed to parse discovered URL ${url}:`, e);
+          }
+        }
+
+        await relayCatalogService.updateDiscoveryState({
+          lastGlobalDiscoveryAt: Date.now(),
+        }, 'global');
+      } else {
+        console.log('[RelayBrowserOrchestrator] Discovery is fresh, skipping.');
+      }
+
+      // 4. Metadata Refresh Phase
+      console.log('[RelayBrowserOrchestrator] Starting metadata refresh for stale entries...');
+      const allEntries = await relayCatalogService.getEntries();
+      const staleEntries = allEntries.filter(e => force || relayCatalogService.isMetadataStale(e));
+
+      // Fetch metadata for stale entries (concurrency limited for safety)
+      // For Task 12, we can just do them sequentially or in small batches.
+      // Keeping it simple for the initial implementation.
+      for (const entry of staleEntries) {
+        try {
+          const result = await fetchRelayMetadata(entry.url);
+          if (result.success && result.metadata) {
+            await relayCatalogService.upsertEntry({
+              url: entry.url,
+              hostname: entry.hostname,
+              metadata: result.metadata,
+              status: 'online',
+              lastChecked: Date.now(),
+            });
+          } else if (!result.success) {
+            await relayCatalogService.upsertEntry({
+              url: entry.url,
+              hostname: entry.hostname,
+              status: 'error',
+              lastChecked: Date.now(),
+            });
+          }
+        } catch (e) {
+          console.error(`[RelayBrowserOrchestrator] Metadata fetch failed for ${entry.url}:`, e);
+        }
+      }
+
+      // 5. Final State Update: Success
+      await relayCatalogService.updateDiscoveryState({
+        isDiscoveryInProgress: false,
+        discoveryStats: {
+           totalDiscovered: allEntries.length,
+           newFound: allEntries.length - entries.length,
+        }
+      }, 'global');
+
+    } catch (error) {
+      console.error('[RelayBrowserOrchestrator] Refresh failed:', error);
+      // 6. Final State Update: Failure (preserve cache, record error)
+      await relayCatalogService.updateDiscoveryState({
+        isDiscoveryInProgress: false,
+        discoveryStats: {
+           totalDiscovered: (await relayCatalogService.getEntries()).length,
+           newFound: 0,
+           lastError: error instanceof Error ? error.message : String(error),
+        }
+      }, 'global');
+    } finally {
+      this.isRefreshing = false;
+    }
+  }
+}
+
+export const relayBrowserOrchestrator = new RelayBrowserOrchestrator();

--- a/src/services/relay-catalog.ts
+++ b/src/services/relay-catalog.ts
@@ -1,0 +1,63 @@
+import { db } from 'src/services/database';
+import { normalizeRelayUrl } from 'src/services/relay-url';
+import type { RelayCatalogEntry } from 'src/types/relay';
+import { RELAY_SEEDS } from 'src/data/relay-seeds';
+
+/**
+ * Loads seed relays into the catalog if they are missing or if we need to mark them as seeds.
+ * Skips invalid seeds.
+ * Preserves existing richer metadata if the entry already exists.
+ */
+export async function loadSeedRelays(): Promise<{ added: number; updated: number; skipped: number }> {
+  let added = 0;
+  let updated = 0;
+  let skipped = 0;
+
+  for (const seedUrl of RELAY_SEEDS) {
+    const result = normalizeRelayUrl(seedUrl);
+
+    if (!result.valid || !result.url || !result.hostname) {
+      skipped++;
+      continue;
+    }
+
+    const { url, hostname } = result;
+
+    try {
+      await db.transaction('rw', db.relayCatalog, async () => {
+        const existing = await db.relayCatalog.get(url);
+
+        if (existing) {
+          // If it already exists, only update if it wasn't already marked as seed
+          if (!existing.isSeed) {
+            await db.relayCatalog.update(url, {
+              isSeed: true,
+              updatedAt: Date.now(),
+            });
+            updated++;
+          }
+        } else {
+          // New seed entry
+          const now = Date.now();
+          const entry: RelayCatalogEntry = {
+            url,
+            hostname,
+            isUserAdded: false,
+            isSeed: true,
+            status: 'unknown',
+            createdAt: now,
+            updatedAt: now,
+            source: 'seed',
+          };
+          await db.relayCatalog.add(entry);
+          added++;
+        }
+      });
+    } catch (e) {
+      console.error(`[RelayCatalog] Failed to upsert seed ${url}:`, e);
+      skipped++;
+    }
+  }
+
+  return { added, updated, skipped };
+}

--- a/src/services/relay-catalog.ts
+++ b/src/services/relay-catalog.ts
@@ -26,35 +26,26 @@ export async function loadSeedRelays(): Promise<{ added: number; updated: number
     const { url, hostname } = result;
 
     try {
-      await db.transaction('rw', db.relayCatalog, async () => {
-        const existing = await db.relayCatalog.get(url);
-
-        if (existing) {
-          // If it already exists, only update if it wasn't already marked as seed
-          if (!existing.isSeed) {
-            await db.relayCatalog.update(url, {
-              isSeed: true,
-              updatedAt: Date.now(),
-            });
-            updated++;
-          }
-        } else {
-          // New seed entry
-          const now = Date.now();
-          const entry: RelayCatalogEntry = {
+      const existing = await db.relayCatalog.get(url);
+      if (existing) {
+        if (!existing.isSeed) {
+          await relayCatalogService.upsertEntry({
             url,
             hostname,
-            isUserAdded: false,
             isSeed: true,
-            status: 'unknown',
-            createdAt: now,
-            updatedAt: now,
             source: 'seed',
-          };
-          await db.relayCatalog.add(entry);
-          added++;
+          });
+          updated++;
         }
-      });
+      } else {
+        await relayCatalogService.upsertEntry({
+          url,
+          hostname,
+          isSeed: true,
+          source: 'seed',
+        });
+        added++;
+      }
     } catch (e) {
       console.error(`[RelayCatalog] Failed to upsert seed ${url}:`, e);
       skipped++;
@@ -70,6 +61,114 @@ export async function loadSeedRelays(): Promise<{ added: number; updated: number
  * This service is read-only and provides predictable formatting and sorting for the UI.
  */
 export class RelayCatalogService {
+  /**
+   * Upserts a relay catalog entry with sophisticated merging rules.
+   *
+   * Merge logic:
+   * 1. If entry exists, merge metadata: only non-empty fields replace existing ones.
+   * 2. Source markers are accumulated (comma-separated).
+   * 3. 'isSeed' and 'isUserAdded' flags are combined (OR-ed).
+   * 4. Richer metadata (like description or software) is preserved if the update has less info.
+   *
+   * @param entry Partial entry to upsert (must have url and hostname).
+   */
+  async upsertEntry(entry: Partial<RelayCatalogEntry> & { url: string; hostname: string }): Promise<void> {
+    await db.transaction('rw', db.relayCatalog, async () => {
+      const existing = await db.relayCatalog.get(entry.url);
+      const now = Date.now();
+
+      if (existing) {
+        const updates: Partial<RelayCatalogEntry> = {
+          updatedAt: now,
+        };
+
+        // 1. Merge source markers (comma-separated)
+        if (entry.source && entry.source !== existing.source) {
+          const sources = new Set(
+            (existing.source || '')
+              .split(',')
+              .map(s => s.trim())
+              .filter(Boolean),
+          );
+          entry.source
+            .split(',')
+            .map(s => s.trim())
+            .filter(Boolean)
+            .forEach(s => sources.add(s));
+          updates.source = Array.from(sources).join(',');
+        }
+
+        // 2. Combine flags
+        if (entry.isSeed !== undefined) updates.isSeed = existing.isSeed || entry.isSeed;
+        if (entry.isUserAdded !== undefined) updates.isUserAdded = existing.isUserAdded || entry.isUserAdded;
+
+        // 3. Status handling: only update if not 'error' or if the new status is better
+        // A 'failed' fetch shouldn't destroy 'online' status immediately unless we're sure
+        if (entry.status && entry.status !== 'unknown') {
+          updates.status = entry.status;
+        }
+
+        if (entry.lastChecked) updates.lastChecked = entry.lastChecked;
+        if (entry.lastSeen) updates.lastSeen = entry.lastSeen;
+
+        // 4. Metadata merging: Preserve richer data
+        if (entry.metadata) {
+          const mergedMetadata = { ...(existing.metadata || {}) };
+          let hasNewMetadata = false;
+
+          for (const [key, value] of Object.entries(entry.metadata)) {
+            const existingValue = mergedMetadata[key];
+
+            // Only overwrite if the new value is "richer" or non-empty
+            // For now, "richer" means non-null, non-undefined, and if it's a string, non-empty.
+            const isNewValueRicher =
+              value !== undefined &&
+              value !== null &&
+              (typeof value !== 'string' || value.trim().length > 0) &&
+              (existingValue === undefined || existingValue === null || (typeof existingValue === 'string' && existingValue.trim().length === 0));
+
+            // Also allow overwriting if they are both strings but new one is different and not empty
+            // (e.g. name changed)
+            const isValueChanged =
+              value !== undefined &&
+              value !== null &&
+              (typeof value !== 'string' || value.trim().length > 0) &&
+              value !== existingValue;
+
+            if (isNewValueRicher || isValueChanged) {
+              mergedMetadata[key] = value;
+              hasNewMetadata = true;
+            }
+          }
+
+          if (hasNewMetadata) {
+            updates.metadata = mergedMetadata;
+          }
+        }
+
+        await db.relayCatalog.update(entry.url, updates);
+      } else {
+        // New entry
+        const newEntry: RelayCatalogEntry = {
+          url: entry.url,
+          hostname: entry.hostname,
+          isUserAdded: entry.isUserAdded || false,
+          isSeed: entry.isSeed || false,
+          status: entry.status || 'unknown',
+          createdAt: now,
+          updatedAt: now,
+        };
+
+        if (entry.metadata !== undefined) newEntry.metadata = entry.metadata;
+        if (entry.source !== undefined) newEntry.source = entry.source;
+        if (entry.lastChecked !== undefined) newEntry.lastChecked = entry.lastChecked;
+        if (entry.lastSeen !== undefined) newEntry.lastSeen = entry.lastSeen;
+
+        await db.relayCatalog.add(newEntry);
+      }
+    });
+  }
+
   /**
    * Retrieves all valid relay catalog entries from the database, sorted by default criteria.
    *

--- a/src/services/relay-catalog.ts
+++ b/src/services/relay-catalog.ts
@@ -105,11 +105,19 @@ export class RelayCatalogService {
         // 3. Status handling: only update if not 'error' or if the new status is better
         // A 'failed' fetch shouldn't destroy 'online' status immediately unless we're sure
         if (entry.status && entry.status !== 'unknown') {
-          updates.status = entry.status;
+          // If existing is 'online' and new is 'error' or 'offline', we only downgrade if it's been a while
+          const isDowngrade =
+            existing.status === 'online' && (entry.status === 'offline' || entry.status === 'error');
+          const isRecentlySeen = existing.lastSeen && now - existing.lastSeen < 60 * 60 * 1000; // 1 hour
+
+          if (!isDowngrade || !isRecentlySeen) {
+            updates.status = entry.status;
+          }
         }
 
         if (entry.lastChecked) updates.lastChecked = entry.lastChecked;
         if (entry.lastSeen) updates.lastSeen = entry.lastSeen;
+        else if (entry.status === 'online') updates.lastSeen = now;
 
         // 4. Metadata merging: Preserve richer data
         if (entry.metadata) {
@@ -163,6 +171,7 @@ export class RelayCatalogService {
         if (entry.source !== undefined) newEntry.source = entry.source;
         if (entry.lastChecked !== undefined) newEntry.lastChecked = entry.lastChecked;
         if (entry.lastSeen !== undefined) newEntry.lastSeen = entry.lastSeen;
+        else if (entry.status === 'online') newEntry.lastSeen = now;
 
         await db.relayCatalog.add(newEntry);
       }

--- a/src/services/relay-catalog.ts
+++ b/src/services/relay-catalog.ts
@@ -3,11 +3,6 @@ import { normalizeRelayUrl } from 'src/services/relay-url';
 import type { RelayCatalogEntry } from 'src/types/relay';
 import { RELAY_SEEDS } from 'src/data/relay-seeds';
 
-/**
- * Loads seed relays into the catalog if they are missing or if we need to mark them as seeds.
- * Skips invalid seeds.
- * Preserves existing richer metadata if the entry already exists.
- */
 export async function loadSeedRelays(): Promise<{ added: number; updated: number; skipped: number }> {
   let added = 0;
   let updated = 0;
@@ -61,3 +56,94 @@ export async function loadSeedRelays(): Promise<{ added: number; updated: number
 
   return { added, updated, skipped };
 }
+
+
+/**
+ * Service for reading relay catalog entries from the database.
+ * This service is read-only and provides predictable formatting and sorting for the UI.
+ */
+export class RelayCatalogService {
+  /**
+   * Retrieves all valid relay catalog entries from the database, sorted by default criteria.
+   *
+   * Default sort order:
+   * 1. Seeded entries with metadata
+   * 2. Discovered entries with metadata
+   * 3. Entries without metadata
+   * 4. Unreachable or failed entries last
+   *
+   * @returns A promise that resolves to a stable array of sorted RelayCatalogEntry objects.
+   */
+  async getEntries(): Promise<RelayCatalogEntry[]> {
+    const allEntries = await db.relayCatalog.toArray();
+
+    // Filter out obviously invalid entries (e.g., missing URL)
+    // And return clones to prevent mutation of the underlying data
+    const validEntries = allEntries
+      .filter(entry => this.isValidEntry(entry))
+      .map(entry => ({ ...entry }));
+
+    // Sort entries based on the required criteria
+    return validEntries.sort((a, b) => this.compareEntries(a, b));
+  }
+
+  /**
+   * Checks if a relay catalog entry is considered valid for UI presentation.
+   * @param entry The entry to validate.
+   * @returns True if the entry is valid, false otherwise.
+   */
+  private isValidEntry(entry: RelayCatalogEntry): boolean {
+    if (!entry.url || typeof entry.url !== 'string') return false;
+    // Basic validation for relay URL scheme
+    return entry.url.startsWith('ws://') || entry.url.startsWith('wss://');
+  }
+
+  /**
+   * Comparison function for sorting relay catalog entries.
+   *
+   * Logic:
+   * - Entries with status 'online' or 'unknown' are preferred over 'offline' or 'error'.
+   * - Seeded entries with metadata > Discovered entries with metadata > Entries without metadata.
+   * - Within the same category, sort alphabetically by URL for determinism.
+   */
+  private compareEntries(a: RelayCatalogEntry, b: RelayCatalogEntry): number {
+    const scoreA = this.getEntryScore(a);
+    const scoreB = this.getEntryScore(b);
+
+    if (scoreA !== scoreB) {
+      return scoreB - scoreA; // Higher score first
+    }
+
+    // Deterministic fallback: sort by URL
+    return a.url.localeCompare(b.url);
+  }
+
+  /**
+   * Calculates a priority score for an entry to help with sorting.
+   * Higher score means higher priority.
+   */
+  private getEntryScore(entry: RelayCatalogEntry): number {
+    // Unreachable or failed entries last
+    if (entry.status === 'offline' || entry.status === 'error') {
+      return 0;
+    }
+
+    const hasMetadata = !!(entry.metadata && (entry.metadata.name || entry.metadata.description));
+
+    if (entry.isSeed && hasMetadata) {
+      return 4;
+    }
+
+    if (hasMetadata) {
+      return 3;
+    }
+
+    if (entry.isSeed || entry.isUserAdded) {
+      return 2;
+    }
+
+    return 1;
+  }
+}
+
+export const relayCatalogService = new RelayCatalogService();

--- a/src/services/relay-catalog.ts
+++ b/src/services/relay-catalog.ts
@@ -1,7 +1,14 @@
 import { db } from 'src/services/database';
 import { normalizeRelayUrl } from 'src/services/relay-url';
-import type { RelayCatalogEntry } from 'src/types/relay';
+import type { RelayCatalogEntry, RelayDiscoveryState } from 'src/types/relay';
 import { RELAY_SEEDS } from 'src/data/relay-seeds';
+
+/**
+ * Constants for relay discovery and metadata staleness thresholds (in milliseconds).
+ * These are easily adjustable for later tuning.
+ */
+export const DISCOVERY_STALENESS_THRESHOLD = 24 * 60 * 60 * 1000; // 24 hours
+export const METADATA_STALENESS_THRESHOLD = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 export async function loadSeedRelays(): Promise<{ added: number; updated: number; skipped: number }> {
   let added = 0;
@@ -143,6 +150,80 @@ export class RelayCatalogService {
     }
 
     return 1;
+  }
+
+  /**
+   * Retrieves the current discovery state from the database.
+   * @param id The ID of the discovery task (defaults to 'global').
+   * @returns The discovery state or null if not found.
+   */
+  async getDiscoveryState(id = 'global'): Promise<RelayDiscoveryState | null> {
+    return (await db.relayDiscoveryState.get(id)) || null;
+  }
+
+  /**
+   * Updates the discovery state in the database.
+   * Creates it if it doesn't exist.
+   * @param id The ID of the discovery task (defaults to 'global').
+   * @param updates The fields to update.
+   */
+  async updateDiscoveryState(updates: Partial<RelayDiscoveryState>, id = 'global'): Promise<void> {
+    await db.transaction('rw', db.relayDiscoveryState, async () => {
+      const existing = await db.relayDiscoveryState.get(id);
+      const now = Date.now();
+
+      if (existing) {
+        await db.relayDiscoveryState.update(id, {
+          ...updates,
+          updatedAt: now,
+        });
+      } else {
+        const newState: RelayDiscoveryState = {
+          id,
+          isDiscoveryInProgress: false,
+          updatedAt: now,
+          ...updates,
+        };
+        await db.relayDiscoveryState.add(newState);
+      }
+    });
+  }
+
+  /**
+   * Determines if global discovery should be refreshed based on staleness rules.
+   *
+   * Logic:
+   * 1. No state -> refresh
+   * 2. In progress -> no refresh (avoid duplicates)
+   * 3. Older than DISCOVERY_STALENESS_THRESHOLD -> refresh
+   *
+   * @param state The current discovery state.
+   * @returns True if discovery is stale and should be refreshed.
+   */
+  isDiscoveryStale(state: RelayDiscoveryState | null): boolean {
+    if (!state) return true;
+    if (state.isDiscoveryInProgress) return false;
+    if (!state.lastGlobalDiscoveryAt) return true;
+
+    return Date.now() - state.lastGlobalDiscoveryAt > DISCOVERY_STALENESS_THRESHOLD;
+  }
+
+  /**
+   * Determines if relay metadata should be refreshed.
+   *
+   * Logic:
+   * 1. Status 'unknown' -> refresh
+   * 2. No lastChecked timestamp -> refresh
+   * 3. Older than METADATA_STALENESS_THRESHOLD -> refresh
+   *
+   * @param entry The relay catalog entry.
+   * @returns True if metadata is stale and should be refreshed.
+   */
+  isMetadataStale(entry: RelayCatalogEntry): boolean {
+    if (entry.status === 'unknown') return true;
+    if (!entry.lastChecked) return true;
+
+    return Date.now() - entry.lastChecked > METADATA_STALENESS_THRESHOLD;
   }
 }
 

--- a/src/services/relay-discovery.ts
+++ b/src/services/relay-discovery.ts
@@ -1,0 +1,123 @@
+import { SimplePool, type Event } from 'nostr-tools';
+import { normalizeRelayUrl } from './relay-url';
+
+/**
+ * Normalizes and deduplicates a list of relay URLs.
+ * @param urls Array of raw relay URL strings
+ * @returns Array of unique, normalized, and valid relay URL strings
+ */
+export function normalizeAndDeduplicateRelays(urls: string[]): string[] {
+  const uniqueUrls = new Set<string>();
+  for (const url of urls) {
+    const result = normalizeRelayUrl(url);
+    if (result.valid && result.url) {
+      uniqueUrls.add(result.url);
+    }
+  }
+  return Array.from(uniqueUrls);
+}
+
+/**
+ * Parses a kind 10002 event and extracts relay URLs from its 'r' tags.
+ * Kind 10002 tags are formatted as ['r', 'wss://relay.url', 'read|write' (optional)]
+ * @param event The Nostr event object (expected kind 10002)
+ * @returns Array of raw relay URL strings extracted from the event
+ */
+export function parseRelayListEvent(event: Event): string[] {
+  if (!event || typeof event !== 'object') return [];
+  if (event.kind !== 10002) return [];
+  if (!Array.isArray(event.tags)) return [];
+
+  const urls: string[] = [];
+  for (const tag of event.tags) {
+    if (Array.isArray(tag) && tag[0] === 'r' && typeof tag[1] === 'string') {
+      urls.push(tag[1]);
+    }
+  }
+  return urls;
+}
+
+export interface DiscoveryResult {
+  discoveredUrls: string[];
+  processedEvents: number;
+  errors: string[];
+}
+
+const pool = new SimplePool();
+
+/**
+ * Bounded relay discovery service that extracts relay candidates from kind 10002 events.
+ */
+export class RelayDiscoveryService {
+  /**
+   * Discovers relay candidates by querying a bounded set of relays for kind 10002 events.
+   * @param seedRelays Bounded set of relays to query
+   * @param limit Maximum number of events to fetch (optional)
+   * @returns Structured discovery result
+   */
+  async discoverFromRelays(seedRelays: string[], limit = 50): Promise<DiscoveryResult> {
+    const allUrls: string[] = [];
+    const errors: string[] = [];
+    let processedCount = 0;
+
+    try {
+      // Query for recent kind 10002 events from the seed relays
+      const events = await pool.querySync(seedRelays, {
+        kinds: [10002],
+        limit,
+      });
+
+      for (const event of events) {
+        try {
+          const urls = parseRelayListEvent(event);
+          if (urls.length > 0) {
+            allUrls.push(...urls);
+            processedCount++;
+          }
+        } catch (err) {
+          errors.push(`Error parsing event ${event.id}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+    } catch (err) {
+      errors.push(`Discovery query failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    return {
+      discoveredUrls: normalizeAndDeduplicateRelays(allUrls),
+      processedEvents: processedCount,
+      errors,
+    };
+  }
+
+  /**
+   * Processes a set of kind 10002 events and returns a list of unique, normalized relay URLs.
+   * @param events Array of Nostr events (should be kind 10002)
+   * @returns Structured discovery result
+   */
+  processEvents(events: Event[]): DiscoveryResult {
+    const allUrls: string[] = [];
+    const errors: string[] = [];
+    let processedCount = 0;
+
+    for (const event of events) {
+      if (!event) continue;
+      try {
+        const urls = parseRelayListEvent(event);
+        if (urls.length > 0) {
+          allUrls.push(...urls);
+          processedCount++;
+        }
+      } catch (err) {
+        errors.push(err instanceof Error ? err.message : String(err));
+      }
+    }
+
+    return {
+      discoveredUrls: normalizeAndDeduplicateRelays(allUrls),
+      processedEvents: processedCount,
+      errors,
+    };
+  }
+}
+
+export const relayDiscoveryService = new RelayDiscoveryService();

--- a/src/services/relay-metadata.ts
+++ b/src/services/relay-metadata.ts
@@ -1,0 +1,165 @@
+import { normalizeRelayUrl } from './relay-url';
+
+export interface RelayMetadata {
+  name?: string;
+  description?: string;
+  pubkey?: string;
+  contact?: string;
+  supported_nips?: number[];
+  software?: string;
+  version?: string;
+  [key: string]: unknown;
+}
+
+export interface RelayMetadataResult {
+  success: boolean;
+  url: string;
+  metadata?: RelayMetadata;
+  error?: string;
+  timestamp: number;
+}
+
+/**
+ * Converts a WebSocket relay URL (wss:// or ws://) to its NIP-11 metadata fetch URL (https:// or http://).
+ * @param relayUrl The WebSocket relay URL to convert.
+ * @returns The corresponding NIP-11 metadata fetch URL.
+ * @throws Error if the URL is invalid or has an unsupported protocol.
+ */
+export function getNip11Url(relayUrl: string): string {
+  const { valid, url } = normalizeRelayUrl(relayUrl);
+  if (!valid || !url) {
+    throw new Error(`Invalid relay URL: ${relayUrl}`);
+  }
+
+  const parsed = new URL(url);
+  if (parsed.protocol === 'wss:') {
+    parsed.protocol = 'https:';
+  } else if (parsed.protocol === 'ws:') {
+    parsed.protocol = 'http:';
+  } else {
+    throw new Error(`Unsupported relay protocol: ${parsed.protocol}`);
+  }
+
+  return parsed.toString();
+}
+
+/**
+ * Fetches NIP-11 metadata for a relay with a specified timeout.
+ * @param relayUrl The normalized WebSocket relay URL.
+ * @param timeoutMs The timeout in milliseconds (default: 5000).
+ * @returns A structured result containing metadata or error.
+ */
+export async function fetchRelayMetadata(
+  relayUrl: string,
+  timeoutMs = 5000
+): Promise<RelayMetadataResult> {
+  const timestamp = Date.now();
+  let nip11Url: string;
+
+  try {
+    nip11Url = getNip11Url(relayUrl);
+  } catch (err) {
+    return {
+      success: false,
+      url: relayUrl,
+      error: err instanceof Error ? err.message : String(err),
+      timestamp,
+    };
+  }
+
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(nip11Url, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/nostr+json',
+      },
+      signal: controller.signal,
+    });
+
+    clearTimeout(id);
+
+    if (!response.ok) {
+      return {
+        success: false,
+        url: relayUrl,
+        error: `HTTP error ${response.status}: ${response.statusText}`,
+        timestamp,
+      };
+    }
+
+    const data = await response.json();
+
+    // Validate that the data is an object
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+        return {
+            success: false,
+            url: relayUrl,
+            error: 'Invalid NIP-11 response: expected JSON object',
+            timestamp,
+        };
+    }
+
+    return {
+      success: true,
+      url: relayUrl,
+      metadata: mapNip11Response(data),
+      timestamp,
+    };
+  } catch (err) {
+    clearTimeout(id);
+    let errorMessage = 'Fetch failed';
+    if (err instanceof Error) {
+      if (err.name === 'AbortError') {
+        errorMessage = `Timeout after ${timeoutMs}ms`;
+      } else {
+        errorMessage = err.message;
+      }
+    } else {
+      errorMessage = String(err);
+    }
+
+    return {
+      success: false,
+      url: relayUrl,
+      error: errorMessage,
+      timestamp,
+    };
+  }
+}
+
+/**
+ * Maps a raw NIP-11 response object into the structured RelayMetadata shape.
+ * This ensures that fields match the expected types and structure.
+ * @param data The raw JSON object from the relay.
+ * @returns A structured RelayMetadata object.
+ */
+function mapNip11Response(data: Record<string, unknown>): RelayMetadata {
+  const metadata: RelayMetadata = {};
+
+  if (typeof data.name === 'string') metadata.name = data.name;
+  if (typeof data.description === 'string') metadata.description = data.description;
+  if (typeof data.pubkey === 'string') metadata.pubkey = data.pubkey;
+  if (typeof data.contact === 'string') metadata.contact = data.contact;
+  if (typeof data.software === 'string') metadata.software = data.software;
+  if (typeof data.version === 'string') metadata.version = data.version;
+
+  if (Array.isArray(data.supported_nips)) {
+    metadata.supported_nips = data.supported_nips
+      .map((nip) => Number(nip))
+      .filter((nip) => !isNaN(nip));
+  }
+
+  // Preserve other fields for flexibility, but sanitize if needed
+  // For now, we just pass through what's in the response to metadata
+  // to support additional NIP-11 fields (like limitation, relay_countries, etc.)
+  Object.keys(data).forEach(key => {
+    if (!['name', 'description', 'pubkey', 'contact', 'supported_nips', 'software', 'version'].includes(key)) {
+      metadata[key] = data[key];
+    }
+  });
+
+  return metadata;
+}

--- a/src/services/relay-service.ts
+++ b/src/services/relay-service.ts
@@ -1,4 +1,4 @@
-import type { RelayCatalogEntry } from 'src/types/relay';
+import type { RelayCatalogEntry, RelayDiscoveryState } from 'src/types/relay';
 import { sendBexMessage } from './vault-service';
 
 /**
@@ -11,5 +11,30 @@ export async function listRelayCatalog(): Promise<RelayCatalogEntry[]> {
   } catch (error) {
     console.error('[RelayService] Failed to fetch relay catalog:', error);
     return [];
+  }
+}
+
+/**
+ * Trigger a refresh of the relay catalog from the background.
+ * @param force If true, bypasses staleness checks.
+ */
+export async function refreshRelayCatalog(force = false): Promise<void> {
+  try {
+    await sendBexMessage('relay.browser.refresh', { force });
+  } catch (error) {
+    console.error('[RelayService] Failed to trigger relay catalog refresh:', error);
+  }
+}
+
+/**
+ * Get current relay discovery status from the background.
+ */
+export async function getRelayDiscoveryStatus(): Promise<RelayDiscoveryState | null> {
+  try {
+    const data = await sendBexMessage('relay.browser.getStatus');
+    return data || null;
+  } catch (error) {
+    console.error('[RelayService] Failed to fetch relay discovery status:', error);
+    return null;
   }
 }

--- a/src/services/relay-service.ts
+++ b/src/services/relay-service.ts
@@ -1,0 +1,15 @@
+import type { RelayCatalogEntry } from 'src/types/relay';
+import { sendBexMessage } from './vault-service';
+
+/**
+ * Fetch cached relay catalog entries from the background.
+ */
+export async function listRelayCatalog(): Promise<RelayCatalogEntry[]> {
+  try {
+    const data = await sendBexMessage('relay.browser.list');
+    return data || [];
+  } catch (error) {
+    console.error('[RelayService] Failed to fetch relay catalog:', error);
+    return [];
+  }
+}

--- a/src/services/relay-url.ts
+++ b/src/services/relay-url.ts
@@ -51,9 +51,9 @@ export function normalizeRelayUrl(input: string | null | undefined): RelayUrlRes
 
     let normalizedUrl = url.toString();
 
-    // If the URL ends with a slash and the pathname was just '/', we trim it for consistency
+    // If the URL ends with a slash and the pathname was just '/' or a path like '/path/', we trim it for consistency
     // but only if it doesn't have search params or hash which would be unusual for a relay but possible.
-    if (url.pathname === '/' && !url.search && !url.hash && normalizedUrl.endsWith('/')) {
+    if (url.pathname.endsWith('/') && !url.search && !url.hash && normalizedUrl.endsWith('/')) {
       normalizedUrl = normalizedUrl.slice(0, -1);
     }
 

--- a/src/services/relay-url.ts
+++ b/src/services/relay-url.ts
@@ -1,0 +1,71 @@
+export interface RelayUrlResult {
+  valid: boolean;
+  url?: string;
+  hostname?: string;
+  error?: string;
+}
+
+/**
+ * Normalizes and validates a relay websocket URL.
+ *
+ * Requirements:
+ * - trim whitespace
+ * - reject empty values
+ * - accept only ws:// and wss:// URLs
+ * - reject malformed URLs
+ * - normalize hostname casing where safe
+ * - normalize trailing slash handling consistently
+ * - derive hostname for display/sorting
+ * - return structured success/failure output
+ *
+ * @param input The raw URL string from user input or discovery
+ * @returns Structured normalization result
+ */
+export function normalizeRelayUrl(input: string | null | undefined): RelayUrlResult {
+  if (!input || input.trim().length === 0) {
+    return {
+      valid: false,
+      error: 'URL cannot be empty',
+    };
+  }
+
+  const trimmed = input.trim();
+
+  try {
+    const url = new URL(trimmed);
+
+    if (url.protocol !== 'ws:' && url.protocol !== 'wss:') {
+      return {
+        valid: false,
+        error: 'Only ws:// and wss:// protocols are supported',
+      };
+    }
+
+    // URL constructor already handles:
+    // - hostname casing (normalizes to lowercase)
+    // - basic malformed URL rejection (throws)
+
+    // Normalize trailing slash: URL object includes a trailing slash for the pathname if it's empty.
+    // We want a consistent format. Many Nostr clients prefer no trailing slash if the path is empty.
+    // However, if there is a path (e.g. ws://relay.com/path), we should keep it.
+
+    let normalizedUrl = url.toString();
+
+    // If the URL ends with a slash and the pathname was just '/', we trim it for consistency
+    // but only if it doesn't have search params or hash which would be unusual for a relay but possible.
+    if (url.pathname === '/' && !url.search && !url.hash && normalizedUrl.endsWith('/')) {
+      normalizedUrl = normalizedUrl.slice(0, -1);
+    }
+
+    return {
+      valid: true,
+      url: normalizedUrl,
+      hostname: url.hostname,
+    };
+  } catch {
+    return {
+      valid: false,
+      error: 'Invalid URL format',
+    };
+  }
+}

--- a/src/services/vault-service.ts
+++ b/src/services/vault-service.ts
@@ -14,7 +14,7 @@ const getBridge = (): any => {
   return (window as any).bridge || (window as any).$q?.bex;
 };
 
-async function sendBexMessage<T extends BridgeAction>(
+export async function sendBexMessage<T extends BridgeAction>(
   type: T,
   payload?: Omit<BridgeRequestMap[T], 'id' | 'action'>,
 ): Promise<BridgeResponsePayload<T> | undefined> {

--- a/src/types/bridge-types.ts
+++ b/src/types/bridge-types.ts
@@ -76,7 +76,8 @@ export type BridgeAction =
   | 'activity.mark'
   | 'nostr.approval.respond'
   | 'relay.browser.list'
-  | 'relay.browser.getStatus';
+  | 'relay.browser.getStatus'
+  | 'relay.browser.refresh';
 
 // Request/Response mapping
 export interface BridgeRequestMap {
@@ -218,6 +219,11 @@ export interface BridgeRequestMap {
     id: string;
     action: 'relay.browser.getStatus';
   };
+  'relay.browser.refresh': {
+    id: string;
+    action: 'relay.browser.refresh';
+    force?: boolean;
+  };
 }
 
 export interface BridgeResponseMap {
@@ -245,6 +251,7 @@ export interface BridgeResponseMap {
   'nostr.approval.respond': boolean | { success: boolean };
   'relay.browser.list': RelayCatalogEntry[];
   'relay.browser.getStatus': RelayDiscoveryState | null;
+  'relay.browser.refresh': boolean | { success: false; error: string };
 }
 
 export type BridgeRequest<K extends BridgeAction> = BridgeRequestMap[K];

--- a/src/types/bridge-types.ts
+++ b/src/types/bridge-types.ts
@@ -1,4 +1,5 @@
 import type { StoredKey } from './index.d';
+import type { RelayCatalogEntry, RelayDiscoveryState } from './relay';
 
 /**
  * Common types shared between UI and Background/Content Script
@@ -73,7 +74,9 @@ export type BridgeAction =
   | 'vault.export'
   | 'vault.import'
   | 'activity.mark'
-  | 'nostr.approval.respond';
+  | 'nostr.approval.respond'
+  | 'relay.browser.list'
+  | 'relay.browser.getStatus';
 
 // Request/Response mapping
 export interface BridgeRequestMap {
@@ -207,6 +210,14 @@ export interface BridgeRequestMap {
     duration: string;
     requestId?: string;
   };
+  'relay.browser.list': {
+    id: string;
+    action: 'relay.browser.list';
+  };
+  'relay.browser.getStatus': {
+    id: string;
+    action: 'relay.browser.getStatus';
+  };
 }
 
 export interface BridgeResponseMap {
@@ -232,6 +243,8 @@ export interface BridgeResponseMap {
   'vault.import': { success: boolean; error?: string };
   'activity.mark': boolean | void;
   'nostr.approval.respond': boolean | { success: boolean };
+  'relay.browser.list': RelayCatalogEntry[];
+  'relay.browser.getStatus': RelayDiscoveryState | null;
 }
 
 export type BridgeRequest<K extends BridgeAction> = BridgeRequestMap[K];

--- a/src/types/relay.ts
+++ b/src/types/relay.ts
@@ -11,7 +11,7 @@ export interface RelayCatalogEntry {
     supported_nips?: number[];
     software?: string;
     version?: string;
-    [key: string]: any;
+    [key: string]: unknown;
   };
   status: 'unknown' | 'online' | 'offline' | 'error';
   lastSeen?: number; // timestamp

--- a/src/types/relay.ts
+++ b/src/types/relay.ts
@@ -1,0 +1,34 @@
+export interface RelayCatalogEntry {
+  url: string; // canonical relay URL (primary key)
+  hostname: string;
+  isUserAdded: boolean; // manually added by user
+  isSeed: boolean; // comes from hardcoded seeds
+  metadata?: {
+    name?: string;
+    description?: string;
+    pubkey?: string;
+    contact?: string;
+    supported_nips?: number[];
+    software?: string;
+    version?: string;
+    [key: string]: any;
+  };
+  status: 'unknown' | 'online' | 'offline' | 'error';
+  lastSeen?: number; // timestamp
+  lastChecked?: number; // timestamp
+  createdAt: number; // timestamp
+  updatedAt: number; // timestamp
+  source?: string; // e.g. 'discovery', 'nprofile', 'manual', 'seed'
+}
+
+export interface RelayDiscoveryState {
+  id: string; // 'global' or some specific discovery task ID
+  lastGlobalDiscoveryAt?: number; // timestamp
+  isDiscoveryInProgress: boolean;
+  discoveryStats?: {
+    totalDiscovered: number;
+    newFound: number;
+    lastError?: string;
+  };
+  updatedAt: number;
+}

--- a/src/types/relay.ts
+++ b/src/types/relay.ts
@@ -11,6 +11,7 @@ export interface RelayCatalogEntry {
     supported_nips?: number[];
     software?: string;
     version?: string;
+    icon?: string;
     [key: string]: unknown;
   };
   status: 'unknown' | 'online' | 'offline' | 'error';

--- a/src/utils/relay-filters.ts
+++ b/src/utils/relay-filters.ts
@@ -1,0 +1,51 @@
+import type { RelayCatalogEntry } from 'src/types/relay';
+
+export function filterAndSortRelays(
+  relays: RelayCatalogEntry[],
+  searchText: string,
+  searchOnly: boolean,
+): RelayCatalogEntry[] {
+  const normalizedSearch = searchText.toLowerCase().trim();
+
+  return relays
+    .filter((relay) => {
+      // 1. Filter by searchCapable (NIP-50)
+      if (searchOnly) {
+        const supportedNips = relay.metadata?.supported_nips || [];
+        if (!supportedNips.includes(50)) {
+          return false;
+        }
+      }
+
+      // 2. Filter by text (name, hostname, URL)
+      if (normalizedSearch) {
+        const name = (relay.metadata?.name || '').toLowerCase();
+        const hostname = (relay.hostname || '').toLowerCase();
+        const url = (relay.url || '').toLowerCase();
+
+        if (
+          !name.includes(normalizedSearch) &&
+          !hostname.includes(normalizedSearch) &&
+          !url.includes(normalizedSearch)
+        ) {
+          return false;
+        }
+      }
+
+      return true;
+    })
+    .sort((a, b) => {
+      // 3. Deterministic Sort (Name/Hostname first, then URL)
+      const nameA = (a.metadata?.name || a.hostname || a.url).toLowerCase();
+      const nameB = (b.metadata?.name || b.hostname || b.url).toLowerCase();
+
+      if (nameA < nameB) return -1;
+      if (nameA > nameB) return 1;
+
+      // If names are identical, fallback to URL for stability
+      if (a.url < b.url) return -1;
+      if (a.url > b.url) return 1;
+
+      return 0;
+    });
+}

--- a/tests/unit/components/RelayBrowserModal.test.ts
+++ b/tests/unit/components/RelayBrowserModal.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi } from 'vitest';
-import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
 import RelayBrowserModal from 'src/components/RelayBrowserModal.vue';
+import { listRelayCatalog } from 'src/services/relay-service';
 
 const i18nMock = {
   t: (key: string) => key,
@@ -10,89 +11,194 @@ vi.mock('vue-i18n', () => ({
   useI18n: () => i18nMock,
 }));
 
+vi.mock('src/services/relay-service', () => ({
+  listRelayCatalog: vi.fn(),
+}));
+
+const stubs = {
+  'q-dialog': {
+    template: '<div><slot v-if="modelValue" /></div>',
+    props: ['modelValue'],
+  },
+  'q-card': {
+    template: '<div><slot /></div>',
+  },
+  'q-card-section': {
+    template: '<div><slot /></div>',
+  },
+  'q-card-actions': {
+    template: '<div><slot /></div>',
+  },
+  'q-btn': {
+    template: '<button @click="$emit(\'click\')">{{ label }}<slot /></button>',
+    props: ['label', 'icon'],
+  },
+  'q-spacer': {
+    template: '<div />',
+  },
+  'q-spinner': {
+    template: '<div />',
+  },
+  'q-icon': {
+    template: '<div />',
+    props: ['name'],
+  },
+  'q-list': {
+    template: '<div><slot /></div>',
+  },
+  'q-item': {
+    template: '<div><slot /></div>',
+  },
+  'q-item-section': {
+    template: '<div><slot /></div>',
+    props: ['side'],
+  },
+  'q-item-label': {
+    template: '<div><slot /></div>',
+    props: ['caption', 'lines'],
+  },
+  'q-badge': {
+    template: '<span>{{ label }}</span>',
+    props: ['color', 'label'],
+  },
+};
+
+const directives = {
+  'close-popup': vi.fn(),
+};
+
 describe('RelayBrowserModal.vue', () => {
-  it('renders correctly when modelValue is true', async () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders correctly when modelValue is true and shows empty state', async () => {
+    vi.mocked(listRelayCatalog).mockResolvedValue([]);
+
     const wrapper = mount(RelayBrowserModal, {
       props: {
         modelValue: true,
       },
       global: {
-        stubs: {
-          'q-dialog': {
-            template: '<div><slot /></div>',
-            props: ['modelValue']
-          },
-          'q-card': {
-            template: '<div><slot /></div>',
-          },
-          'q-card-section': {
-            template: '<div><slot /></div>',
-          },
-          'q-card-actions': {
-            template: '<div><slot /></div>',
-          },
-          'q-btn': {
-            template: '<button @click="$emit(\'click\')"><slot /></button>',
-            props: ['label', 'icon']
-          },
-          'q-spacer': {
-            template: '<div />',
-          },
-          'q-spinner': {
-            template: '<div />',
-          },
-          'q-icon': {
-            template: '<div />',
-            props: ['name']
-          }
-        },
+        stubs,
+        directives,
       },
     });
+
+    await flushPromises();
 
     expect(wrapper.exists()).toBe(true);
     expect(wrapper.text()).toContain('relays.browser.title');
     expect(wrapper.text()).toContain('relays.browser.empty');
   });
 
+  it('renders cached relay catalog entries in the list', async () => {
+    const mockRelays = [
+      {
+        url: 'wss://relay.example.com',
+        hostname: 'relay.example.com',
+        status: 'online',
+        metadata: {
+          name: 'Example Relay',
+          description: 'A test relay',
+        },
+      },
+    ];
+    vi.mocked(listRelayCatalog).mockResolvedValue(mockRelays as any);
+
+    const wrapper = mount(RelayBrowserModal, {
+      props: {
+        modelValue: false,
+      },
+      global: {
+        stubs,
+        directives,
+      },
+    });
+
+    await wrapper.setProps({ modelValue: true });
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Example Relay');
+    expect(wrapper.text()).toContain('wss://relay.example.com');
+    expect(wrapper.text()).toContain('A test relay');
+    expect(wrapper.text()).toContain('online');
+  });
+
+  it('falls back to hostname or URL when display name is missing', async () => {
+    const mockRelays = [
+      {
+        url: 'wss://no-name.com',
+        hostname: 'no-name.com',
+        status: 'online',
+        metadata: {},
+      },
+      {
+        url: 'wss://no-nothing.com',
+        status: 'offline',
+      },
+    ];
+    vi.mocked(listRelayCatalog).mockResolvedValue(mockRelays as any);
+
+    const wrapper = mount(RelayBrowserModal, {
+      props: {
+        modelValue: false,
+      },
+      global: {
+        stubs,
+        directives,
+      },
+    });
+
+    await wrapper.setProps({ modelValue: true });
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('no-name.com');
+    expect(wrapper.text()).toContain('wss://no-nothing.com');
+  });
+
+  it('handles missing optional metadata without crashing', async () => {
+    const mockRelays = [
+      {
+        url: 'wss://minimal.com',
+        status: 'unknown',
+      },
+    ];
+    vi.mocked(listRelayCatalog).mockResolvedValue(mockRelays as any);
+
+    const wrapper = mount(RelayBrowserModal, {
+      props: {
+        modelValue: false,
+      },
+      global: {
+        stubs,
+        directives,
+      },
+    });
+
+    await wrapper.setProps({ modelValue: true });
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('wss://minimal.com');
+    expect(wrapper.text()).toContain('unknown');
+  });
+
   it('emits update:modelValue when close button is clicked', async () => {
+    vi.mocked(listRelayCatalog).mockResolvedValue([]);
+
     const wrapper = mount(RelayBrowserModal, {
       props: {
         modelValue: true,
       },
       global: {
-        stubs: {
-          'q-dialog': {
-            template: '<div><slot /></div>',
-            props: ['modelValue']
-          },
-          'q-card': {
-            template: '<div><slot /></div>',
-          },
-          'q-card-section': {
-            template: '<div><slot /></div>',
-          },
-          'q-card-actions': {
-            template: '<div><slot /></div>',
-          },
-          'q-btn': {
-            template: '<button @click="$emit(\'click\')">{{ label }}<slot /></button>',
-            props: ['label', 'icon']
-          },
-          'q-spacer': {
-            template: '<div />',
-          },
-          'q-spinner': {
-            template: '<div />',
-          },
-          'q-icon': {
-            template: '<div />',
-            props: ['name']
-          }
-        },
+        stubs,
+        directives,
       },
     });
 
-    const closeBtn = wrapper.findAll('button').find(b => b.text().includes('relays.browser.close'));
+    await flushPromises();
+
+    const closeBtn = wrapper.findAll('button').find((b) => b.text().includes('relays.browser.close'));
     await closeBtn?.trigger('click');
 
     expect(wrapper.emitted('update:modelValue')).toBeTruthy();

--- a/tests/unit/components/RelayBrowserModal.test.ts
+++ b/tests/unit/components/RelayBrowserModal.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import RelayBrowserModal from 'src/components/RelayBrowserModal.vue';
+
+const i18nMock = {
+  t: (key: string) => key,
+};
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => i18nMock,
+}));
+
+describe('RelayBrowserModal.vue', () => {
+  it('renders correctly when modelValue is true', async () => {
+    const wrapper = mount(RelayBrowserModal, {
+      props: {
+        modelValue: true,
+      },
+      global: {
+        stubs: {
+          'q-dialog': {
+            template: '<div><slot /></div>',
+            props: ['modelValue']
+          },
+          'q-card': {
+            template: '<div><slot /></div>',
+          },
+          'q-card-section': {
+            template: '<div><slot /></div>',
+          },
+          'q-card-actions': {
+            template: '<div><slot /></div>',
+          },
+          'q-btn': {
+            template: '<button @click="$emit(\'click\')"><slot /></button>',
+            props: ['label', 'icon']
+          },
+          'q-spacer': {
+            template: '<div />',
+          },
+          'q-spinner': {
+            template: '<div />',
+          },
+          'q-icon': {
+            template: '<div />',
+            props: ['name']
+          }
+        },
+      },
+    });
+
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.text()).toContain('relays.browser.title');
+    expect(wrapper.text()).toContain('relays.browser.empty');
+  });
+
+  it('emits update:modelValue when close button is clicked', async () => {
+    const wrapper = mount(RelayBrowserModal, {
+      props: {
+        modelValue: true,
+      },
+      global: {
+        stubs: {
+          'q-dialog': {
+            template: '<div><slot /></div>',
+            props: ['modelValue']
+          },
+          'q-card': {
+            template: '<div><slot /></div>',
+          },
+          'q-card-section': {
+            template: '<div><slot /></div>',
+          },
+          'q-card-actions': {
+            template: '<div><slot /></div>',
+          },
+          'q-btn': {
+            template: '<button @click="$emit(\'click\')">{{ label }}<slot /></button>',
+            props: ['label', 'icon']
+          },
+          'q-spacer': {
+            template: '<div />',
+          },
+          'q-spinner': {
+            template: '<div />',
+          },
+          'q-icon': {
+            template: '<div />',
+            props: ['name']
+          }
+        },
+      },
+    });
+
+    const closeBtn = wrapper.findAll('button').find(b => b.text().includes('relays.browser.close'));
+    await closeBtn?.trigger('click');
+
+    expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([false]);
+  });
+});

--- a/tests/unit/components/RelayBrowserModal.test.ts
+++ b/tests/unit/components/RelayBrowserModal.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
 import RelayBrowserModal from 'src/components/RelayBrowserModal.vue';
-import { listRelayCatalog } from 'src/services/relay-service';
+import { listRelayCatalog, refreshRelayCatalog, getRelayDiscoveryStatus } from 'src/services/relay-service';
 
 const i18nMock = {
   t: (key: string) => key,
@@ -13,6 +13,8 @@ vi.mock('vue-i18n', () => ({
 
 vi.mock('src/services/relay-service', () => ({
   listRelayCatalog: vi.fn(),
+  refreshRelayCatalog: vi.fn(),
+  getRelayDiscoveryStatus: vi.fn(),
 }));
 
 const stubs = {
@@ -30,7 +32,7 @@ const stubs = {
     template: '<div><slot /></div>',
   },
   'q-btn': {
-    template: '<button @click="$emit(\'click\')">{{ label }}<slot /></button>',
+    template: '<button @click="$emit(\'click\')" :icon="icon">{{ label }}{{ icon }}<slot /></button>',
     props: ['label', 'icon'],
   },
   'q-spacer': {
@@ -47,19 +49,31 @@ const stubs = {
     template: '<div><slot /></div>',
   },
   'q-item': {
-    template: '<div><slot /></div>',
+    template: '<div class="q-item" @click="$emit(\'click\')"><slot /></div>',
+    props: ['clickable'],
   },
   'q-item-section': {
     template: '<div><slot /></div>',
     props: ['side'],
   },
   'q-item-label': {
-    template: '<div><slot /></div>',
+    template: '<div class="q-item-label" :class="{ caption }"><slot /></div>',
     props: ['caption', 'lines'],
   },
   'q-badge': {
     template: '<span>{{ label }}</span>',
     props: ['color', 'label'],
+  },
+  'q-tooltip': {
+    template: '<div><slot /></div>',
+  },
+  'q-input': {
+    template: '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+    props: ['modelValue', 'label'],
+  },
+  'q-toggle': {
+    template: '<input type="checkbox" :checked="modelValue" @change="$emit(\'update:modelValue\', $event.target.checked)" />',
+    props: ['modelValue', 'label'],
   },
 };
 
@@ -203,5 +217,194 @@ describe('RelayBrowserModal.vue', () => {
 
     expect(wrapper.emitted('update:modelValue')).toBeTruthy();
     expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([false]);
+  });
+
+  it('emits select and closes when a relay is clicked', async () => {
+    const mockRelays = [
+      {
+        url: 'wss://relay.example.com',
+        hostname: 'relay.example.com',
+        status: 'online',
+        metadata: { name: 'Example Relay' },
+      },
+    ];
+    vi.mocked(listRelayCatalog).mockResolvedValue(mockRelays as any);
+
+    const wrapper = mount(RelayBrowserModal, {
+      props: {
+        modelValue: true,
+      },
+      global: {
+        stubs,
+        directives,
+      },
+    });
+
+    await flushPromises();
+
+    const item = wrapper.find('.q-item');
+    await item.trigger('click');
+
+    expect(wrapper.emitted('select')).toBeTruthy();
+    expect(wrapper.emitted('select')?.[0]).toEqual([mockRelays[0]]);
+    expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([false]);
+  });
+});
+
+describe('RelayBrowserModal.vue filtering and sorting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const mockRelays = [
+    {
+      url: 'wss://zebra.relay.com',
+      hostname: 'zebra.relay.com',
+      status: 'online',
+      metadata: { name: 'Zebra Relay' },
+    },
+    {
+      url: 'wss://apple.relay.com',
+      hostname: 'apple.relay.com',
+      status: 'online',
+      metadata: { name: 'Apple Relay', supported_nips: [50] },
+    },
+  ];
+
+  it('filters relays by search text', async () => {
+    vi.mocked(listRelayCatalog).mockResolvedValue(mockRelays as any);
+    const wrapper = mount(RelayBrowserModal, {
+      props: { modelValue: true },
+      global: { stubs, directives },
+    });
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Zebra Relay');
+    expect(wrapper.text()).toContain('Apple Relay');
+
+    const input = wrapper.find('input');
+    await input.setValue('apple');
+    await flushPromises();
+
+    expect(wrapper.text()).not.toContain('Zebra Relay');
+    expect(wrapper.text()).toContain('Apple Relay');
+  });
+
+  it('filters relays by search-capable toggle', async () => {
+    vi.mocked(listRelayCatalog).mockResolvedValue(mockRelays as any);
+    const wrapper = mount(RelayBrowserModal, {
+      props: { modelValue: true },
+      global: { stubs, directives },
+    });
+    await flushPromises();
+
+    const toggle = wrapper.find('input[type="checkbox"]');
+    (toggle.element as HTMLInputElement).checked = true;
+    await toggle.trigger('change');
+    await flushPromises();
+
+    expect(wrapper.text()).not.toContain('Zebra Relay');
+    expect(wrapper.text()).toContain('Apple Relay');
+  });
+
+  it('sorts relays alphabetically by default', async () => {
+    vi.mocked(listRelayCatalog).mockResolvedValue(mockRelays as any);
+    const wrapper = mount(RelayBrowserModal, {
+      props: { modelValue: true },
+      global: { stubs, directives },
+    });
+    await flushPromises();
+
+    const items = wrapper.findAll('.q-item-label').filter(i => !i.classes('caption'));
+    // Apple Relay name, Apple Relay URL, Zebra Relay name, Zebra Relay URL
+    expect(items).toHaveLength(4);
+    expect(items[0]!.text()).toContain('Apple Relay');
+    expect(items[1]!.text()).toContain('wss://apple.relay.com');
+    expect(items[2]!.text()).toContain('Zebra Relay');
+    expect(items[3]!.text()).toContain('wss://zebra.relay.com');
+  });
+
+  it('shows empty state when no results match filter', async () => {
+    vi.mocked(listRelayCatalog).mockResolvedValue(mockRelays as any);
+    const wrapper = mount(RelayBrowserModal, {
+      props: { modelValue: true },
+      global: { stubs, directives },
+    });
+    await flushPromises();
+
+    const input = wrapper.find('input');
+    await input.setValue('non-existent');
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('relays.browser.empty');
+    expect(wrapper.text()).not.toContain('Zebra Relay');
+    expect(wrapper.text()).not.toContain('Apple Relay');
+  });
+
+  it('triggers refresh automatically when catalog is small', async () => {
+    vi.mocked(listRelayCatalog).mockResolvedValue([{ url: 'wss://seed.com', hostname: 'seed.com', isSeed: true }] as any);
+    vi.mocked(getRelayDiscoveryStatus).mockResolvedValue({ isDiscoveryInProgress: false } as any);
+
+    mount(RelayBrowserModal, {
+      props: { modelValue: true },
+      global: { stubs, directives },
+    });
+    await flushPromises();
+
+    expect(refreshRelayCatalog).toHaveBeenCalled();
+  });
+
+  it('triggers refresh manually when refresh button is clicked', async () => {
+    vi.mocked(listRelayCatalog).mockResolvedValue([
+      { url: '1', hostname: '1' },
+      { url: '2', hostname: '2' },
+      { url: '3', hostname: '3' },
+      { url: '4', hostname: '4' },
+      { url: '5', hostname: '5' },
+      { url: '6', hostname: '6' },
+      { url: '7', hostname: '7' },
+      { url: '8', hostname: '8' },
+      { url: '9', hostname: '9' },
+      { url: '10', hostname: '10' },
+      { url: '11', hostname: '11' },
+    ] as any);
+    vi.mocked(getRelayDiscoveryStatus).mockResolvedValue({ isDiscoveryInProgress: false } as any);
+
+    const wrapper = mount(RelayBrowserModal, {
+      props: { modelValue: true },
+      global: { stubs, directives },
+    });
+    await flushPromises();
+
+    // Auto-refresh should NOT have been called because we have 11 relays
+    expect(refreshRelayCatalog).not.toHaveBeenCalled();
+
+    const refreshBtn = wrapper.findAll('button').find((b) => b.attributes('icon') === 'refresh');
+    await refreshBtn?.trigger('click');
+
+    expect(refreshRelayCatalog).toHaveBeenCalledWith(true);
+  });
+
+  it('polls status when discovery is in progress', async () => {
+    vi.useFakeTimers();
+    vi.mocked(listRelayCatalog).mockResolvedValue([]);
+    vi.mocked(getRelayDiscoveryStatus).mockResolvedValue({ isDiscoveryInProgress: true } as any);
+
+    mount(RelayBrowserModal, {
+      props: { modelValue: true },
+      global: { stubs, directives },
+    });
+    await flushPromises();
+
+    // The first call is from onMounted -> checkStatus
+    // The second call is from onMounted -> fetchRelays -> triggerRefresh -> startPollingStatus -> checkStatus
+    expect(getRelayDiscoveryStatus).toHaveBeenCalled();
+
+    // Advance time to trigger next poll
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(getRelayDiscoveryStatus).toHaveBeenCalledTimes(3);
+
+    vi.useRealTimers();
   });
 });

--- a/tests/unit/components/RelayEditor.test.ts
+++ b/tests/unit/components/RelayEditor.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import RelayEditor from 'src/components/RelayEditor.vue';
+import RelayBrowserModal from 'src/components/RelayBrowserModal.vue';
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
@@ -43,13 +44,17 @@ describe('RelayEditor.vue', () => {
 
   const globalStubs = {
     'q-input': {
-      template: '<div class="q-input-stub"><slot name="append" /></div>',
+      template: '<input class="q-input-stub" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)"><slot name="append" /></input>',
+      props: ['modelValue'],
     },
     'q-btn': {
       template: '<button class="q-btn-stub" :data-icon="icon" @click="$emit(\'click\')"><slot /></button>',
       props: ['icon']
     },
-    'q-checkbox': true,
+    'q-checkbox': {
+      template: '<input type="checkbox" :checked="modelValue" @change="$emit(\'update:modelValue\', $event.target.checked)" />',
+      props: ['modelValue', 'label'],
+    },
     'q-list': true,
     'q-item': true,
     'q-item-section': true,
@@ -59,7 +64,8 @@ describe('RelayEditor.vue', () => {
     'q-tooltip': true,
     'relay-browser-modal': {
        template: '<div v-if="modelValue" class="mock-modal">Relay Browser Modal</div>',
-       props: ['modelValue']
+       props: ['modelValue'],
+       emits: ['select']
     }
   };
 
@@ -89,5 +95,35 @@ describe('RelayEditor.vue', () => {
     await browseBtn.trigger('click');
 
     expect(wrapper.find('.mock-modal').exists()).toBe(true);
+  });
+
+  it('populates input and defaults when relay is selected', async () => {
+    const wrapper = mount(RelayEditor, {
+      props,
+      global: {
+        stubs: globalStubs,
+      },
+    });
+
+    const modal = wrapper.getComponent(RelayBrowserModal);
+    const mockRelay = {
+      url: 'wss://selected-relay.com',
+      hostname: 'selected-relay.com',
+    };
+
+    await modal.setValue(true, 'modelValue');
+    await modal.vm.$emit('select', mockRelay);
+
+    // Check URL input
+    const input = wrapper.find('input.q-input-stub');
+    expect((input.element as HTMLInputElement).value).toBe('wss://selected-relay.com');
+
+    // Check checkboxes
+    const checkboxes = wrapper.findAll('input[type="checkbox"]');
+    expect(checkboxes).toHaveLength(2);
+
+    // Based on template: read is first, write is second
+    expect((checkboxes[0]!.element as HTMLInputElement).checked).toBe(true); // Read
+    expect((checkboxes[1]!.element as HTMLInputElement).checked).toBe(false); // Write
   });
 });

--- a/tests/unit/components/RelayEditor.test.ts
+++ b/tests/unit/components/RelayEditor.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import RelayEditor from 'src/components/RelayEditor.vue';
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('quasar', () => ({
+  useQuasar: () => ({
+    notify: vi.fn(),
+  }),
+}));
+
+// Mock nostr-tools
+vi.mock('nostr-tools', () => {
+  return {
+    SimplePool: class {
+      get = vi.fn().mockResolvedValue(null);
+      close = vi.fn();
+    },
+    finalizeEvent: vi.fn(),
+  };
+});
+
+vi.mock('@noble/hashes/utils', () => ({
+  hexToBytes: vi.fn(),
+}));
+
+describe('RelayEditor.vue', () => {
+  const props = {
+    storedKey: {
+      id: 'pubkey',
+      alias: 'alias',
+      account: {
+        privkey: '00'.repeat(32),
+      },
+      createdAt: new Date().toISOString(),
+    },
+  };
+
+  const globalStubs = {
+    'q-input': {
+      template: '<div class="q-input-stub"><slot name="append" /></div>',
+    },
+    'q-btn': {
+      template: '<button class="q-btn-stub" :data-icon="icon" @click="$emit(\'click\')"><slot /></button>',
+      props: ['icon']
+    },
+    'q-checkbox': true,
+    'q-list': true,
+    'q-item': true,
+    'q-item-section': true,
+    'q-item-label': true,
+    'q-badge': true,
+    'q-spinner': true,
+    'q-tooltip': true,
+    'relay-browser-modal': {
+       template: '<div v-if="modelValue" class="mock-modal">Relay Browser Modal</div>',
+       props: ['modelValue']
+    }
+  };
+
+  it('renders Browse button', () => {
+    const wrapper = mount(RelayEditor, {
+      props,
+      global: {
+        stubs: globalStubs,
+      },
+    });
+
+    const browseBtn = wrapper.find('button[data-icon="explore"]');
+    expect(browseBtn.exists()).toBe(true);
+  });
+
+  it('opens modal when Browse button is clicked', async () => {
+    const wrapper = mount(RelayEditor, {
+      props,
+      global: {
+        stubs: globalStubs,
+      },
+    });
+
+    expect(wrapper.find('.mock-modal').exists()).toBe(false);
+
+    const browseBtn = wrapper.find('button[data-icon="explore"]');
+    await browseBtn.trigger('click');
+
+    expect(wrapper.find('.mock-modal').exists()).toBe(true);
+  });
+});

--- a/tests/unit/dispatcher.test.ts
+++ b/tests/unit/dispatcher.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { dispatchMessage } from 'app/src-bex/dispatcher';
+import { handleRelayBrowserList, handleRelayBrowserGetStatus } from 'app/src-bex/handlers/relay-browser-handler';
+
+// Mock handlers
+vi.mock('app/src-bex/handlers/vault-handler', () => ({
+  handleVaultUnlock: vi.fn(),
+  handleVaultLock: vi.fn(),
+  handleVaultIsUnlocked: vi.fn(),
+  handleVaultCreate: vi.fn(),
+  handleVaultGetData: vi.fn(),
+  handleVaultUpdateData: vi.fn(),
+  handleVaultExport: vi.fn(),
+  handleVaultImport: vi.fn(),
+}));
+
+vi.mock('app/src-bex/services/auto-lock', () => ({
+  resetAutoLockTimer: vi.fn(),
+  startAutoLockTimer: vi.fn(),
+  stopAutoLockTimer: vi.fn(),
+}));
+
+vi.mock('app/src-bex/handlers/nip07', () => ({
+  handleGetPublicKey: vi.fn(),
+  handleSignEvent: vi.fn(),
+}));
+
+vi.mock('app/src-bex/handlers/blossom-handler', () => ({
+  handleBlossomUpload: vi.fn(),
+}));
+
+vi.mock('app/src-bex/handlers/nip04', () => ({
+  handleNip04Encrypt: vi.fn(),
+  handleNip04Decrypt: vi.fn(),
+}));
+
+vi.mock('app/src-bex/handlers/relay-browser-handler', () => ({
+  handleRelayBrowserList: vi.fn(),
+  handleRelayBrowserGetStatus: vi.fn(),
+}));
+
+describe('Dispatcher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should route ping action correctly', async () => {
+    const result = await dispatchMessage('ping', {});
+    expect(result).toBe('pong');
+  });
+
+  it('should route relay.browser.list correctly', async () => {
+    const mockEntries = [{ url: 'wss://relay.com' }];
+    vi.mocked(handleRelayBrowserList).mockResolvedValue({ success: true, data: mockEntries as any });
+
+    const result = await dispatchMessage('relay.browser.list', {});
+
+    expect(result).toEqual(mockEntries);
+    expect(handleRelayBrowserList).toHaveBeenCalled();
+  });
+
+  it('should return empty array for relay.browser.list when handler fails', async () => {
+    vi.mocked(handleRelayBrowserList).mockResolvedValue({ success: false, error: 'Fail' });
+
+    const result = await dispatchMessage('relay.browser.list', {});
+
+    expect(result).toEqual([]);
+    expect(handleRelayBrowserList).toHaveBeenCalled();
+  });
+
+  it('should route relay.browser.getStatus correctly', async () => {
+    const mockStatus = { id: 'global', isDiscoveryInProgress: false };
+    vi.mocked(handleRelayBrowserGetStatus).mockResolvedValue({ success: true, data: mockStatus as any });
+
+    const result = await dispatchMessage('relay.browser.getStatus', {});
+
+    expect(result).toEqual(mockStatus);
+    expect(handleRelayBrowserGetStatus).toHaveBeenCalled();
+  });
+
+  it('should return null for relay.browser.getStatus when handler fails', async () => {
+    vi.mocked(handleRelayBrowserGetStatus).mockResolvedValue({ success: false, error: 'Fail' });
+
+    const result = await dispatchMessage('relay.browser.getStatus', {});
+
+    expect(result).toBeNull();
+    expect(handleRelayBrowserGetStatus).toHaveBeenCalled();
+  });
+
+  it('should return null for unknown message type', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await dispatchMessage('unknown.action' as any, {});
+    expect(result).toBeNull();
+  });
+});

--- a/tests/unit/handlers/relay-browser-handler.test.ts
+++ b/tests/unit/handlers/relay-browser-handler.test.ts
@@ -7,6 +7,7 @@ import { db } from 'src/services/database';
 vi.mock('src/services/relay-catalog', () => ({
   relayCatalogService: {
     getEntries: vi.fn(),
+    getDiscoveryState: vi.fn(),
   },
 }));
 
@@ -60,7 +61,7 @@ describe('RelayBrowserHandler', () => {
         isDiscoveryInProgress: false,
         updatedAt: 123456789,
       };
-      vi.mocked(db.relayDiscoveryState.get).mockResolvedValue(mockStatus as any);
+      vi.mocked(relayCatalogService.getDiscoveryState).mockResolvedValue(mockStatus as any);
 
       const result = await handleRelayBrowserGetStatus();
 
@@ -68,11 +69,11 @@ describe('RelayBrowserHandler', () => {
       if (result.success) {
         expect(result.data).toEqual(mockStatus);
       }
-      expect(db.relayDiscoveryState.get).toHaveBeenCalledWith('global');
+      expect(relayCatalogService.getDiscoveryState).toHaveBeenCalledWith('global');
     });
 
     it('should return null when no status exists in database', async () => {
-      vi.mocked(db.relayDiscoveryState.get).mockResolvedValue(undefined as any);
+      vi.mocked(relayCatalogService.getDiscoveryState).mockResolvedValue(null);
 
       const result = await handleRelayBrowserGetStatus();
 
@@ -83,7 +84,7 @@ describe('RelayBrowserHandler', () => {
     });
 
     it('should return failure when database access fails', async () => {
-      vi.mocked(db.relayDiscoveryState.get).mockRejectedValue(new Error('Read error'));
+      vi.mocked(relayCatalogService.getDiscoveryState).mockRejectedValue(new Error('Read error'));
 
       const result = await handleRelayBrowserGetStatus();
 

--- a/tests/unit/handlers/relay-browser-handler.test.ts
+++ b/tests/unit/handlers/relay-browser-handler.test.ts
@@ -1,7 +1,8 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleRelayBrowserList, handleRelayBrowserGetStatus } from 'app/src-bex/handlers/relay-browser-handler';
 import { relayCatalogService } from 'src/services/relay-catalog';
-import { db } from 'src/services/database';
+import type { RelayCatalogEntry } from 'src/types/relay';
 
 // Mock dependencies
 vi.mock('src/services/relay-catalog', () => ({
@@ -30,7 +31,7 @@ describe('RelayBrowserHandler', () => {
         { url: 'wss://relay1.com', hostname: 'relay1.com', status: 'online' },
         { url: 'wss://relay2.com', hostname: 'relay2.com', status: 'offline' },
       ];
-      vi.mocked(relayCatalogService.getEntries).mockResolvedValue(mockEntries as any);
+      vi.mocked(relayCatalogService.getEntries).mockResolvedValue(mockEntries as unknown as RelayCatalogEntry[]);
 
       const result = await handleRelayBrowserList();
 
@@ -38,7 +39,7 @@ describe('RelayBrowserHandler', () => {
       if (result.success) {
         expect(result.data).toEqual(mockEntries);
       }
-      expect(relayCatalogService.getEntries).toHaveBeenCalled();
+      expect(vi.mocked(relayCatalogService.getEntries)).toHaveBeenCalled();
     });
 
     it('should return failure when service throws an error', async () => {
@@ -61,7 +62,7 @@ describe('RelayBrowserHandler', () => {
         isDiscoveryInProgress: false,
         updatedAt: 123456789,
       };
-      vi.mocked(relayCatalogService.getDiscoveryState).mockResolvedValue(mockStatus as any);
+      vi.mocked(relayCatalogService.getDiscoveryState).mockResolvedValue(mockStatus as unknown as { id: string; lastGlobalDiscoveryAt: number; isDiscoveryInProgress: boolean; updatedAt: number });
 
       const result = await handleRelayBrowserGetStatus();
 

--- a/tests/unit/handlers/relay-browser-handler.test.ts
+++ b/tests/unit/handlers/relay-browser-handler.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleRelayBrowserList, handleRelayBrowserGetStatus } from 'app/src-bex/handlers/relay-browser-handler';
+import { relayCatalogService } from 'src/services/relay-catalog';
+import { db } from 'src/services/database';
+
+// Mock dependencies
+vi.mock('src/services/relay-catalog', () => ({
+  relayCatalogService: {
+    getEntries: vi.fn(),
+  },
+}));
+
+vi.mock('src/services/database', () => ({
+  db: {
+    relayDiscoveryState: {
+      get: vi.fn(),
+    },
+  },
+}));
+
+describe('RelayBrowserHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('handleRelayBrowserList', () => {
+    it('should return cached relay entries successfully', async () => {
+      const mockEntries = [
+        { url: 'wss://relay1.com', hostname: 'relay1.com', status: 'online' },
+        { url: 'wss://relay2.com', hostname: 'relay2.com', status: 'offline' },
+      ];
+      vi.mocked(relayCatalogService.getEntries).mockResolvedValue(mockEntries as any);
+
+      const result = await handleRelayBrowserList();
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual(mockEntries);
+      }
+      expect(relayCatalogService.getEntries).toHaveBeenCalled();
+    });
+
+    it('should return failure when service throws an error', async () => {
+      vi.mocked(relayCatalogService.getEntries).mockRejectedValue(new Error('Database error'));
+
+      const result = await handleRelayBrowserList();
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('Database error');
+      }
+    });
+  });
+
+  describe('handleRelayBrowserGetStatus', () => {
+    it('should return discovery status successfully', async () => {
+      const mockStatus = {
+        id: 'global',
+        lastGlobalDiscoveryAt: 123456789,
+        isDiscoveryInProgress: false,
+        updatedAt: 123456789,
+      };
+      vi.mocked(db.relayDiscoveryState.get).mockResolvedValue(mockStatus as any);
+
+      const result = await handleRelayBrowserGetStatus();
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual(mockStatus);
+      }
+      expect(db.relayDiscoveryState.get).toHaveBeenCalledWith('global');
+    });
+
+    it('should return null when no status exists in database', async () => {
+      vi.mocked(db.relayDiscoveryState.get).mockResolvedValue(undefined as any);
+
+      const result = await handleRelayBrowserGetStatus();
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBeNull();
+      }
+    });
+
+    it('should return failure when database access fails', async () => {
+      vi.mocked(db.relayDiscoveryState.get).mockRejectedValue(new Error('Read error'));
+
+      const result = await handleRelayBrowserGetStatus();
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('Read error');
+      }
+    });
+  });
+});

--- a/tests/unit/mocks/crypto.ts
+++ b/tests/unit/mocks/crypto.ts
@@ -121,6 +121,15 @@ export class MockCrypto {
         }
         return Promise.resolve({ kty: 'oct', k: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' } as unknown as JsonWebKey);
       },
+
+      // Mock digest
+      async digest(
+        algorithm: AlgorithmIdentifier,
+        data: BufferSource
+      ): Promise<ArrayBuffer> {
+        // Return a dummy digest
+        return Promise.resolve(new Uint8Array(32).fill(0).buffer);
+      },
     } as SubtleCrypto;
   }
 

--- a/tests/unit/services/relay-browser-orchestrator.test.ts
+++ b/tests/unit/services/relay-browser-orchestrator.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RelayBrowserOrchestrator } from 'src/services/relay-browser-orchestrator';
+import { relayCatalogService, loadSeedRelays } from 'src/services/relay-catalog';
+import { relayDiscoveryService } from 'src/services/relay-discovery';
+import { fetchRelayMetadata } from 'src/services/relay-metadata';
+
+// Mock dependencies
+vi.mock('src/services/relay-catalog', () => ({
+  relayCatalogService: {
+    getEntries: vi.fn(),
+    getDiscoveryState: vi.fn(),
+    updateDiscoveryState: vi.fn(),
+    isDiscoveryStale: vi.fn(),
+    isMetadataStale: vi.fn(),
+    upsertEntry: vi.fn(),
+  },
+  loadSeedRelays: vi.fn(),
+}));
+
+vi.mock('src/services/relay-discovery', () => ({
+  relayDiscoveryService: {
+    discoverFromRelays: vi.fn(),
+  },
+}));
+
+vi.mock('src/services/relay-metadata', () => ({
+  fetchRelayMetadata: vi.fn(),
+}));
+
+describe('RelayBrowserOrchestrator', () => {
+  let orchestrator: RelayBrowserOrchestrator;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    orchestrator = new RelayBrowserOrchestrator();
+
+    // Default mock behaviors
+    vi.mocked(relayCatalogService.getDiscoveryState).mockResolvedValue({
+      id: 'global',
+      isDiscoveryInProgress: false,
+      updatedAt: Date.now(),
+    });
+    vi.mocked(relayCatalogService.getEntries).mockResolvedValue([]);
+    vi.mocked(relayCatalogService.updateDiscoveryState).mockResolvedValue();
+    vi.mocked(loadSeedRelays).mockResolvedValue({ added: 1, updated: 0, skipped: 0 });
+    vi.mocked(relayCatalogService.isDiscoveryStale).mockReturnValue(true);
+    vi.mocked(relayDiscoveryService.discoverFromRelays).mockResolvedValue({
+      discoveredUrls: [],
+      processedEvents: 0,
+      errors: [],
+    });
+    vi.mocked(fetchRelayMetadata).mockResolvedValue({
+      success: false,
+      url: 'wss://seed1.com',
+      error: 'Not found',
+      timestamp: Date.now(),
+    });
+  });
+
+  it('should load seeds and trigger discovery on first run (empty catalog)', async () => {
+    vi.mocked(relayCatalogService.getEntries).mockResolvedValueOnce([]).mockResolvedValueOnce([
+        { url: 'wss://seed1.com', hostname: 'seed1.com', isSeed: true } as any
+    ]);
+
+    await orchestrator.refreshCatalog();
+
+    expect(loadSeedRelays).toHaveBeenCalled();
+    expect(relayCatalogService.updateDiscoveryState).toHaveBeenCalledWith(
+      expect.objectContaining({ isDiscoveryInProgress: true }),
+      'global'
+    );
+    expect(relayDiscoveryService.discoverFromRelays).toHaveBeenCalledWith(['wss://seed1.com']);
+    expect(relayCatalogService.updateDiscoveryState).toHaveBeenCalledWith(
+      expect.objectContaining({ isDiscoveryInProgress: false }),
+      'global'
+    );
+  });
+
+  it('should trigger discovery only when stale', async () => {
+    vi.mocked(relayCatalogService.getEntries).mockResolvedValue([
+      { url: 'wss://seed1.com', hostname: 'seed1.com', isSeed: true } as any
+    ]);
+    vi.mocked(relayCatalogService.isDiscoveryStale).mockReturnValue(false);
+
+    await orchestrator.refreshCatalog();
+
+    expect(relayDiscoveryService.discoverFromRelays).not.toHaveBeenCalled();
+
+    // Forced refresh should trigger discovery even if not stale
+    await orchestrator.refreshCatalog(true);
+    expect(relayDiscoveryService.discoverFromRelays).toHaveBeenCalled();
+  });
+
+  it('should prevent duplicate runs if already in progress in-memory', async () => {
+    // We can't easily test the in-memory flag without making it public or using a delay
+    // but we can test the DB flag.
+    vi.mocked(relayCatalogService.getDiscoveryState).mockResolvedValue({
+      id: 'global',
+      isDiscoveryInProgress: true,
+      updatedAt: Date.now(),
+    });
+
+    await orchestrator.refreshCatalog();
+
+    expect(relayCatalogService.updateDiscoveryState).not.toHaveBeenCalled();
+  });
+
+  it('should trigger metadata refresh for stale entries', async () => {
+    const entry1 = { url: 'wss://relay1.com', hostname: 'relay1.com' } as any;
+    const entry2 = { url: 'wss://relay2.com', hostname: 'relay2.com' } as any;
+
+    vi.mocked(relayCatalogService.getEntries).mockResolvedValue([entry1, entry2]);
+    vi.mocked(relayCatalogService.isDiscoveryStale).mockReturnValue(false);
+    vi.mocked(relayCatalogService.isMetadataStale).mockImplementation((e) => e.url === 'wss://relay1.com');
+
+    vi.mocked(fetchRelayMetadata).mockResolvedValue({
+      success: true,
+      url: 'wss://relay1.com',
+      metadata: { name: 'Relay 1' },
+      timestamp: Date.now(),
+    });
+
+    await orchestrator.refreshCatalog();
+
+    expect(fetchRelayMetadata).toHaveBeenCalledWith('wss://relay1.com');
+    expect(fetchRelayMetadata).not.toHaveBeenCalledWith('wss://relay2.com');
+    expect(relayCatalogService.upsertEntry).toHaveBeenCalledWith(expect.objectContaining({
+      url: 'wss://relay1.com',
+      metadata: { name: 'Relay 1' },
+      status: 'online'
+    }));
+  });
+
+  it('should preserve cache and record error on failure', async () => {
+    vi.mocked(relayCatalogService.getEntries).mockRejectedValueOnce(new Error('DB failure')).mockResolvedValueOnce([]);
+
+    await orchestrator.refreshCatalog();
+
+    expect(relayCatalogService.updateDiscoveryState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isDiscoveryInProgress: false,
+        discoveryStats: expect.objectContaining({
+           lastError: 'DB failure'
+        })
+      }),
+      'global'
+    );
+  });
+});

--- a/tests/unit/services/relay-catalog.test.ts
+++ b/tests/unit/services/relay-catalog.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { loadSeedRelays } from 'src/services/relay-catalog';
+import { RELAY_SEEDS } from 'src/data/relay-seeds';
+import type { RelayCatalogEntry } from 'src/types/relay';
+
+// Mock the database
+const mockRelayCatalog = new Map<string, RelayCatalogEntry>();
+
+vi.mock('src/services/database', () => {
+  return {
+    db: {
+      relayCatalog: {
+        get: vi.fn(async (url: string) => mockRelayCatalog.get(url)),
+        add: vi.fn(async (entry: RelayCatalogEntry) => {
+          mockRelayCatalog.set(entry.url, entry);
+          return entry.url;
+        }),
+        update: vi.fn(async (url: string, changes: Partial<RelayCatalogEntry>) => {
+          const existing = mockRelayCatalog.get(url);
+          if (existing) {
+            mockRelayCatalog.set(url, { ...existing, ...changes });
+          }
+          return 1;
+        }),
+      },
+      transaction: vi.fn(async (mode, tables, callback) => {
+        return callback();
+      }),
+    },
+  };
+});
+
+// Mock RELAY_SEEDS to have a controlled set for testing, including an invalid one
+vi.mock('src/data/relay-seeds', () => ({
+  RELAY_SEEDS: [
+    'wss://relay.damus.io',
+    'wss://nos.lol',
+    'invalid-url',
+  ],
+}));
+
+describe('Relay Catalog Service - loadSeedRelays', () => {
+  beforeEach(() => {
+    mockRelayCatalog.clear();
+    vi.clearAllMocks();
+  });
+
+  it('should insert missing seeds into an empty catalog', async () => {
+    const result = await loadSeedRelays();
+
+    expect(result.added).toBe(2); // damus and nos.lol
+    expect(result.skipped).toBe(1); // invalid-url
+    expect(mockRelayCatalog.size).toBe(2);
+
+    const damus = mockRelayCatalog.get('wss://relay.damus.io');
+    expect(damus).toBeDefined();
+    expect(damus?.isSeed).toBe(true);
+    expect(damus?.source).toBe('seed');
+  });
+
+  it('should not create duplicates when run twice', async () => {
+    await loadSeedRelays();
+    const secondResult = await loadSeedRelays();
+
+    expect(secondResult.added).toBe(0);
+    expect(secondResult.updated).toBe(0);
+    expect(mockRelayCatalog.size).toBe(2);
+  });
+
+  it('should preserve richer existing metadata and update isSeed status', async () => {
+    // Pre-insert an entry with metadata but isSeed: false
+    const existingEntry: RelayCatalogEntry = {
+      url: 'wss://relay.damus.io',
+      hostname: 'relay.damus.io',
+      isUserAdded: true,
+      isSeed: false,
+      status: 'online',
+      metadata: { name: 'Damus Relay', description: 'Very rich description' },
+      createdAt: Date.now() - 10000,
+      updatedAt: Date.now() - 10000,
+      source: 'manual',
+    };
+    mockRelayCatalog.set(existingEntry.url, existingEntry);
+
+    const result = await loadSeedRelays();
+
+    expect(result.added).toBe(1); // nos.lol added
+    expect(result.updated).toBe(1); // damus updated to isSeed: true
+
+    const updatedDamus = mockRelayCatalog.get('wss://relay.damus.io');
+    expect(updatedDamus?.isSeed).toBe(true);
+    expect(updatedDamus?.isUserAdded).toBe(true); // preserved
+    expect(updatedDamus?.metadata?.name).toBe('Damus Relay'); // preserved
+    expect(updatedDamus?.source).toBe('manual'); // preserved (since update didn't change it)
+  });
+
+  it('should ignore invalid seed entries safely', async () => {
+    const result = await loadSeedRelays();
+    expect(result.skipped).toBe(1);
+    expect(mockRelayCatalog.has('invalid-url')).toBe(false);
+  });
+});

--- a/tests/unit/services/relay-catalog.test.ts
+++ b/tests/unit/services/relay-catalog.test.ts
@@ -92,7 +92,169 @@ describe('Relay Catalog Service - loadSeedRelays', () => {
     expect(updatedDamus?.isSeed).toBe(true);
     expect(updatedDamus?.isUserAdded).toBe(true); // preserved
     expect(updatedDamus?.metadata?.name).toBe('Damus Relay'); // preserved
-    expect(updatedDamus?.source).toBe('manual'); // preserved (since update didn't change it)
+    expect(updatedDamus?.source).toBe('manual,seed'); // accumulated
+  });
+
+  describe('upsertEntry', () => {
+    beforeEach(() => {
+      mockRelayCatalog.clear();
+      vi.clearAllMocks();
+    });
+
+    it('should insert a new relay entry', async () => {
+      await relayCatalogService.upsertEntry({
+        url: 'wss://new.relay.com',
+        hostname: 'new.relay.com',
+        source: 'discovery',
+      });
+
+      const entry = mockRelayCatalog.get('wss://new.relay.com');
+      expect(entry).toBeDefined();
+      expect(entry?.url).toBe('wss://new.relay.com');
+      expect(entry?.source).toBe('discovery');
+      expect(entry?.status).toBe('unknown');
+    });
+
+    it('should merge a seed entry into an existing richer entry', async () => {
+      const existing: RelayCatalogEntry = {
+        url: 'wss://rich.com',
+        hostname: 'rich.com',
+        isUserAdded: true,
+        isSeed: false,
+        status: 'online',
+        metadata: { name: 'Rich Relay', description: 'Extremely rich' },
+        createdAt: 1000,
+        updatedAt: 1000,
+        source: 'manual',
+      };
+      mockRelayCatalog.set(existing.url, existing);
+
+      await relayCatalogService.upsertEntry({
+        url: 'wss://rich.com',
+        hostname: 'rich.com',
+        isSeed: true,
+        source: 'seed',
+      });
+
+      const updated = mockRelayCatalog.get('wss://rich.com');
+      expect(updated?.isSeed).toBe(true);
+      expect(updated?.isUserAdded).toBe(true);
+      expect(updated?.metadata?.name).toBe('Rich Relay');
+      expect(updated?.metadata?.description).toBe('Extremely rich');
+      expect(updated?.source).toBe('manual,seed');
+    });
+
+    it('should merge fetched metadata into a placeholder entry', async () => {
+      const placeholder: RelayCatalogEntry = {
+        url: 'wss://placeholder.com',
+        hostname: 'placeholder.com',
+        isUserAdded: false,
+        isSeed: true,
+        status: 'unknown',
+        createdAt: 1000,
+        updatedAt: 1000,
+        source: 'seed',
+      };
+      mockRelayCatalog.set(placeholder.url, placeholder);
+
+      await relayCatalogService.upsertEntry({
+        url: 'wss://placeholder.com',
+        hostname: 'placeholder.com',
+        status: 'online',
+        metadata: { name: 'Now Real', software: 'noscl' },
+        lastChecked: 2000,
+      });
+
+      const updated = mockRelayCatalog.get('wss://placeholder.com');
+      expect(updated?.status).toBe('online');
+      expect(updated?.metadata?.name).toBe('Now Real');
+      expect(updated?.metadata?.software).toBe('noscl');
+      expect(updated?.lastChecked).toBe(2000);
+    });
+
+    it('should not duplicate source markers or entries', async () => {
+      await relayCatalogService.upsertEntry({
+        url: 'wss://dup.com',
+        hostname: 'dup.com',
+        source: 'discovery',
+      });
+
+      await relayCatalogService.upsertEntry({
+        url: 'wss://dup.com',
+        hostname: 'dup.com',
+        source: 'discovery',
+      });
+
+      await relayCatalogService.upsertEntry({
+        url: 'wss://dup.com',
+        hostname: 'dup.com',
+        source: 'nprofile,discovery',
+      });
+
+      const entry = mockRelayCatalog.get('wss://dup.com');
+      expect(entry?.source).toBe('discovery,nprofile');
+      expect(mockRelayCatalog.size).toBe(1);
+    });
+
+    it('should not destroy good prior metadata when merging less-rich metadata', async () => {
+      const rich: RelayCatalogEntry = {
+        url: 'wss://stable.com',
+        hostname: 'stable.com',
+        isUserAdded: false,
+        isSeed: true,
+        status: 'online',
+        metadata: { name: 'Stable', description: 'Very stable', version: '1.0' },
+        createdAt: 1000,
+        updatedAt: 1000,
+        source: 'seed',
+      };
+      mockRelayCatalog.set(rich.url, rich);
+
+      // Attempt to upsert with "poorer" metadata (missing description and version)
+      await relayCatalogService.upsertEntry({
+        url: 'wss://stable.com',
+        hostname: 'stable.com',
+        metadata: { name: 'Stable' }, // Missing other fields
+      });
+
+      const entry = mockRelayCatalog.get('wss://stable.com');
+      expect(entry?.metadata?.name).toBe('Stable');
+      expect(entry?.metadata?.description).toBe('Very stable'); // Preserved
+      expect(entry?.metadata?.version).toBe('1.0'); // Preserved
+    });
+
+    it('should not downgrade status from online to error during a failed metadata refresh', async () => {
+        const online: RelayCatalogEntry = {
+          url: 'wss://online.com',
+          hostname: 'online.com',
+          isUserAdded: false,
+          isSeed: true,
+          status: 'online',
+          createdAt: 1000,
+          updatedAt: 1000,
+          source: 'seed',
+        };
+        mockRelayCatalog.set(online.url, online);
+
+        // Simulate a "failed" refresh which might try to set status to 'error' or 'unknown'
+        await relayCatalogService.upsertEntry({
+          url: 'wss://online.com',
+          hostname: 'online.com',
+          status: 'unknown', // This should be ignored because we have a better status
+        });
+
+        let entry = mockRelayCatalog.get('wss://online.com');
+        expect(entry?.status).toBe('online');
+
+        // But 'error' might be allowed if we explicitly want to mark it as failing
+        await relayCatalogService.upsertEntry({
+            url: 'wss://online.com',
+            hostname: 'online.com',
+            status: 'error',
+          });
+          entry = mockRelayCatalog.get('wss://online.com');
+          expect(entry?.status).toBe('error');
+      });
   });
 
   it('should ignore invalid seed entries safely', async () => {

--- a/tests/unit/services/relay-catalog.test.ts
+++ b/tests/unit/services/relay-catalog.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { loadSeedRelays, relayCatalogService } from 'src/services/relay-catalog';
-import { RELAY_SEEDS } from 'src/data/relay-seeds';
 import type { RelayCatalogEntry } from 'src/types/relay';
 
 // Mock the database
@@ -10,22 +9,22 @@ vi.mock('src/services/database', () => {
   return {
     db: {
       relayCatalog: {
-        get: vi.fn(async (url: string) => mockRelayCatalog.get(url)),
-        add: vi.fn(async (entry: RelayCatalogEntry) => {
+        get: vi.fn((url: string) => Promise.resolve(mockRelayCatalog.get(url))),
+        add: vi.fn((entry: RelayCatalogEntry) => {
           mockRelayCatalog.set(entry.url, entry);
-          return entry.url;
+          return Promise.resolve(entry.url);
         }),
-        update: vi.fn(async (url: string, changes: Partial<RelayCatalogEntry>) => {
+        update: vi.fn((url: string, changes: Partial<RelayCatalogEntry>) => {
           const existing = mockRelayCatalog.get(url);
           if (existing) {
             mockRelayCatalog.set(url, { ...existing, ...changes });
           }
-          return 1;
+          return Promise.resolve(1);
         }),
-        toArray: vi.fn(async () => Array.from(mockRelayCatalog.values())),
+        toArray: vi.fn(() => Promise.resolve(Array.from(mockRelayCatalog.values()))),
       },
-      transaction: vi.fn(async (mode, tables, callback) => {
-        return callback();
+      transaction: vi.fn((mode: string, tables: string[], callback: () => unknown) => {
+        return Promise.resolve(callback());
       }),
     },
   };
@@ -223,38 +222,66 @@ describe('Relay Catalog Service - loadSeedRelays', () => {
       expect(entry?.metadata?.version).toBe('1.0'); // Preserved
     });
 
-    it('should not downgrade status from online to error during a failed metadata refresh', async () => {
-        const online: RelayCatalogEntry = {
-          url: 'wss://online.com',
-          hostname: 'online.com',
-          isUserAdded: false,
-          isSeed: true,
-          status: 'online',
-          createdAt: 1000,
-          updatedAt: 1000,
-          source: 'seed',
-        };
-        mockRelayCatalog.set(online.url, online);
+    it('should protect online status from transient failures if recently seen', async () => {
+      const now = Date.now();
+      const online: RelayCatalogEntry = {
+        url: 'wss://recently-online.com',
+        hostname: 'recently-online.com',
+        isUserAdded: false,
+        isSeed: true,
+        status: 'online',
+        lastSeen: now - 10 * 60 * 1000, // 10 minutes ago
+        createdAt: 1000,
+        updatedAt: 1000,
+      };
+      mockRelayCatalog.set(online.url, online);
 
-        // Simulate a "failed" refresh which might try to set status to 'error' or 'unknown'
-        await relayCatalogService.upsertEntry({
-          url: 'wss://online.com',
-          hostname: 'online.com',
-          status: 'unknown', // This should be ignored because we have a better status
-        });
-
-        let entry = mockRelayCatalog.get('wss://online.com');
-        expect(entry?.status).toBe('online');
-
-        // But 'error' might be allowed if we explicitly want to mark it as failing
-        await relayCatalogService.upsertEntry({
-            url: 'wss://online.com',
-            hostname: 'online.com',
-            status: 'error',
-          });
-          entry = mockRelayCatalog.get('wss://online.com');
-          expect(entry?.status).toBe('error');
+      // Simulate a "failed" refresh which tries to set status to 'error'
+      await relayCatalogService.upsertEntry({
+        url: 'wss://recently-online.com',
+        hostname: 'recently-online.com',
+        status: 'error',
       });
+
+      const entry = mockRelayCatalog.get('wss://recently-online.com');
+      expect(entry?.status).toBe('online'); // Protected
+    });
+
+    it('should allow status downgrade if not recently seen', async () => {
+      const now = Date.now();
+      const online: RelayCatalogEntry = {
+        url: 'wss://old-online.com',
+        hostname: 'old-online.com',
+        isUserAdded: false,
+        isSeed: true,
+        status: 'online',
+        lastSeen: now - 2 * 60 * 60 * 1000, // 2 hours ago
+        createdAt: 1000,
+        updatedAt: 1000,
+      };
+      mockRelayCatalog.set(online.url, online);
+
+      await relayCatalogService.upsertEntry({
+        url: 'wss://old-online.com',
+        hostname: 'old-online.com',
+        status: 'error',
+      });
+
+      const entry = mockRelayCatalog.get('wss://old-online.com');
+      expect(entry?.status).toBe('error'); // Downgraded
+    });
+
+    it('should update lastSeen when status is online', async () => {
+      const before = Date.now();
+      await relayCatalogService.upsertEntry({
+        url: 'wss://new-online.com',
+        hostname: 'new-online.com',
+        status: 'online',
+      });
+
+      const entry = mockRelayCatalog.get('wss://new-online.com');
+      expect(entry?.lastSeen).toBeGreaterThanOrEqual(before);
+    });
   });
 
   it('should ignore invalid seed entries safely', async () => {
@@ -373,8 +400,8 @@ describe('Relay Catalog Service - getEntries', () => {
     const results = await relayCatalogService.getEntries();
     expect(results.length).toBe(1);
 
-    // Attempt to mutate the returned object (if we can)
-    (results[0] as any).status = 'offline';
+    // @ts-expect-error - testing immutability via side-effect
+    results[0].status = 'offline';
 
     // Verify stored record is unchanged
     expect(mockRelayCatalog.get('wss://immutable.com')?.status).toBe('online');

--- a/tests/unit/services/relay-catalog.test.ts
+++ b/tests/unit/services/relay-catalog.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { loadSeedRelays } from 'src/services/relay-catalog';
+import { loadSeedRelays, relayCatalogService } from 'src/services/relay-catalog';
 import { RELAY_SEEDS } from 'src/data/relay-seeds';
 import type { RelayCatalogEntry } from 'src/types/relay';
 
@@ -22,6 +22,7 @@ vi.mock('src/services/database', () => {
           }
           return 1;
         }),
+        toArray: vi.fn(async () => Array.from(mockRelayCatalog.values())),
       },
       transaction: vi.fn(async (mode, tables, callback) => {
         return callback();
@@ -98,5 +99,148 @@ describe('Relay Catalog Service - loadSeedRelays', () => {
     const result = await loadSeedRelays();
     expect(result.skipped).toBe(1);
     expect(mockRelayCatalog.has('invalid-url')).toBe(false);
+  });
+});
+
+describe('Relay Catalog Service - getEntries', () => {
+  beforeEach(() => {
+    mockRelayCatalog.clear();
+    vi.clearAllMocks();
+  });
+
+  it('should return an empty list when the catalog is empty', async () => {
+    const entries = await relayCatalogService.getEntries();
+    expect(entries).toEqual([]);
+  });
+
+  it('should return sorted results when catalog is populated', async () => {
+    const now = Date.now();
+    const entries: RelayCatalogEntry[] = [
+      {
+        url: 'wss://offline.com',
+        hostname: 'offline.com',
+        isUserAdded: false,
+        isSeed: true,
+        status: 'offline',
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        url: 'wss://seed-with-meta.com',
+        hostname: 'seed-with-meta.com',
+        isUserAdded: false,
+        isSeed: true,
+        status: 'online',
+        metadata: { name: 'Seed' },
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        url: 'wss://discovered-with-meta.com',
+        hostname: 'discovered-with-meta.com',
+        isUserAdded: false,
+        isSeed: false,
+        status: 'online',
+        metadata: { name: 'Discovered' },
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        url: 'wss://no-meta.com',
+        hostname: 'no-meta.com',
+        isUserAdded: false,
+        isSeed: false,
+        status: 'unknown',
+        createdAt: now,
+        updatedAt: now,
+      },
+    ];
+
+    for (const entry of entries) {
+      mockRelayCatalog.set(entry.url, entry);
+    }
+
+    const sorted = await relayCatalogService.getEntries();
+
+    expect(sorted.length).toBe(4);
+    expect(sorted[0]?.url).toBe('wss://seed-with-meta.com');
+    expect(sorted[1]?.url).toBe('wss://discovered-with-meta.com');
+    expect(sorted[2]?.url).toBe('wss://no-meta.com');
+    expect(sorted[3]?.url).toBe('wss://offline.com');
+  });
+
+  it('should exclude invalid entries', async () => {
+    const now = Date.now();
+    mockRelayCatalog.set('invalid-scheme://relay.com', {
+      url: 'invalid-scheme://relay.com',
+      hostname: 'relay.com',
+      isUserAdded: true,
+      isSeed: false,
+      status: 'online',
+      createdAt: now,
+      updatedAt: now,
+    });
+    mockRelayCatalog.set('wss://valid.com', {
+      url: 'wss://valid.com',
+      hostname: 'valid.com',
+      isUserAdded: true,
+      isSeed: false,
+      status: 'online',
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const results = await relayCatalogService.getEntries();
+    expect(results.length).toBe(1);
+    expect(results[0]?.url).toBe('wss://valid.com');
+  });
+
+  it('should not mutate underlying stored records', async () => {
+    const now = Date.now();
+    const entry: RelayCatalogEntry = {
+      url: 'wss://immutable.com',
+      hostname: 'immutable.com',
+      isUserAdded: false,
+      isSeed: true,
+      status: 'online',
+      createdAt: now,
+      updatedAt: now,
+    };
+    mockRelayCatalog.set(entry.url, entry);
+
+    const results = await relayCatalogService.getEntries();
+    expect(results.length).toBe(1);
+
+    // Attempt to mutate the returned object (if we can)
+    (results[0] as any).status = 'offline';
+
+    // Verify stored record is unchanged
+    expect(mockRelayCatalog.get('wss://immutable.com')?.status).toBe('online');
+  });
+
+  it('should sort deterministically by URL when scores are equal', async () => {
+    const now = Date.now();
+    mockRelayCatalog.set('wss://b.com', {
+      url: 'wss://b.com',
+      hostname: 'b.com',
+      isUserAdded: true,
+      isSeed: false,
+      status: 'online',
+      createdAt: now,
+      updatedAt: now,
+    });
+    mockRelayCatalog.set('wss://a.com', {
+      url: 'wss://a.com',
+      hostname: 'a.com',
+      isUserAdded: true,
+      isSeed: false,
+      status: 'online',
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const results = await relayCatalogService.getEntries();
+    expect(results[0]?.url).toBe('wss://a.com');
+    expect(results[1]?.url).toBe('wss://b.com');
   });
 });

--- a/tests/unit/services/relay-database.test.ts
+++ b/tests/unit/services/relay-database.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { RelayCatalogEntry, RelayDiscoveryState } from 'src/types/relay';
+
+// Mock the database since we can't run a real IndexedDB in this environment
+const mockRelayCatalog = new Map<string, RelayCatalogEntry>();
+const mockRelayDiscoveryState = new Map<string, RelayDiscoveryState>();
+const mockVaults = new Map<string, any>();
+const mockExceptions: any[] = [];
+const mockApprovals: any[] = [];
+
+vi.mock('src/services/database', () => {
+  return {
+    DiogelDatabase: class {
+      relayCatalog = {
+        add: vi.fn(async (entry: RelayCatalogEntry) => {
+          mockRelayCatalog.set(entry.url, entry);
+          return entry.url;
+        }),
+        get: vi.fn(async (url: string) => mockRelayCatalog.get(url)),
+        count: vi.fn(async () => mockRelayCatalog.size),
+      };
+      relayDiscoveryState = {
+        add: vi.fn(async (state: RelayDiscoveryState) => {
+          mockRelayDiscoveryState.set(state.id, state);
+          return state.id;
+        }),
+        get: vi.fn(async (id: string) => mockRelayDiscoveryState.get(id)),
+      };
+      vaults = {
+        add: vi.fn(async (vault: any) => {
+          mockVaults.set(vault.id, vault);
+          return vault.id;
+        }),
+        get: vi.fn(async (id: string) => mockVaults.get(id)),
+      };
+      exceptions = {
+        add: vi.fn(async (ex: any) => {
+          mockExceptions.push(ex);
+          return mockExceptions.length;
+        }),
+        count: vi.fn(async () => mockExceptions.length),
+      };
+      approvals = {
+        add: vi.fn(async (app: any) => {
+          mockApprovals.push(app);
+          return mockApprovals.length;
+        }),
+        count: vi.fn(async () => mockApprovals.length),
+      };
+      tables = [
+        { name: 'vaults' },
+        { name: 'exceptions' },
+        { name: 'approvals' },
+        { name: 'relayCatalog' },
+        { name: 'relayDiscoveryState' },
+      ];
+      open = vi.fn(async () => Promise.resolve());
+      delete = vi.fn(async () => Promise.resolve());
+    },
+    db: {}
+  };
+});
+
+import { DiogelDatabase } from 'src/services/database';
+
+describe('Relay Database Schema', () => {
+  let db: DiogelDatabase;
+
+  beforeEach(() => {
+    mockRelayCatalog.clear();
+    mockRelayDiscoveryState.clear();
+    mockVaults.clear();
+    mockExceptions.length = 0;
+    mockApprovals.length = 0;
+    db = new DiogelDatabase();
+  });
+
+  afterEach(async () => {
+    // Cleanup
+  });
+
+  it('should initialize with relayCatalog and relayDiscoveryState tables', async () => {
+    // Check that we can access the tables through the class instance
+    expect(db.relayCatalog).toBeDefined();
+    expect(db.relayDiscoveryState).toBeDefined();
+
+    await db.open();
+    expect(db.tables.map(t => t.name)).toContain('relayCatalog');
+    expect(db.tables.map(t => t.name)).toContain('relayDiscoveryState');
+  });
+
+  it('should insert and retrieve a relay catalog entry', async () => {
+    const entry: RelayCatalogEntry = {
+      url: 'wss://relay.damus.io',
+      hostname: 'relay.damus.io',
+      isUserAdded: true,
+      isSeed: false,
+      status: 'online',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      source: 'manual'
+    };
+
+    await db.relayCatalog.add(entry);
+    const retrieved = await db.relayCatalog.get('wss://relay.damus.io');
+
+    expect(retrieved).toEqual(entry);
+  });
+
+  it('should insert and retrieve a relay discovery state', async () => {
+    const state: RelayDiscoveryState = {
+      id: 'global',
+      isDiscoveryInProgress: true,
+      updatedAt: Date.now(),
+      discoveryStats: {
+        totalDiscovered: 10,
+        newFound: 2
+      }
+    };
+
+    await db.relayDiscoveryState.add(state);
+    const retrieved = await db.relayDiscoveryState.get('global');
+
+    expect(retrieved).toEqual(state);
+  });
+
+  it('should not break existing tables (vaults, exceptions, approvals)', async () => {
+    // Test that we can still use existing tables
+    await db.vaults.add({ id: 'master', encryptedData: 'abc', createdAt: new Date().toISOString() });
+    await db.exceptions.add({ dateTime: new Date().toISOString(), message: 'test error' });
+    await db.approvals.add({ dateTime: new Date().toISOString(), eventKind: 1, hostname: 'localhost' });
+
+    const vault = await db.vaults.get('master');
+    const exceptionCount = await db.exceptions.count();
+    const approvalCount = await db.approvals.count();
+
+    expect(vault?.encryptedData).toBe('abc');
+    expect(exceptionCount).toBe(1);
+    expect(approvalCount).toBe(1);
+  });
+});

--- a/tests/unit/services/relay-discovery-logic.test.ts
+++ b/tests/unit/services/relay-discovery-logic.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi } from 'vitest';
+import { parseRelayListEvent, normalizeAndDeduplicateRelays, relayDiscoveryService } from 'src/services/relay-discovery';
+import type { Event } from 'nostr-tools';
+
+// Mock nostr-tools
+vi.mock('nostr-tools', () => {
+  const querySyncMock = vi.fn().mockResolvedValue([
+    {
+      kind: 10002,
+      id: 'event1',
+      tags: [['r', 'wss://relay1.com']],
+      pubkey: 'pk1'
+    },
+    {
+      kind: 10002,
+      id: 'event2',
+      tags: [['r', 'wss://relay2.com']],
+      pubkey: 'pk2'
+    }
+  ]);
+
+  return {
+    SimplePool: vi.fn().mockImplementation(function() {
+      return {
+        querySync: querySyncMock,
+        close: vi.fn()
+      };
+    })
+  };
+});
+
+describe('RelayDiscoveryService Parsing and Extraction Logic', () => {
+
+  describe('parseRelayListEvent', () => {
+    it('should extract URLs from valid kind 10002 event', () => {
+      const mockEvent = {
+        kind: 10002,
+        tags: [
+          ['r', 'wss://relay1.com', 'read'],
+          ['r', 'wss://relay2.com', 'write'],
+          ['r', 'wss://relay3.com'],
+          ['p', 'another-pubkey'], // non-r tag
+        ],
+        pubkey: 'pubkey1'
+      };
+
+      const result = parseRelayListEvent(mockEvent as Event);
+
+      expect(result).toEqual([
+        'wss://relay1.com',
+        'wss://relay2.com',
+        'wss://relay3.com'
+      ]);
+    });
+
+    it('should ignore non-r tags and malformed tags', () => {
+      const mockEvent = {
+        kind: 10002,
+        tags: [
+          ['r', 'wss://relay1.com'],
+          ['not-r', 'wss://relay2.com'],
+          ['r'], // missing URL
+          ['r', 123], // URL not a string
+          null as any,
+          [],
+        ],
+        pubkey: 'pubkey1'
+      };
+
+      const result = parseRelayListEvent(mockEvent as Event);
+
+      expect(result).toEqual(['wss://relay1.com']);
+    });
+
+    it('should return empty array for non-kind-10002 event', () => {
+      const mockEvent = {
+        kind: 1,
+        content: 'hello',
+        tags: [['r', 'wss://relay1.com']],
+        pubkey: 'pubkey1'
+      };
+
+      const result = parseRelayListEvent(mockEvent as Event);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array for malformed event object', () => {
+      expect(parseRelayListEvent(null as any)).toEqual([]);
+      expect(parseRelayListEvent({} as any)).toEqual([]);
+      expect(parseRelayListEvent({ kind: 10002 } as any)).toEqual([]); // missing tags
+    });
+  });
+
+  describe('normalizeAndDeduplicateRelays', () => {
+    it('should normalize and deduplicate URLs', () => {
+      const urls = [
+        'wss://relay1.com/',
+        'wss://relay1.com', // same after normalization
+        'wss://relay2.com/path/',
+        'wss://RELAY2.com/path', // same after normalization
+        'invalid-url',
+        'https://relay3.com', // invalid protocol (not ws/wss)
+        'wss://relay1.com' // duplicate
+      ];
+
+      const result = normalizeAndDeduplicateRelays(urls);
+
+      expect(result).toEqual([
+        'wss://relay1.com',
+        'wss://relay2.com/path'
+      ]);
+    });
+
+    it('should handle empty input gracefully', () => {
+      expect(normalizeAndDeduplicateRelays([])).toEqual([]);
+    });
+  });
+
+  describe('relayDiscoveryService.processEvents', () => {
+    it('should process multiple kind 10002 events and return unique normalized URLs', () => {
+      const event1 = {
+        kind: 10002,
+        tags: [
+          ['r', 'wss://relay1.com/'],
+          ['r', 'wss://relay2.com'],
+        ],
+        pubkey: 'pubkey1'
+      };
+      const event2 = {
+        kind: 10002,
+        tags: [
+          ['r', 'wss://relay2.com/'],
+          ['r', 'wss://relay3.com'],
+        ],
+        pubkey: 'pubkey2'
+      };
+      const event3 = { kind: 1, content: 'ignore me' };
+
+      const result = relayDiscoveryService.processEvents([event1, event2, event3] as Event[]);
+
+      expect(result.discoveredUrls).toEqual([
+        'wss://relay1.com',
+        'wss://relay2.com',
+        'wss://relay3.com'
+      ]);
+      expect(result.processedEvents).toBe(2);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('should handle malformed events safely in a batch', () => {
+      const events = [
+        { kind: 10002, tags: [['r', 'wss://relay1.com']] },
+        null,
+        { kind: 10002, tags: [['r', 'wss://relay2.com']] },
+      ];
+
+      const result = relayDiscoveryService.processEvents(events as any as Event[]);
+
+      expect(result.discoveredUrls).toEqual([
+        'wss://relay1.com',
+        'wss://relay2.com'
+      ]);
+      expect(result.processedEvents).toBe(2);
+    });
+  });
+
+  describe('relayDiscoveryService.discoverFromRelays', () => {
+    it('should query relays and return discovered URLs', async () => {
+      const seedRelays = ['wss://seed1.com', 'wss://seed2.com'];
+      const result = await relayDiscoveryService.discoverFromRelays(seedRelays);
+
+      expect(result.discoveredUrls).toEqual([
+        'wss://relay1.com',
+        'wss://relay2.com'
+      ]);
+      expect(result.processedEvents).toBe(2);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('should handle query failures gracefully', async () => {
+      // Access the mock pool instance and make it throw
+      const { SimplePool } = await import('nostr-tools');
+      const poolInstance = (SimplePool as any).mock.results[0].value;
+      // Since querySyncMock is reused, we need to mock its next call
+      poolInstance.querySync.mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await relayDiscoveryService.discoverFromRelays(['wss://seed1.com']);
+
+      expect(result.errors[0]).toContain('Discovery query failed: Network error');
+    });
+  });
+});

--- a/tests/unit/services/relay-discovery.test.ts
+++ b/tests/unit/services/relay-discovery.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { relayCatalogService, DISCOVERY_STALENESS_THRESHOLD, METADATA_STALENESS_THRESHOLD } from 'src/services/relay-catalog';
+import type { RelayDiscoveryState, RelayCatalogEntry } from 'src/types/relay';
+
+// Mock the database
+const mockRelayDiscoveryState = new Map<string, RelayDiscoveryState>();
+
+vi.mock('src/services/database', () => {
+  return {
+    db: {
+      relayDiscoveryState: {
+        get: vi.fn(async (id: string) => mockRelayDiscoveryState.get(id)),
+        add: vi.fn(async (state: RelayDiscoveryState) => {
+          mockRelayDiscoveryState.set(state.id, state);
+          return state.id;
+        }),
+        update: vi.fn(async (id: string, changes: Partial<RelayDiscoveryState>) => {
+          const existing = mockRelayDiscoveryState.get(id);
+          if (existing) {
+            mockRelayDiscoveryState.set(id, { ...existing, ...changes });
+          }
+          return 1;
+        }),
+      },
+      transaction: vi.fn(async (mode, tables, callback) => {
+        return callback();
+      }),
+    },
+  };
+});
+
+describe('Relay Catalog Service - Discovery State', () => {
+  beforeEach(() => {
+    mockRelayDiscoveryState.clear();
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should retrieve null if no state exists', async () => {
+    const state = await relayCatalogService.getDiscoveryState('global');
+    expect(state).toBeNull();
+  });
+
+  it('should update and retrieve discovery state', async () => {
+    const now = Date.now();
+    await relayCatalogService.updateDiscoveryState({
+      isDiscoveryInProgress: true,
+      lastGlobalDiscoveryAt: now,
+    });
+
+    const state = await relayCatalogService.getDiscoveryState('global');
+    expect(state).toBeDefined();
+    expect(state?.isDiscoveryInProgress).toBe(true);
+    expect(state?.lastGlobalDiscoveryAt).toBe(now);
+  });
+
+  it('should create a new state if it doesn\'t exist during update', async () => {
+    await relayCatalogService.updateDiscoveryState({ isDiscoveryInProgress: true });
+    const state = await relayCatalogService.getDiscoveryState('global');
+    expect(state?.id).toBe('global');
+    expect(state?.isDiscoveryInProgress).toBe(true);
+  });
+});
+
+describe('Relay Catalog Service - Staleness Logic', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('isDiscoveryStale', () => {
+    it('should consider empty state as stale', () => {
+      expect(relayCatalogService.isDiscoveryStale(null)).toBe(true);
+    });
+
+    it('should consider fresh discovery as not stale', () => {
+      const now = Date.now();
+      const state: RelayDiscoveryState = {
+        id: 'global',
+        isDiscoveryInProgress: false,
+        lastGlobalDiscoveryAt: now - 1000, // 1 second ago
+        updatedAt: now,
+      };
+      expect(relayCatalogService.isDiscoveryStale(state)).toBe(false);
+    });
+
+    it('should consider expired discovery as stale', () => {
+      const now = Date.now();
+      const state: RelayDiscoveryState = {
+        id: 'global',
+        isDiscoveryInProgress: false,
+        lastGlobalDiscoveryAt: now - DISCOVERY_STALENESS_THRESHOLD - 1000,
+        updatedAt: now,
+      };
+      expect(relayCatalogService.isDiscoveryStale(state)).toBe(true);
+    });
+
+    it('should consider state with no prior discovery as stale', () => {
+      const state: RelayDiscoveryState = {
+        id: 'global',
+        isDiscoveryInProgress: false,
+        updatedAt: Date.now(),
+      };
+      expect(relayCatalogService.isDiscoveryStale(state)).toBe(true);
+    });
+
+    it('should suppress refresh if discovery is in progress', () => {
+      const now = Date.now();
+      const state: RelayDiscoveryState = {
+        id: 'global',
+        isDiscoveryInProgress: true, // IN PROGRESS
+        lastGlobalDiscoveryAt: now - DISCOVERY_STALENESS_THRESHOLD - 1000, // expired
+        updatedAt: now,
+      };
+      expect(relayCatalogService.isDiscoveryStale(state)).toBe(false);
+    });
+  });
+
+  describe('isMetadataStale', () => {
+    const now = Date.now();
+    const baseEntry: RelayCatalogEntry = {
+      url: 'wss://relay.com',
+      hostname: 'relay.com',
+      isUserAdded: false,
+      isSeed: true,
+      status: 'online',
+      createdAt: now,
+      updatedAt: now,
+      lastChecked: now,
+    };
+
+    it('should consider status "unknown" as stale', () => {
+      const entry = { ...baseEntry, status: 'unknown' as const };
+      expect(relayCatalogService.isMetadataStale(entry)).toBe(true);
+    });
+
+    it('should consider entry with no lastChecked as stale', () => {
+      const entry = { ...baseEntry };
+      delete entry.lastChecked;
+      expect(relayCatalogService.isMetadataStale(entry)).toBe(true);
+    });
+
+    it('should consider fresh metadata as not stale', () => {
+      const entry = { ...baseEntry, lastChecked: Date.now() - 1000 };
+      expect(relayCatalogService.isMetadataStale(entry)).toBe(false);
+    });
+
+    it('should consider expired metadata as stale', () => {
+      const entry = {
+        ...baseEntry,
+        lastChecked: Date.now() - METADATA_STALENESS_THRESHOLD - 1000,
+      };
+      expect(relayCatalogService.isMetadataStale(entry)).toBe(true);
+    });
+
+    it('should work independently from discovery staleness', () => {
+        // This is more of a logical check that they use different thresholds and different state objects
+        expect(DISCOVERY_STALENESS_THRESHOLD).not.toBe(METADATA_STALENESS_THRESHOLD);
+
+        const state: RelayDiscoveryState = {
+            id: 'global',
+            isDiscoveryInProgress: false,
+            lastGlobalDiscoveryAt: Date.now() - 1000, // fresh discovery
+            updatedAt: Date.now(),
+        };
+        const entry: RelayCatalogEntry = {
+            ...baseEntry,
+            lastChecked: Date.now() - METADATA_STALENESS_THRESHOLD - 1000, // stale metadata
+        };
+
+        expect(relayCatalogService.isDiscoveryStale(state)).toBe(false);
+        expect(relayCatalogService.isMetadataStale(entry)).toBe(true);
+    });
+  });
+});

--- a/tests/unit/services/relay-metadata.test.ts
+++ b/tests/unit/services/relay-metadata.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getNip11Url, fetchRelayMetadata } from 'src/services/relay-metadata';
+
+describe('Relay Metadata Service', () => {
+  describe('getNip11Url', () => {
+    it('should convert wss:// to https://', () => {
+      expect(getNip11Url('wss://relay.damus.io')).toBe('https://relay.damus.io/');
+    });
+
+    it('should convert ws:// to http://', () => {
+      expect(getNip11Url('ws://localhost:8080')).toBe('http://localhost:8080/');
+    });
+
+    it('should handle paths correctly', () => {
+      expect(getNip11Url('wss://relay.damus.io/path')).toBe('https://relay.damus.io/path');
+    });
+
+    it('should throw for invalid URLs', () => {
+      expect(() => getNip11Url('not-a-url')).toThrow('Invalid relay URL');
+    });
+
+    it('should throw for unsupported protocols', () => {
+      expect(() => getNip11Url('gopher://relay.com')).toThrow('Invalid relay URL');
+    });
+  });
+
+  describe('fetchRelayMetadata', () => {
+    beforeEach(() => {
+      vi.stubGlobal('fetch', vi.fn());
+    });
+
+    it('should return successful metadata mapping', async () => {
+      const mockMetadata = {
+        name: 'Damus Relay',
+        description: 'A relay for Damus',
+        pubkey: 'pk123',
+        contact: 'contact@damus.io',
+        supported_nips: [1, 11, 20],
+        software: 'nostr-rs-relay',
+        version: '0.8.1',
+        extra_field: 'extra',
+      };
+
+      (vi.mocked(fetch) as any).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockMetadata,
+      });
+
+      const result = await fetchRelayMetadata('wss://relay.damus.io');
+
+      expect(result.success).toBe(true);
+      expect(result.url).toBe('wss://relay.damus.io');
+      expect(result.metadata).toEqual({
+        name: 'Damus Relay',
+        description: 'A relay for Damus',
+        pubkey: 'pk123',
+        contact: 'contact@damus.io',
+        supported_nips: [1, 11, 20],
+        software: 'nostr-rs-relay',
+        version: '0.8.1',
+        extra_field: 'extra',
+      });
+      expect(result.timestamp).toBeGreaterThan(0);
+    });
+
+    it('should handle timeout correctly', async () => {
+      (vi.mocked(fetch) as any).mockImplementationOnce(() => {
+        return new Promise((resolve, reject) => {
+          const error = new Error('The operation was aborted');
+          error.name = 'AbortError';
+          setTimeout(() => reject(error), 10);
+        });
+      });
+
+      const result = await fetchRelayMetadata('wss://relay.damus.io', 5);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Timeout after 5ms');
+    });
+
+    it('should handle HTTP error responses', async () => {
+      (vi.mocked(fetch) as any).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      });
+
+      const result = await fetchRelayMetadata('wss://relay.damus.io');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('HTTP error 404: Not Found');
+    });
+
+    it('should handle malformed JSON safely', async () => {
+      (vi.mocked(fetch) as any).mockResolvedValueOnce({
+        ok: true,
+        json: async () => {
+          throw new Error('Unexpected token');
+        },
+      });
+
+      const result = await fetchRelayMetadata('wss://relay.damus.io');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Unexpected token');
+    });
+
+    it('should handle non-object JSON responses', async () => {
+        (vi.mocked(fetch) as any).mockResolvedValueOnce({
+          ok: true,
+          json: async () => ['not', 'an', 'object'],
+        });
+
+        const result = await fetchRelayMetadata('wss://relay.damus.io');
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('Invalid NIP-11 response: expected JSON object');
+      });
+
+    it('should handle missing or weird fields in mapping', async () => {
+      const mockMetadata = {
+        name: 123, // should be ignored as it's not a string
+        supported_nips: ['1', 'invalid', 2], // should be mapped to [1, 2]
+      };
+
+      (vi.mocked(fetch) as any).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockMetadata,
+      });
+
+      const result = await fetchRelayMetadata('wss://relay.damus.io');
+
+      expect(result.success).toBe(true);
+      expect(result.metadata?.name).toBeUndefined();
+      expect(result.metadata?.supported_nips).toEqual([1, 2]);
+    });
+
+    it('should fail cleanly for invalid relay URLs', async () => {
+      const result = await fetchRelayMetadata('invalid-url');
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid relay URL');
+    });
+  });
+});

--- a/tests/unit/services/relay-url.test.ts
+++ b/tests/unit/services/relay-url.test.ts
@@ -36,10 +36,10 @@ describe('normalizeRelayUrl', () => {
     expect(result.url).toBe('wss://relay.damus.io');
   });
 
-  it('should keep trailing slash if there is a path', () => {
+  it('should normalize trailing slash even if there is a path', () => {
     const result = normalizeRelayUrl('wss://relay.damus.io/path/');
     expect(result.valid).toBe(true);
-    expect(result.url).toBe('wss://relay.damus.io/path/');
+    expect(result.url).toBe('wss://relay.damus.io/path');
   });
 
   it('should reject empty string', () => {

--- a/tests/unit/services/relay-url.test.ts
+++ b/tests/unit/services/relay-url.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeRelayUrl } from 'src/services/relay-url';
+
+describe('normalizeRelayUrl', () => {
+  it('should validate a valid wss:// URL', () => {
+    const result = normalizeRelayUrl('wss://relay.damus.io');
+    expect(result.valid).toBe(true);
+    expect(result.url).toBe('wss://relay.damus.io');
+    expect(result.hostname).toBe('relay.damus.io');
+    expect(result.error).toBeUndefined();
+  });
+
+  it('should validate a valid ws:// URL', () => {
+    const result = normalizeRelayUrl('ws://localhost:8080');
+    expect(result.valid).toBe(true);
+    expect(result.url).toBe('ws://localhost:8080');
+    expect(result.hostname).toBe('localhost');
+  });
+
+  it('should trim whitespace', () => {
+    const result = normalizeRelayUrl('  wss://relay.damus.io  ');
+    expect(result.valid).toBe(true);
+    expect(result.url).toBe('wss://relay.damus.io');
+  });
+
+  it('should normalize uppercase hostname to lowercase', () => {
+    const result = normalizeRelayUrl('WSS://RELAY.DAMUS.IO');
+    expect(result.valid).toBe(true);
+    expect(result.url).toBe('wss://relay.damus.io');
+    expect(result.hostname).toBe('relay.damus.io');
+  });
+
+  it('should normalize trailing slash (remove it if path is empty)', () => {
+    const result = normalizeRelayUrl('wss://relay.damus.io/');
+    expect(result.valid).toBe(true);
+    expect(result.url).toBe('wss://relay.damus.io');
+  });
+
+  it('should keep trailing slash if there is a path', () => {
+    const result = normalizeRelayUrl('wss://relay.damus.io/path/');
+    expect(result.valid).toBe(true);
+    expect(result.url).toBe('wss://relay.damus.io/path/');
+  });
+
+  it('should reject empty string', () => {
+    const result = normalizeRelayUrl('');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('URL cannot be empty');
+  });
+
+  it('should reject string with only whitespace', () => {
+    const result = normalizeRelayUrl('   ');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('URL cannot be empty');
+  });
+
+  it('should reject null or undefined', () => {
+    expect(normalizeRelayUrl(null).valid).toBe(false);
+    expect(normalizeRelayUrl(undefined).valid).toBe(false);
+  });
+
+  it('should reject non-websocket schemes', () => {
+    const result = normalizeRelayUrl('https://relay.damus.io');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Only ws:// and wss:// protocols are supported');
+  });
+
+  it('should reject malformed URLs', () => {
+    const result = normalizeRelayUrl('not-a-url');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Invalid URL format');
+  });
+
+  it('should handle URLs with ports correctly', () => {
+    const result = normalizeRelayUrl('wss://relay.pro:443/');
+    expect(result.valid).toBe(true);
+    expect(result.url).toBe('wss://relay.pro'); // URL constructor might strip default port
+    expect(result.hostname).toBe('relay.pro');
+  });
+
+  it('should handle custom paths', () => {
+    const result = normalizeRelayUrl('wss://relay.damus.io/v1');
+    expect(result.valid).toBe(true);
+    expect(result.url).toBe('wss://relay.damus.io/v1');
+  });
+});

--- a/tests/unit/utils/relay-filters.test.ts
+++ b/tests/unit/utils/relay-filters.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import type { RelayCatalogEntry } from 'src/types/relay';
+import { filterAndSortRelays } from 'src/utils/relay-filters';
+
+const mockRelays: RelayCatalogEntry[] = [
+  {
+    url: 'wss://zebra.relay.com',
+    hostname: 'zebra.relay.com',
+    status: 'online',
+    isUserAdded: false,
+    isSeed: false,
+    createdAt: 0,
+    updatedAt: 0,
+    metadata: { name: 'Zebra Relay' },
+  },
+  {
+    url: 'wss://apple.relay.com',
+    hostname: 'apple.relay.com',
+    status: 'online',
+    isUserAdded: false,
+    isSeed: false,
+    createdAt: 0,
+    updatedAt: 0,
+    metadata: { name: 'Apple Relay', supported_nips: [50] },
+  },
+  {
+    url: 'wss://search.example.com',
+    hostname: 'search.example.com',
+    status: 'online',
+    isUserAdded: false,
+    isSeed: false,
+    createdAt: 0,
+    updatedAt: 0,
+    metadata: { name: 'Searchable Relay', supported_nips: [1, 50] },
+  },
+  {
+    url: 'wss://nostr.v0l.me',
+    hostname: 'nostr.v0l.me',
+    status: 'online',
+    isUserAdded: false,
+    isSeed: false,
+    createdAt: 0,
+    updatedAt: 0,
+    metadata: { name: 'Volme' },
+  },
+];
+
+describe('relay-filters util', () => {
+  it('should filter by text match in name', () => {
+    const result = filterAndSortRelays(mockRelays, 'Zebra', false);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.url).toBe('wss://zebra.relay.com');
+  });
+
+  it('should filter by text match in hostname', () => {
+    const result = filterAndSortRelays(mockRelays, 'v0l.me', false);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.url).toBe('wss://nostr.v0l.me');
+  });
+
+  it('should filter by text match in URL', () => {
+    const result = filterAndSortRelays(mockRelays, 'wss://zebra', false);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.url).toBe('wss://zebra.relay.com');
+  });
+
+  it('should filter for search-capable (NIP-50) only', () => {
+    const result = filterAndSortRelays(mockRelays, '', true);
+    expect(result).toHaveLength(2);
+    expect(result.some((r) => r.url === 'wss://apple.relay.com')).toBe(true);
+    expect(result.some((r) => r.url === 'wss://search.example.com')).toBe(true);
+  });
+
+  it('should apply both text filter and NIP-50 toggle', () => {
+    const result = filterAndSortRelays(mockRelays, 'apple', true);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.url).toBe('wss://apple.relay.com');
+  });
+
+  it('should return empty list when no matches found', () => {
+    const result = filterAndSortRelays(mockRelays, 'no-match-at-all', false);
+    expect(result).toHaveLength(0);
+  });
+
+  it('should sort relays alphabetically by name', () => {
+    const result = filterAndSortRelays(mockRelays, '', false);
+    // Apple, Searchable, Volme, Zebra
+    expect(result).toHaveLength(4);
+    expect(result[0]!.metadata?.name).toBe('Apple Relay');
+    expect(result[1]!.metadata?.name).toBe('Searchable Relay');
+    expect(result[2]!.metadata?.name).toBe('Volme');
+    expect(result[3]!.metadata?.name).toBe('Zebra Relay');
+  });
+
+  it('should be deterministic after filtering', () => {
+    const result1 = filterAndSortRelays(mockRelays, 'relay', false);
+    const result2 = filterAndSortRelays(mockRelays, 'relay', false);
+    expect(result1).toEqual(result2);
+  });
+});


### PR DESCRIPTION
- **docs: update README and footer, adjust documentation authors**
- **docs: update README and footer, adjust documentation authors**
- **feat: add `normalizeRelayUrl` validator with unit tests**
- **feat: add `normalizeRelayUrl` validator with unit tests**
- **feat: add `RelayCatalogService.getEntries` with unit tests**
- **chore: add `relay.browser.list` and `relay.browser.getStatus` handlers, integrate with dispatcher, and add unit tests**
- **chore: add `RelayBrowserModal` and `RelayEditor` components with unit tests, integrate relay browsing functionality, and extend i18n for related strings**
- **chore: export `sendBexMessage`, seed relay catalog on startup, and enhance `RelayBrowserModal` with relay listing and unit tests**
- **chore: add `listRelayCatalog` function to fetch relay catalog entries from the background**
- **chore: refactor `handleRelayBrowserGetStatus` to use `relayCatalogService` for discovery state management, add staleness checks, and update unit tests**
- **chore: add `RelayDiscoveryService` for bounded relay discovery, implement staleness checks, update URL normalization, and include comprehensive unit tests**
- **chore: add `RelayMetadataService` with `getNip11Url` and `fetchRelayMetadata` functions, implement comprehensive unit tests for URL conversion and metadata fetching**
- **chore: add `upsertEntry` method to `RelayCatalogService` with advanced merging logic, update seed handling and include comprehensive unit tests**
- **chore: add `RelayBrowserOrchestrator` for managing relay discovery and metadata refresh, implement `relay.browser.refresh` handler, and include comprehensive unit tests**
- **chore: enhance `RelayBrowserModal` with relay filtering, sorting, and search capabilities, add refresh and discovery status handling, update unit tests, and extend i18n strings**
- **chore: enhance `RelayCatalogService` with status downgrade protection and `lastSeen` updates, add relay icon in `RelayBrowserModal`, and update related tests**
