### PR TITLE
test(relay): cover relay-service.ts and the refresh handler (PR 2/4 of #126)

### DIFF
--- a/tests/unit/handlers/relay-browser-handler.test.ts
+++ b/tests/unit/handlers/relay-browser-handler.test.ts
@@ -1,7 +1,12 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { handleRelayBrowserList, handleRelayBrowserGetStatus } from 'app/src-bex/handlers/relay-browser-handler';
+import {
+  handleRelayBrowserList,
+  handleRelayBrowserGetStatus,
+  handleRelayBrowserRefresh,
+} from 'app/src-bex/handlers/relay-browser-handler';
 import { relayCatalogService } from 'src/services/relay-catalog';
+import { relayBrowserOrchestrator } from 'src/services/relay-browser-orchestrator';
 import type { RelayCatalogEntry } from 'src/types/relay';
 
 // Mock dependencies
@@ -9,6 +14,12 @@ vi.mock('src/services/relay-catalog', () => ({
   relayCatalogService: {
     getEntries: vi.fn(),
     getDiscoveryState: vi.fn(),
+  },
+}));
+
+vi.mock('src/services/relay-browser-orchestrator', () => ({
+  relayBrowserOrchestrator: {
+    refreshCatalog: vi.fn(),
   },
 }));
 
@@ -92,6 +103,55 @@ describe('RelayBrowserHandler', () => {
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.error).toBe('Read error');
+      }
+    });
+  });
+
+  describe('handleRelayBrowserRefresh', () => {
+    it('returns success immediately without awaiting the refresh, forwarding the force flag', async () => {
+      let resolveRefresh!: () => void;
+      vi.mocked(relayBrowserOrchestrator.refreshCatalog).mockReturnValue(
+        new Promise((resolve) => {
+          resolveRefresh = resolve;
+        }),
+      );
+
+      const result = await handleRelayBrowserRefresh({ force: true });
+
+      expect(result).toEqual({ success: true, data: undefined });
+      expect(relayBrowserOrchestrator.refreshCatalog).toHaveBeenCalledWith(true);
+
+      resolveRefresh();
+    });
+
+    it('defaults force to false when no payload is given', async () => {
+      vi.mocked(relayBrowserOrchestrator.refreshCatalog).mockResolvedValue(undefined);
+
+      await handleRelayBrowserRefresh();
+
+      expect(relayBrowserOrchestrator.refreshCatalog).toHaveBeenCalledWith(false);
+    });
+
+    it('does not propagate a rejection from the background refresh (fire-and-forget)', async () => {
+      vi.mocked(relayBrowserOrchestrator.refreshCatalog).mockRejectedValue(new Error('refresh failed'));
+
+      const result = await handleRelayBrowserRefresh({ force: false });
+      expect(result).toEqual({ success: true, data: undefined });
+
+      // Let the fire-and-forget .catch() run before the test ends.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    it('returns failure when triggering the refresh throws synchronously', async () => {
+      vi.mocked(relayBrowserOrchestrator.refreshCatalog).mockImplementation(() => {
+        throw new Error('orchestrator unavailable');
+      });
+
+      const result = await handleRelayBrowserRefresh({ force: true });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('orchestrator unavailable');
       }
     });
   });

