### PR TITLE
docs: add CODINGSTANDARDS.md (lint/format, TypeScript, DDD standards)

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -46,48 +46,10 @@ Quasar + Vue 3 + TypeScript codebase and its Browser Extension (BEX) targets.
 
 #### Testing
 
-Currently `package.json` defines `"test": "echo \"No test specified\" && exit 0"` and there is no dedicated test
-framework wired up. You can still write and run lightweight tests immediately using Node’s built-in test runner (
-`node:test`), which requires no extra dependencies and works with the engine range declared in this project.
-
-- One-off test execution (demonstrated and verified):
-  1. Create a temporary file at the project root, for example `tmp-sample.test.mjs` with:
-
-     ```js
-     import test from 'node:test';
-     import assert from 'node:assert/strict';
-
-     test('math sanity', () => {
-       assert.equal(1 + 1, 2);
-     });
-     ```
-
-  2. Run it: `node --test tmp-sample.test.mjs`
-     - Verified output (example):
-       - tests 1, pass 1, fail 0
-  3. Delete the temporary file after use to keep the repo clean.
-
-- Suggested npm script (optional): add to `package.json` if you want a convenience runner without adding a new
-  framework:
-  - `"test": "node --test \"src/**/*.test.{js,mjs,cjs,ts}\""`
-  - With this in place, place small focused tests alongside code (e.g., `src/utils/foo.test.ts`) and run with
-    `npm test`.
-
-- Adopting Vitest (optional, when the test surface grows):
-  - Pros: Jest-like API, watch mode, rich reporters, tight Vite integration, better TS ergonomics for large suites.
-  - Minimal steps (not yet applied to this repo):
-    - `npm i -D vitest @vitest/ui @vitest/coverage-v8 jsdom` (if you need DOM APIs)
-    - Create `vitest.config.ts` aligned with `quasar.config.ts` aliases and Vue plugin.
-    - Add scripts: `"test": "vitest", "test:run": "vitest run"`
-    - Add a sample `*.spec.ts` under `src/` and run `npm test`.
-
-Guidelines for adding tests (irrespective of runner):
-
-- Co-locate tests next to implementation where it increases clarity; otherwise use `tests/` with the same module
-  boundaries.
-- Keep tests deterministic; mock network (`axios`) at the module boundary.
-- For Vue SFCs, prefer component-level tests only after extracting logic into composables/stores where feasible; this
-  keeps UI tests lean.
+Vitest + jsdom is wired up and in active use (config: `vitest.config.ts`, setup:
+`tests/setup.ts`). Run the full suite with `npm run test:run`, or `npm run test` for watch
+mode. See [CODINGSTANDARDS.md](../CODINGSTANDARDS.md) for the canonical testing
+conventions (test locations, crypto/network mocking, determinism).
 
 #### Development notes and code style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,6 @@ This project uses [Junie](https://github.com/JetBrains/junie) to help with devel
 
 You can find the project-specific guidelines for Junie in [.junie/guidelines.md](.junie/guidelines.md).
 
-## Type discipline
-
-- Do not introduce `any` in project code.
-- Prefer exact types, type guards, discriminated unions, generics, and `unknown` plus narrowing.
-- If a third-party surface is awkward, define a local type or adapter instead of falling back to `any`.
-- Treat new `any` usage as a failure unless it was explicitly requested and justified.
+Coding standards and practices — lint/format, TypeScript discipline, and Domain-Driven
+Design guidance — live in [CODINGSTANDARDS.md](CODINGSTANDARDS.md). Read it before
+implementing features or updates.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,26 +101,7 @@ provider-side call in `nostr-provider.js`.
 - i18n messages live under `src/i18n/en-US`; the unplugin only picks up files under
   `src/i18n/`.
 
-## TypeScript conventions
+## TypeScript conventions and testing
 
-See [CODINGSTANDARDS.md](CODINGSTANDARDS.md) for the full lint/format, TypeScript
-discipline, and Domain-Driven Design standards. Highlights:
-
-- Strict mode is on. **Never use `any`** (`@typescript-eslint/no-explicit-any` is an
-  error) — use exact types, type guards, discriminated unions, generics, or `unknown`
-  + narrowing. For awkward third-party types, add adapters/ambient declarations under
-  `src/types/`.
-- Use `<script setup lang="ts">` for all SFCs.
-- ESLint scope is `./src*/**/*.{ts,js,cjs,mjs,vue}` (covers both `src/` and `src-bex/`);
-  Prettier is the sole formatter (no conflicting stylistic ESLint rules).
-
-## Testing
-
-- Vitest + jsdom, config in `vitest.config.ts`, setup in `tests/setup.ts`.
-- Test locations: `tests/unit/**` (mirrors `src`/`src-bex` module structure: `services/`,
-  `components/`, `pages/`, `stores/`, `composables/`, `utils/`) and co-located
-  `*.spec.ts` under `src/`/`src-bex/`.
-- Mock crypto via `tests/unit/mocks/crypto.ts`; mock network (axios) at the module
-  boundary; keep tests deterministic.
-- Path aliases available in tests (see `vitest.config.ts`): `src`, `components`,
-  `app`, `src-bex`.
+See [CODINGSTANDARDS.md](CODINGSTANDARDS.md) for lint/format, TypeScript discipline,
+testing conventions, and Domain-Driven Design standards.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,9 @@ provider-side call in `nostr-provider.js`.
 
 ## TypeScript conventions
 
