### PR TITLE
test(vault): add coverage for the least-tested vault/key-custody files (PR 1/4 of #126)

### DIFF
--- a/tests/unit/handlers/vault-handler.test.ts
+++ b/tests/unit/handlers/vault-handler.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { VaultData } from 'src/types/bridge';
+
+const mockUnlockVault = vi.fn();
+const mockLockVault = vi.fn();
+const mockIsVaultUnlocked = vi.fn();
+const mockCreateNewVault = vi.fn();
+const mockExportVault = vi.fn();
+const mockImportVault = vi.fn();
+const mockGetVaultData = vi.fn();
+const mockUpdateVaultData = vi.fn();
+const mockRestoreVaultState = vi.fn();
+
+vi.mock('app/src-bex/vault', () => ({
+  unlockVault: mockUnlockVault,
+  lockVault: mockLockVault,
+  isVaultUnlocked: mockIsVaultUnlocked,
+  createNewVault: mockCreateNewVault,
+  exportVault: mockExportVault,
+  importVault: mockImportVault,
+  getVaultData: mockGetVaultData,
+  updateVaultData: mockUpdateVaultData,
+  restoreVaultState: mockRestoreVaultState,
+}));
+
+const vaultData: VaultData = {
+  accounts: [{ id: 'pubkey-hex', alias: 'alpha', account: { privkey: 'secret' }, createdAt: '2026-01-01T00:00:00.000Z' }],
+};
+
+describe('vault-handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('handleVaultUnlock returns vaultData on success', async () => {
+    const { handleVaultUnlock } = await import('app/src-bex/handlers/vault-handler');
+    mockUnlockVault.mockResolvedValue({ success: true, vaultData });
+
+    const result = await handleVaultUnlock({ password: 'pw' }, '');
+
+    expect(mockUnlockVault).toHaveBeenCalledWith('pw');
+    expect(result).toEqual({ success: true, data: { vaultData } });
+  });
+
+  it('handleVaultUnlock surfaces the failure error and code', async () => {
+    const { handleVaultUnlock } = await import('app/src-bex/handlers/vault-handler');
+    mockUnlockVault.mockResolvedValue({ success: false, error: 'Invalid password', errorCode: 'VLT_INVALID_PASSWORD' });
+
+    const result = await handleVaultUnlock({ password: 'wrong' }, '');
+
+    expect(result).toEqual({ success: false, error: 'Invalid password', code: 'VLT_INVALID_PASSWORD' });
+  });
+
+  it('handleVaultLock always succeeds and calls lock()', async () => {
+    const { handleVaultLock } = await import('app/src-bex/handlers/vault-handler');
+
+    const result = await handleVaultLock(undefined, '');
+
+    expect(mockLockVault).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ success: true, data: undefined });
+  });
+
+  it('handleVaultIsUnlocked reflects the underlying vault state', async () => {
+    const { handleVaultIsUnlocked } = await import('app/src-bex/handlers/vault-handler');
+    mockIsVaultUnlocked.mockReturnValue(true);
+
+    const result = await handleVaultIsUnlocked(undefined, '');
+
+    expect(result).toEqual({ success: true, data: true });
+  });
+
+  it('handleVaultCreate returns the encrypted vault on success', async () => {
+    const { handleVaultCreate } = await import('app/src-bex/handlers/vault-handler');
+    mockCreateNewVault.mockResolvedValue({ success: true, encryptedVault: 'v2:abc' });
+
+    const result = await handleVaultCreate({ password: 'pw', vaultData }, '');
+
+    expect(mockCreateNewVault).toHaveBeenCalledWith('pw', vaultData);
+    expect(result).toEqual({ success: true, data: { encryptedVault: 'v2:abc' } });
+  });
+
+  it('handleVaultCreate surfaces failure', async () => {
+    const { handleVaultCreate } = await import('app/src-bex/handlers/vault-handler');
+    mockCreateNewVault.mockResolvedValue({ success: false, error: 'boom', errorCode: 'GEN_UNKNOWN' });
+
+    const result = await handleVaultCreate({ password: 'pw', vaultData }, '');
+
+    expect(result).toEqual({ success: false, error: 'boom', code: 'GEN_UNKNOWN' });
+  });
+
+  it('handleVaultGetData returns vaultData on success', async () => {
+    const { handleVaultGetData } = await import('app/src-bex/handlers/vault-handler');
+    mockGetVaultData.mockResolvedValue({ success: true, vaultData });
+
+    const result = await handleVaultGetData(undefined, '');
+
+    expect(result).toEqual({ success: true, data: { vaultData } });
+  });
+
+  it('handleVaultUpdateData delegates and succeeds', async () => {
+    const { handleVaultUpdateData } = await import('app/src-bex/handlers/vault-handler');
+    mockUpdateVaultData.mockResolvedValue({ success: true });
+
+    const result = await handleVaultUpdateData({ vaultData }, '');
+
+    expect(mockUpdateVaultData).toHaveBeenCalledWith(vaultData);
+    expect(result).toEqual({ success: true, data: undefined });
+  });
+
+  it('handleVaultExport returns encryptedData on success', async () => {
+    const { handleVaultExport } = await import('app/src-bex/handlers/vault-handler');
+    mockExportVault.mockResolvedValue({ success: true, encryptedData: 'v2:xyz' });
+
+    const result = await handleVaultExport(undefined, '');
+
+    expect(result).toEqual({ success: true, data: { encryptedData: 'v2:xyz' } });
+  });
+
+  it('handleVaultImport delegates and succeeds', async () => {
+    const { handleVaultImport } = await import('app/src-bex/handlers/vault-handler');
+    mockImportVault.mockResolvedValue({ success: true });
+
+    const result = await handleVaultImport({ encryptedData: 'v2:xyz' }, '');
+
+    expect(mockImportVault).toHaveBeenCalledWith('v2:xyz');
+    expect(result).toEqual({ success: true, data: undefined });
+  });
+
+  it('re-exports restoreVaultState from ../vault', async () => {
+    const { restoreVaultState } = await import('app/src-bex/handlers/vault-handler');
+    mockRestoreVaultState.mockResolvedValue(true);
+
+    await expect(restoreVaultState()).resolves.toBe(true);
+  });
+});