--- a/tests/unit/services/relay-service.test.ts
+++ b/tests/unit/services/relay-service.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RelayCatalogEntry, RelayDiscoveryState } from 'src/types/relay';
+
+const mockSendBexMessage = vi.fn();
+
+vi.mock('src/services/vault-service', () => ({
+  sendBexMessage: mockSendBexMessage,
+}));
+
+describe('relay-service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('listRelayCatalog', () => {
+    it('returns the catalog entries from the background', async () => {
+      const entries = [{ url: 'wss://relay.damus.io', hostname: 'relay.damus.io' }] as RelayCatalogEntry[];
+      mockSendBexMessage.mockResolvedValue(entries);
+
+      const { listRelayCatalog } = await import('src/services/relay-service');
+      await expect(listRelayCatalog()).resolves.toEqual(entries);
+      expect(mockSendBexMessage).toHaveBeenCalledWith('relay.browser.list');
+    });
+
+    it('returns an empty array when the background responds with nothing', async () => {
+      mockSendBexMessage.mockResolvedValue(undefined);
+
+      const { listRelayCatalog } = await import('src/services/relay-service');
+      await expect(listRelayCatalog()).resolves.toEqual([]);
+    });
+
+    it('returns an empty array when the bridge call throws', async () => {
+      mockSendBexMessage.mockRejectedValue(new Error('bridge down'));
+
+      const { listRelayCatalog } = await import('src/services/relay-service');
+      await expect(listRelayCatalog()).resolves.toEqual([]);
+    });
+  });
+
+  describe('refreshRelayCatalog', () => {
+    it('forwards the force flag to the background', async () => {
+      mockSendBexMessage.mockResolvedValue(undefined);
+
+      const { refreshRelayCatalog } = await import('src/services/relay-service');
+      await refreshRelayCatalog(true);
+
+      expect(mockSendBexMessage).toHaveBeenCalledWith('relay.browser.refresh', { force: true });
+    });
+
+    it('defaults force to false', async () => {
+      mockSendBexMessage.mockResolvedValue(undefined);
+
+      const { refreshRelayCatalog } = await import('src/services/relay-service');
+      await refreshRelayCatalog();
+
+      expect(mockSendBexMessage).toHaveBeenCalledWith('relay.browser.refresh', { force: false });
+    });
+
+    it('swallows errors from the bridge without throwing', async () => {
+      mockSendBexMessage.mockRejectedValue(new Error('bridge down'));
+
+      const { refreshRelayCatalog } = await import('src/services/relay-service');
+      await expect(refreshRelayCatalog()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getRelayDiscoveryStatus', () => {
+    it('returns the discovery status from the background', async () => {
+      const status = { id: 'global', lastGlobalDiscoveryAt: 1, isDiscoveryInProgress: false, updatedAt: 1 } as RelayDiscoveryState;
+      mockSendBexMessage.mockResolvedValue(status);
+
+      const { getRelayDiscoveryStatus } = await import('src/services/relay-service');
+      await expect(getRelayDiscoveryStatus()).resolves.toEqual(status);
+    });
+
+    it('returns null when the background responds with nothing', async () => {
+      mockSendBexMessage.mockResolvedValue(undefined);
+
+      const { getRelayDiscoveryStatus } = await import('src/services/relay-service');
+      await expect(getRelayDiscoveryStatus()).resolves.toBeNull();
+    });
+
+    it('returns null when the bridge call throws', async () => {
+      mockSendBexMessage.mockRejectedValue(new Error('bridge down'));
+
+      const { getRelayDiscoveryStatus } = await import('src/services/relay-service');
+      await expect(getRelayDiscoveryStatus()).resolves.toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Part of #126 (bounded-context migration, PR 2 of 4: relay management). Based on `issue-125-value-objects` (#129), same as PR 1 (#130) -- independently mergeable, not stacked on #130. **Please rebase onto `master` once #129 merges.**

`#126`'s plan flagged `relay-service.ts` as also calling `chrome.*`/`browser.*` directly. On inspection, it doesn't -- the earlier audit grep matched the literal string `'relay.browser.list'` (an event name passed to `sendBexMessage`, the same messaging abstraction `vault-service.ts` uses), not an actual chrome/browser API reference. None of this bounded context's files touch chrome/browser APIs directly, so no port extraction is needed here (same finding as PR 1 for `storage-service.ts`/`vault-service.ts`).

Adopting `RelayUrl` (from #125) at `relay-catalog.ts`'s `RelayCatalogEntry.url` boundary was considered and skipped: that type is consumed widely outside this file set (components, other services), so narrowing it here would expand this PR beyond its declared, independently-mergeable scope.

Delivered instead -- tests for the two real coverage gaps in this context per #124's baseline:

| File | Baseline coverage | 
|---|---|
| `src/services/relay-service.ts` | 0% |
| `src-bex/handlers/relay-browser-handler.ts` | 58.82% (missing `handleRelayBrowserRefresh`) |

`profile-search-relay-settings-service.ts` already had full test coverage, so it needed nothing.

**Purely additive: no production code changed.** 13 new tests; full suite: 462 passed.

Remaining PRs for #126: signing/NIP handlers, profile/misc -- separate follow-up `build-now` runs.

## Test plan
- [x] `npm run lint` -- passes
- [x] `npm run typecheck` -- passes
- [x] `npm run test:run` -- 462 tests pass (13 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)