+See [CODINGSTANDARDS.md](CODINGSTANDARDS.md) for the full lint/format, TypeScript
+discipline, and Domain-Driven Design standards. Highlights:
+
 - Strict mode is on. **Never use `any`** (`@typescript-eslint/no-explicit-any` is an
   error) — use exact types, type guards, discriminated unions, generics, or `unknown`
   + narrowing. For awkward third-party types, add adapters/ambient declarations under

--- a/CODINGSTANDARDS.md
+++ b/CODINGSTANDARDS.md
@@ -1,0 +1,105 @@
+# Coding Standards
+
+This is the canonical source for coding standards and practices in this repository — for
+human contributors and coding agents alike. `AGENTS.md`, `CLAUDE.md`, and
+`.junie/guidelines.md` point here rather than restating these rules.
+
+This document does not require any existing code to be rewritten. It governs new code and
+code you touch going forward. Bringing the existing codebase in line with these standards is
+tracked as separate follow-up work.
+
+## Lint, format, and style
+
+- ESLint 9 (flat config, `eslint.config.js`) is the linter, scoped to
+  `./src*/**/*.{ts,js,cjs,mjs,vue}` (covers both `src/` and `src-bex/`). Run `npm run lint`
+  (`-- --fix` to autofix). Key rules already enforced: `@typescript-eslint/no-explicit-any`
+  as an error, and `@typescript-eslint/consistent-type-imports` (prefer `import type`).
+- Prettier 3 (`.prettierrc.json`: single quotes, 100-column print width) is the sole
+  formatter. Run `npm run format`. Do not add stylistic ESLint rules that would conflict
+  with Prettier.
+- `.editorconfig` governs whitespace/EOL/charset at the editor level; keep it in sync with
+  Prettier's settings if either changes.
+- The rule set above is treated as sufficient for this repository today. Extending it (for
+  example, an import/dependency-boundary rule to enforce the layering described below) is
+  deliberately out of scope for this document — revisit only if boundary violations become a
+  recurring problem in review.
+
+## TypeScript discipline
+
+- Strict mode is on (`quasar.config.ts` → `build.typescript.strict: true`); do not weaken it.
+- **Never use `any`.** Prefer exact types, type guards, discriminated unions, generics, or
+  `unknown` plus narrowing. If a third-party surface is awkward or weakly typed, add a local
+  type, adapter, or ambient declaration under `src/types/` instead of reaching for `any`. New
+  `any` usage is treated as a failure unless explicitly requested and justified in review.
+- Prefer `readonly` properties and `as const` assertions to prevent accidental mutation of
+  values that should be immutable.
+- Prefer pure functions for calculations and queries. Use union types and discriminated
+  unions to model state so illegal states are unrepresentable rather than checked at
+  runtime.
+- Use `<script setup lang="ts">` for all Vue SFCs.
+
+## Domain-Driven Design standards
+
+These standards apply to domain logic you write or materially change — business rules,
+invariants, and the concepts they operate on. They are principle-level guidance, not a
+mandated folder layout: this repository does not yet have a dedicated domain directory (e.g.
+`src/domain/`), and this document does not introduce one. Where a new domain concept needs a
+home, place it near its existing feature area (e.g. alongside the relevant `src/services/*`
+or `src-bex/handlers/*` module) using the patterns below. A concrete folder convention, if
+adopted, is a decision for a future, separate ticket once enough domain code exists to
+justify one.
+
+### Core modeling standards
+
+1. **Value objects** — Encapsulate concepts like an email address or an amount using
+   immutable type aliases or classes. Two value objects with equal values are
+   interchangeable; equality is by value, not identity.
+2. **Entities** — Model objects with a distinct identity (e.g. a UUID) that persists over
+   time. Equality is by identity, not by attributes — two entities with identical attributes
+   but different identities are different entities.
+3. **Aggregates** — Group related entities and value objects into a single unit for data
+   changes, and enforce invariants at the aggregate root. Code outside the aggregate should
+   not mutate its internals directly.
+4. **Avoid primitive obsession** — Don't pass raw `string`/`number` for domain concepts that
+   carry business rules (an npub, a relay URL, a satoshi amount). Use a named type alias or
+   branded type (e.g. `type RelayUrl = string & { readonly __brand: 'RelayUrl' }`) so the
+   type system — not convention — prevents misuse.
+
+### Architectural structure
+
+5. **Hexagonal / onion layering** — Keep the domain layer (business logic, entities, value
+   objects) free of framework, browser, and I/O concerns. Application-layer code
+   (use cases/services) orchestrates the domain; infrastructure code (storage, network,
+   browser APIs) implements the domain's ports. Domain code should not import Vue, Quasar,
+   Dexie, or `chrome.*`/`browser.*` APIs directly.
+6. **Bounded contexts** — Organize code by business concept (e.g. vault/key custody, relay
+   management, signing approval) rather than by technical layer alone, so each area's
+   vocabulary and rules stay legible on their own.
+7. **Ports as interfaces** — Define repository/service interfaces in the domain layer;
+   implement them in the infrastructure layer. This is dependency inversion: the domain
+   depends on an interface it owns, not on a concrete storage or transport mechanism.
+
+### Naming and construction
+
+- **Ubiquitous language** — Name classes, methods, and variables after the domain concepts
+  they represent (e.g. `SigningApproval`, `RelayCatalog`, `VaultAccount`), so code reads in
+  the same vocabulary used to describe the product, not in generic CRUD terms.
+- **Factories** — Use factory functions or classes to encapsulate creation logic that must
+  enforce invariants, so an entity or aggregate can never exist in an invalid state.
+
+## Testing
+
+- Vitest + jsdom is the test framework; config is `vitest.config.ts`, setup is
+  `tests/setup.ts`. Run with `npm run test` (watch) or `npm run test:run` (single run).
+- Tests live under `tests/unit/**` (mirroring the `src`/`src-bex` module structure:
+  `services/`, `components/`, `pages/`, `stores/`, `composables/`, `utils/`) or as
+  co-located `*.spec.ts` files under `src/`/`src-bex/`.
+- Mock crypto via `tests/unit/mocks/crypto.ts`; mock network (Axios) at the module boundary.
+  Keep tests deterministic.
+
+## Where this document does not go
+
+- It does not require rewriting existing `src/`/`src-bex/` code — that migration is
+  explicitly out of scope here and tracked separately.
+- It does not change lint/format tooling or add new dependencies.
+- It does not mandate a `src/domain/`-style folder convention.