--- a/tests/unit/services/dexie-storage.test.ts
+++ b/tests/unit/services/dexie-storage.test.ts
@@ -118,3 +118,160 @@ describe('dexie-storage renameAlias', () => {
     expect(mockUpdateVaultData).not.toHaveBeenCalled();
   });
 });
+
+describe('dexie-storage get', () => {
+  const baseKey: StoredKey = {
+    id: 'pubkey-hex',
+    alias: 'alpha',
+    account: { privkey: 'secret' },
+    createdAt: '2026-01-01T00:00:00.000Z',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns an empty object when the vault is locked', async () => {
+    mockIsVaultUnlocked.mockResolvedValue(false);
+
+    const { get } = await import('src/services/dexie-storage');
+
+    await expect(get()).resolves.toEqual({});
+    expect(mockGetVaultData).not.toHaveBeenCalled();
+  });
+
+  it('returns accounts keyed by alias when unlocked', async () => {
+    mockIsVaultUnlocked.mockResolvedValue(true);
+    mockGetVaultData.mockResolvedValue({ success: true, vaultData: { accounts: [baseKey] } });
+
+    const { get } = await import('src/services/dexie-storage');
+
+    await expect(get()).resolves.toEqual({ alpha: baseKey });
+  });
+
+  it('returns an empty object when getVaultData fails', async () => {
+    mockIsVaultUnlocked.mockResolvedValue(true);
+    mockGetVaultData.mockResolvedValue({ success: false });
+
+    const { get } = await import('src/services/dexie-storage');
+
+    await expect(get()).resolves.toEqual({});
+  });
+});
+
+describe('dexie-storage getActive / setActive', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getActive reads the active alias from storage', async () => {
+    mockStorageGet.mockResolvedValue('alpha');
+
+    const { getActive } = await import('src/services/dexie-storage');
+
+    await expect(getActive()).resolves.toBe('alpha');
+    expect(mockStorageGet).toHaveBeenCalledWith('NOSTR_ACTIVE');
+  });
+
+  it('setActive writes the alias to storage', async () => {
+    const { setActive } = await import('src/services/dexie-storage');
+
+    await setActive('beta');
+
+    expect(mockStorageSet).toHaveBeenCalledWith('NOSTR_ACTIVE', 'beta');
+  });
+});
+
+describe('dexie-storage save', () => {
+  const baseKey: StoredKey = {
+    id: 'pubkey-hex',
+    alias: 'alpha',
+    account: { privkey: 'secret' },
+    createdAt: '2026-01-01T00:00:00.000Z',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsVaultUnlocked.mockResolvedValue(true);
+    mockStorageSet.mockResolvedValue(undefined);
+  });
+
+  it('rejects when the vault is locked', async () => {
+    mockIsVaultUnlocked.mockResolvedValue(false);
+
+    const { save } = await import('src/services/dexie-storage');
+
+    await expect(save(baseKey)).rejects.toThrow('Vault is locked. Cannot save key.');
+    expect(mockUpdateVaultData).not.toHaveBeenCalled();
+  });
+
+  it('rejects a duplicate alias', async () => {
+    mockGetVaultData.mockResolvedValue({ success: true, vaultData: { accounts: [structuredClone(baseKey)] } });
+
+    const { save } = await import('src/services/dexie-storage');
+
+    await expect(save({ ...baseKey, id: 'different-id' })).rejects.toThrow(
+      'Key with the same alias already exists.',
+    );
+  });
+
+  it('rejects a duplicate id (npub)', async () => {
+    mockGetVaultData.mockResolvedValue({ success: true, vaultData: { accounts: [structuredClone(baseKey)] } });
+
+    const { save } = await import('src/services/dexie-storage');
+
+    await expect(save({ ...baseKey, alias: 'different-alias' })).rejects.toThrow(
+      'Key with the same npub already exists.',
+    );
+  });
+
+  it('appends the new key and sets it active', async () => {
+    mockGetVaultData.mockResolvedValue({ success: true, vaultData: { accounts: [] } });
+
+    const { save } = await import('src/services/dexie-storage');
+    await save(baseKey);
+
+    expect(mockUpdateVaultData).toHaveBeenCalledWith({ accounts: [baseKey] });
+    expect(mockStorageSet).toHaveBeenCalledWith('NOSTR_ACTIVE', 'alpha');
+  });
+});
+
+describe('dexie-storage remove', () => {
+  const baseKey: StoredKey = {
+    id: 'pubkey-hex',
+    alias: 'alpha',
+    account: { privkey: 'secret' },
+    createdAt: '2026-01-01T00:00:00.000Z',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsVaultUnlocked.mockResolvedValue(true);
+  });
+
+  it('rejects when the vault is locked', async () => {
+    mockIsVaultUnlocked.mockResolvedValue(false);
+
+    const { remove } = await import('src/services/dexie-storage');
+
+    await expect(remove('pubkey-hex')).rejects.toThrow('Vault is locked. Cannot remove key.');
+  });
+
+  it('removes the matching account by id', async () => {
+    mockGetVaultData.mockResolvedValue({ success: true, vaultData: { accounts: [structuredClone(baseKey)] } });
+
+    const { remove } = await import('src/services/dexie-storage');
+    await remove('pubkey-hex');
+
+    expect(mockUpdateVaultData).toHaveBeenCalledWith({ accounts: [] });
+  });
+
+  it('is a no-op when the id is not found', async () => {
+    mockGetVaultData.mockResolvedValue({ success: true, vaultData: { accounts: [structuredClone(baseKey)] } });
+
+    const { remove } = await import('src/services/dexie-storage');
+    await remove('does-not-exist');
+
+    expect(mockUpdateVaultData).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/generate-key.test.ts
+++ b/tests/unit/services/generate-key.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { getPublicKey } from 'nostr-tools';
+import { hexToBytes } from '@noble/hashes/utils';
+import { generateKey } from 'src/services/generate-key';
+import { createPubkey } from 'src/types/pubkey';
+
+describe('generateKey', () => {
+  it('returns a stored key whose id is a valid pubkey derived from its own privkey', () => {
+    const storedKey = generateKey();
+
+    expect(createPubkey(storedKey.id)).toBe(storedKey.id);
+    expect(storedKey.id).toBe(getPublicKey(hexToBytes(storedKey.account.privkey)));
+  });
+
+  it('returns an empty alias and an ISO createdAt timestamp', () => {
+    const storedKey = generateKey();
+
+    expect(storedKey.alias).toBe('');
+    expect(() => new Date(storedKey.createdAt).toISOString()).not.toThrow();
+    expect(new Date(storedKey.createdAt).toISOString()).toBe(storedKey.createdAt);
+  });
+
+  it('generates a different key on every call', () => {
+    const a = generateKey();
+    const b = generateKey();
+
+    expect(a.id).not.toBe(b.id);
+    expect(a.account.privkey).not.toBe(b.account.privkey);
+  });
+});

--- a/tests/unit/services/vault-service.test.ts
+++ b/tests/unit/services/vault-service.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockDbVaultsGet = vi.fn();
+
+vi.mock('src/services/database', () => ({
+  db: {
+    vaults: {
+      get: mockDbVaultsGet,
+    },
+  },
+}));
+
+type BridgeWindow = Window & {
+  bridge?: { send: (request: unknown) => Promise<unknown> } | undefined;
+  $q?: { bex?: { send: (request: unknown) => Promise<unknown> } };
+};
+
+function setBridge(send: ((request: unknown) => Promise<unknown>) | undefined) {
+  (window as BridgeWindow).bridge = send ? { send } : undefined;
+}
+
+function setChromeRuntime(sendMessage: typeof chrome.runtime.sendMessage | undefined) {
+  if (sendMessage) {
+    vi.stubGlobal('chrome', { runtime: { sendMessage, lastError: undefined } });
+  } else {
+    vi.unstubAllGlobals();
+  }
+}
+
+describe('vault-service (bridge messaging)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setBridge(undefined);
+    setChromeRuntime(undefined);
+  });
+
+  afterEach(() => {
+    setBridge(undefined);
+    setChromeRuntime(undefined);
+  });
+
+  it('unlockVault succeeds via the Quasar bridge when available', async () => {
+    setBridge(async () => ({ data: { success: true, vaultData: { accounts: [] } } }));
+
+    const { unlockVault } = await import('src/services/vault-service');
+    const result = await unlockVault('correct-password');
+
+    expect(result).toEqual({ success: true, vaultData: { accounts: [] } });
+  });
+
+  it('unlockVault falls back to chrome.runtime.sendMessage when no bridge is present', async () => {
+    setChromeRuntime(((message, callback) => {
+      (callback as (response: unknown) => void)({ success: true, vaultData: { accounts: [] } });
+    }) as typeof chrome.runtime.sendMessage);
+
+    const { unlockVault } = await import('src/services/vault-service');
+    const result = await unlockVault('correct-password');
+
+    expect(result).toEqual({ success: true, vaultData: { accounts: [] } });
+  });
+
+  it('unlockVault returns a failure result when neither bridge nor chrome.runtime exist', async () => {
+    const { unlockVault } = await import('src/services/vault-service');
+    const result = await unlockVault('any-password');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('No communication channel available');
+  });
+
+  it('lockVault swallows errors from the bridge without throwing', async () => {
+    setBridge(async () => {
+      throw new Error('bridge down');
+    });
+
+    const { lockVault } = await import('src/services/vault-service');
+    await expect(lockVault()).resolves.toBeUndefined();
+  });
+
+  it('createVault forwards password and vaultData through the bridge', async () => {
+    const send = vi.fn().mockResolvedValue({ data: { success: true, encryptedVault: 'v2:abc' } });
+    setBridge(send);
+
+    const { createVault } = await import('src/services/vault-service');
+    const result = await createVault('pw', { accounts: [] });
+
+    expect(send).toHaveBeenCalledWith({
+      event: 'vault.create',
+      to: 'background',
+      payload: { password: 'pw', vaultData: { accounts: [] } },
+    });
+    expect(result).toEqual({ success: true, encryptedVault: 'v2:abc' });
+  });
+
+  it('isVaultUnlocked returns the bridge boolean response', async () => {
+    setBridge(async () => ({ data: true }));
+
+    const { isVaultUnlocked } = await import('src/services/vault-service');
+    await expect(isVaultUnlocked()).resolves.toBe(true);
+  });
+
+  it('isVaultUnlocked returns false when the bridge throws', async () => {
+    setBridge(async () => {
+      throw new Error('bridge down');
+    });
+
+    const { isVaultUnlocked } = await import('src/services/vault-service');
+    await expect(isVaultUnlocked()).resolves.toBe(false);
+  });
+
+  it('getVaultData surfaces a failure response', async () => {
+    setBridge(async () => ({ data: { success: false, error: 'Vault is locked' } }));
+
+    const { getVaultData } = await import('src/services/vault-service');
+    await expect(getVaultData()).resolves.toEqual({ success: false, error: 'Vault is locked' });
+  });
+
+  it('updateVaultData forwards the payload and returns the bridge result', async () => {
+    const send = vi.fn().mockResolvedValue({ data: { success: true } });
+    setBridge(send);
+
+    const { updateVaultData } = await import('src/services/vault-service');
+    const result = await updateVaultData({ accounts: [] });
+
+    expect(send).toHaveBeenCalledWith({
+      event: 'vault.updateData',
+      to: 'background',
+      payload: { vaultData: { accounts: [] } },
+    });
+    expect(result).toEqual({ success: true });
+  });
+
+  it('exportVault returns the encrypted payload on success', async () => {
+    setBridge(async () => ({ data: { success: true, encryptedData: 'v2:xyz' } }));
+
+    const { exportVault } = await import('src/services/vault-service');
+    await expect(exportVault()).resolves.toEqual({ success: true, encryptedData: 'v2:xyz' });
+  });
+
+  it('importVault forwards the encrypted data', async () => {
+    const send = vi.fn().mockResolvedValue({ data: { success: true } });
+    setBridge(send);
+
+    const { importVault } = await import('src/services/vault-service');
+    const result = await importVault('v2:xyz');
+
+    expect(send).toHaveBeenCalledWith({
+      event: 'vault.import',
+      to: 'background',
+      payload: { encryptedData: 'v2:xyz' },
+    });
+    expect(result).toEqual({ success: true });
+  });
+});
+
+describe('vault-service hasVault (direct DB access)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns true when a master vault record exists', async () => {
+    mockDbVaultsGet.mockResolvedValue({ id: 'master', encryptedData: 'v2:abc', createdAt: '2026-01-01T00:00:00.000Z' });
+
+    const { hasVault } = await import('src/services/vault-service');
+    await expect(hasVault()).resolves.toBe(true);
+  });
+
+  it('returns false when no master vault record exists', async () => {
+    mockDbVaultsGet.mockResolvedValue(undefined);
+
+    const { hasVault } = await import('src/services/vault-service');
+    await expect(hasVault()).resolves.toBe(false);
+  });
+
+  it('returns false when the database read rejects', async () => {
+    mockDbVaultsGet.mockRejectedValue(new Error('db unavailable'));
+
+    const { hasVault } = await import('src/services/vault-service');
+    await expect(hasVault()).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Part of #126 (bounded-context migration, PR 1 of 4: vault/key custody). Based on `issue-125-value-objects` (#129) rather than `master`, since this branch depends on that PR's `Pubkey` type; **please rebase onto `master` once #129 merges**, or merge #129 first.

`#126`'s plan flagged `storage-service.ts` and `vault-service.ts` as candidates for a `chrome`/`browser` port-interface extraction. After reading both files closely:

- `storage-service.ts` already defines a `StorageService` interface with a single `chrome.storage`-backed implementation (`storageService`) -- the port/adapter pattern this migration was meant to introduce already exists.
- `vault-service.ts`'s `chrome.runtime.sendMessage` usage is itself the messaging-transport fallback inside `sendBexMessage`, not domain logic entangled with a chrome API -- already at the correct infrastructure boundary alongside the existing `BridgeLike` interface.

Per `CODINGSTANDARDS.md`: apply patterns "where they clarify a real invariant, not everywhere reflexively" -- so no port was forced into existence where one already exists. Instead, this PR delivers the other half of PR 1's approach ("add/extend tests for the code touched") against the files with the weakest coverage in the whole codebase per #124's baseline:

| File | Baseline coverage | 
|---|---|
| `src/services/generate-key.ts` | untested (not even in the report) |
| `src-bex/handlers/vault-handler.ts` | untested (not even in the report) |
| `src/services/vault-service.ts` | 1.38% |
| `src/services/dexie-storage.ts` | 38.35% (only `renameAlias` was covered) |

**Purely additive: no production code changed.** 40 new tests; full suite: 489 passed.

Remaining PRs for #126 (relay management, signing/NIP handlers, profile/misc) are separate follow-up `build-now` runs.

## Test plan
- [x] `npm run lint` -- passes
- [x] `npm run typecheck` -- passes
- [x] `npm run test:run` -- 489 tests pass (40 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)