--- a/CODINGSTANDARDS.md
+++ b/CODINGSTANDARDS.md
@@ -92,8 +92,8 @@ justify one.
 - Vitest + jsdom is the test framework; config is `vitest.config.ts`, setup is
   `tests/setup.ts`. Run with `npm run test` (watch) or `npm run test:run` (single run).
 - Tests live under `tests/unit/**` (mirroring the `src`/`src-bex` module structure:
-  `services/`, `components/`, `pages/`, `stores/`, `composables/`, `utils/`) or as
-  co-located `*.spec.ts` files under `src/`/`src-bex/`.
+  `services/`, `components/`, `pages/`, `stores/`, `composables/`, `utils/`,
+  `handlers/`) or as co-located `*.spec.ts` files under `src/`/`src-bex/`.
 - Mock crypto via `tests/unit/mocks/crypto.ts`; mock network (Axios) at the module boundary.
   Keep tests deterministic.
 


### PR DESCRIPTION
## Summary
- Adds `CODINGSTANDARDS.md` as the canonical coding-standards doc: existing lint/format tooling, TypeScript discipline, and Domain-Driven Design guidance (value objects, entities, aggregates, primitive-obsession avoidance, hexagonal/onion layering, bounded contexts, ports/dependency inversion, ubiquitous language, factories) for new/changed domain code.
- Deliberately principle-level per the approved plan: no new folder convention (e.g. `src/domain/`) is mandated, no lint/format tooling changes, no existing code touched — migrating existing code is explicit follow-up work.
- `AGENTS.md` and `CLAUDE.md` now link to `CODINGSTANDARDS.md` instead of duplicating the type-discipline rules.
- `.junie/guidelines.md`'s testing section is corrected — it described a "no test framework" state that predates this repo's Vitest adoption (432 tests currently pass via `npm run test:run`).

Fixes #121

## Test plan
- [x] `npm run lint` — passes
- [x] `npm run typecheck` — passes
- [x] Docs-only change; no production code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)