### PR TITLE
test(signing): cover nip57's zap flow and nip47's connection handlers (PR 3/4 of #126)

### DIFF
--- a/tests/unit/handlers/nip47.test.ts
+++ b/tests/unit/handlers/nip47.test.ts
@@ -2,9 +2,20 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 /* eslint-disable @typescript-eslint/unbound-method */
 
-import { handleNip47PayInvoice } from 'app/src-bex/handlers/nip47';
+import {
+  handleNip47ConnectionImport,
+  handleNip47ConnectionRemove,
+  handleNip47ConnectionSetActive,
+  handleNip47ConnectionsList,
+  handleNip47GetBalance,
+  handleNip47GetInfo,
+  handleNip47PayInvoice,
+  handleNip47PaymentHistoryList,
+} from 'app/src-bex/handlers/nip47';
 import { getVaultData, updateVaultData } from 'app/src-bex/vault';
 import { nip47Client } from 'app/src-bex/services/nip47-client';
+import { parseNwcUri, buildNip47ConnectionId } from 'src/services/nip47-uri';
+import { listNip47PaymentHistory } from 'app/src-bex/services/nip47-payment-history-store';
 import type { VaultData } from 'src/types/bridge';
 import type { Nip47Connection } from 'src/types/nip47';
 
@@ -16,8 +27,23 @@ vi.mock('app/src-bex/vault', () => ({
 vi.mock('app/src-bex/services/nip47-client', () => ({
   nip47Client: {
     payInvoice: vi.fn(),
+    getInfo: vi.fn(),
+    getBalance: vi.fn(),
   },
 }));
+
+vi.mock('src/services/nip47-uri', () => ({
+  parseNwcUri: vi.fn(),
+  buildNip47ConnectionId: vi.fn(),
+}));
+
+vi.mock('app/src-bex/services/nip47-payment-history-store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('app/src-bex/services/nip47-payment-history-store')>();
+  return {
+    ...actual,
+    listNip47PaymentHistory: vi.fn(actual.listNip47PaymentHistory),
+  };
+});
 
 function buildConnection(overrides: Partial<Nip47Connection> = {}): Nip47Connection {
   return {
@@ -120,5 +146,217 @@ describe('handleNip47PayInvoice', () => {
     await expect(handleNip47PayInvoice({ connectionId: 'missing-wallet', invoice: INVOICE })).rejects.toThrow(
       'NIP-47 connection not found',
     );
+  });
+});
+
+describe('handleNip47ConnectionsList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('summarizes all connections, stripping the client secret', async () => {
+    vi.mocked(getVaultData).mockResolvedValue({
+      success: true,
+      vaultData: { accounts: [], nip47Connections: [buildConnection()] },
+    });
+
+    const result = await handleNip47ConnectionsList();
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({ id: 'wallet-a', hasClientSecret: true });
+      expect(result.data[0]).not.toHaveProperty('clientSecret');
+    }
+  });
+
+  it('returns an empty list when the vault has no connections', async () => {
+    vi.mocked(getVaultData).mockResolvedValue({ success: true, vaultData: { accounts: [] } });
+
+    const result = await handleNip47ConnectionsList();
+
+    expect(result).toEqual({ success: true, data: [] });
+  });
+});
+
+describe('handleNip47ConnectionImport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(updateVaultData).mockResolvedValue({ success: true });
+    vi.mocked(parseNwcUri).mockReturnValue({
+      walletServicePubkey: 'wallet-service-pubkey',
+      clientSecret: 'aa'.repeat(32),
+      relays: ['wss://relay.example.com/'],
+    });
+    vi.mocked(buildNip47ConnectionId).mockReturnValue('nip47:wallet-service-pubkey:client-pubkey');
+  });
+
+  it('creates a new connection from a parsed NWC URI', async () => {
+    vi.mocked(getVaultData).mockResolvedValue({ success: true, vaultData: { accounts: [] } });
+
+    const result = await handleNip47ConnectionImport({ uri: 'nostr+walletconnect://...', label: 'My Wallet' });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toMatchObject({
+        id: 'nip47:wallet-service-pubkey:client-pubkey',
+        label: 'My Wallet',
+        isActive: true,
+        capabilities: [],
+      });
+      expect(result.data).not.toHaveProperty('clientSecret');
+    }
+    expect(updateVaultData).toHaveBeenCalledTimes(1);
+    const saved = vi.mocked(updateVaultData).mock.calls[0]?.[0] as VaultData;
+    expect(saved.nip47Connections).toHaveLength(1);
+  });
+
+  it('preserves capabilities and createdAt when re-importing an existing connection', async () => {
+    const existing = buildConnection({
+      id: 'nip47:wallet-service-pubkey:client-pubkey',
+      capabilities: ['pay_invoice'],
+      createdAt: '2020-01-01T00:00:00.000Z',
+    });
+    vi.mocked(getVaultData).mockResolvedValue({
+      success: true,
+      vaultData: { accounts: [], nip47Connections: [existing] },
+    });
+
+    const result = await handleNip47ConnectionImport({ uri: 'nostr+walletconnect://...' });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.capabilities).toEqual(['pay_invoice']);
+      expect(result.data.createdAt).toBe('2020-01-01T00:00:00.000Z');
+      // No label was given, so it falls back to the existing label.
+      expect(result.data.label).toBe(existing.label);
+    }
+  });
+});
+
+describe('handleNip47ConnectionRemove', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(updateVaultData).mockResolvedValue({ success: true });
+  });
+
+  it('removes the connection and persists the vault', async () => {
+    vi.mocked(getVaultData).mockResolvedValue({
+      success: true,
+      vaultData: { accounts: [], nip47Connections: [buildConnection()] },
+    });
+
+    const result = await handleNip47ConnectionRemove({ connectionId: 'wallet-a' });
+
+    expect(result).toEqual({ success: true, data: true });
+    const saved = vi.mocked(updateVaultData).mock.calls[0]?.[0] as VaultData;
+    expect(saved.nip47Connections).toEqual([]);
+  });
+});
+
+describe('handleNip47ConnectionSetActive', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(updateVaultData).mockResolvedValue({ success: true });
+  });
+
+  it('activates the target connection and deactivates the rest', async () => {
+    const other = buildConnection({ id: 'wallet-b', isActive: true });
+    const target = buildConnection({ id: 'wallet-a', isActive: false });
+    vi.mocked(getVaultData).mockResolvedValue({
+      success: true,
+      vaultData: { accounts: [], nip47Connections: [other, target] },
+    });
+
+    const result = await handleNip47ConnectionSetActive({ connectionId: 'wallet-a' });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.id).toBe('wallet-a');
+    }
+    const saved = vi.mocked(updateVaultData).mock.calls[0]?.[0] as VaultData;
+    expect(saved.nip47Connections?.find((c) => c.id === 'wallet-a')?.isActive).toBe(true);
+    expect(saved.nip47Connections?.find((c) => c.id === 'wallet-b')?.isActive).toBe(false);
+  });
+
+  it('rejects when the connection does not exist', async () => {
+    vi.mocked(getVaultData).mockResolvedValue({ success: true, vaultData: { accounts: [] } });
+
+    await expect(handleNip47ConnectionSetActive({ connectionId: 'missing' })).rejects.toThrow(
+      'NIP-47 connection not found',
+    );
+  });
+});
+
+describe('handleNip47GetInfo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(updateVaultData).mockResolvedValue({ success: true });
+  });
+
+  it('fetches wallet info and persists updated capabilities', async () => {
+    vi.mocked(getVaultData).mockResolvedValue({
+      success: true,
+      vaultData: { accounts: [], nip47Connections: [buildConnection()] },
+    });
+    vi.mocked(nip47Client.getInfo).mockResolvedValue({
+      capabilities: ['pay_invoice', 'get_balance'],
+      checkedAt: '2026-06-14T00:00:00.000Z',
+    } as never);
+
+    const result = await handleNip47GetInfo({ connectionId: 'wallet-a' });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.capabilities).toEqual(['pay_invoice', 'get_balance']);
+    }
+    const saved = vi.mocked(updateVaultData).mock.calls[0]?.[0] as VaultData;
+    expect(saved.nip47Connections?.[0]).toMatchObject({ capabilities: ['pay_invoice', 'get_balance'] });
+  });
+
+  it('rejects when the connection does not exist', async () => {
+    vi.mocked(getVaultData).mockResolvedValue({ success: true, vaultData: { accounts: [] } });
+
+    await expect(handleNip47GetInfo({ connectionId: 'missing' })).rejects.toThrow('NIP-47 connection not found');
+  });
+});
+
+describe('handleNip47GetBalance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the wallet balance for an existing connection', async () => {
+    vi.mocked(getVaultData).mockResolvedValue({
+      success: true,
+      vaultData: { accounts: [], nip47Connections: [buildConnection()] },
+    });
+    vi.mocked(nip47Client.getBalance).mockResolvedValue({ balanceMsat: 100_000 } as never);
+
+    const result = await handleNip47GetBalance({ connectionId: 'wallet-a' });
+
+    expect(result).toEqual({ success: true, data: { balanceMsat: 100_000 } });
+  });
+
+  it('rejects when the connection does not exist', async () => {
+    vi.mocked(getVaultData).mockResolvedValue({ success: true, vaultData: { accounts: [] } });
+
+    await expect(handleNip47GetBalance({ connectionId: 'missing' })).rejects.toThrow('NIP-47 connection not found');
+  });
+});
+
+describe('handleNip47PaymentHistoryList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the payment history for the unlocked vault', async () => {
+    const vaultData: VaultData = { accounts: [], nip47PaymentHistory: [] };
+    vi.mocked(getVaultData).mockResolvedValue({ success: true, vaultData });
+
+    const result = await handleNip47PaymentHistoryList();
+
+    expect(result).toEqual({ success: true, data: [] });
+    expect(listNip47PaymentHistory).toHaveBeenCalledWith(vaultData);
   });
 });

--- a/tests/unit/handlers/nip57.test.ts
+++ b/tests/unit/handlers/nip57.test.ts
@@ -1,0 +1,268 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { VaultData } from 'src/types/bridge';
+import type { Nip47Connection } from 'src/types/nip47';
+import type { SendZapRequest } from 'src/types/nip57';
+import { ErrorCode } from 'src/types/error-codes.d';
+
+/* eslint-disable @typescript-eslint/unbound-method */
+
+vi.mock('app/src-bex/vault', () => ({
+  getVaultData: vi.fn(),
+  updateVaultData: vi.fn(),
+}));
+
+vi.mock('src/services/storage-service', () => ({
+  NOSTR_ACTIVE: 'NOSTR_ACTIVE',
+  storageService: { get: vi.fn() },
+}));
+
+vi.mock('app/src-bex/services/nip47-connection-store', () => ({
+  findNip47Connection: vi.fn(),
+  listNip47Connections: vi.fn(),
+}));
+
+vi.mock('app/src-bex/services/nip47-client', () => ({
+  nip47Client: { payInvoice: vi.fn() },
+}));
+
+vi.mock('app/src-bex/services/nip57-zap-history-store', () => ({
+  appendNip57ZapHistory: vi.fn((vaultData: VaultData) => vaultData),
+  listNip57ZapHistory: vi.fn(),
+}));
+
+vi.mock('src/services/nip57-lnurl', () => ({
+  assertLnurlAmount: vi.fn(),
+  fetchLnurlPayTarget: vi.fn(),
+  requestZapInvoice: vi.fn(),
+}));
+
+vi.mock('src/services/nip57-zap-request', () => ({
+  signZapRequest: vi.fn(),
+}));
+
+vi.mock('src/services/nip47-invoice', () => ({
+  parseBolt11AmountMsat: vi.fn(),
+  previewInvoice: vi.fn((invoice: string) => `preview:${invoice}`),
+}));
+
+import { getVaultData, updateVaultData } from 'app/src-bex/vault';
+import { storageService } from 'src/services/storage-service';
+import { findNip47Connection, listNip47Connections } from 'app/src-bex/services/nip47-connection-store';
+import { nip47Client } from 'app/src-bex/services/nip47-client';
+import { appendNip57ZapHistory, listNip57ZapHistory } from 'app/src-bex/services/nip57-zap-history-store';
+import { assertLnurlAmount, fetchLnurlPayTarget, requestZapInvoice } from 'src/services/nip57-lnurl';
+import { signZapRequest } from 'src/services/nip57-zap-request';
+import { parseBolt11AmountMsat } from 'src/services/nip47-invoice';
+import {
+  handleNip57GetCapabilities,
+  handleNip57SendZap,
+  handleNip57ZapHistoryList,
+} from 'app/src-bex/handlers/nip57';
+
+function buildConnection(overrides: Partial<Nip47Connection> = {}): Nip47Connection {
+  return {
+    id: 'wallet-a',
+    label: 'Wallet A',
+    walletServicePubkey: 'wallet-a-wallet-pubkey',
+    clientSecret: 'wallet-a-secret',
+    clientPubkey: 'wallet-a-client-pubkey',
+    relays: ['wss://relay.example.com/'],
+    capabilities: ['pay_invoice'],
+    createdAt: '2026-06-14T00:00:00.000Z',
+    updatedAt: '2026-06-14T00:00:00.000Z',
+    isActive: true,
+    ...overrides,
+  };
+}
+
+const account = { id: 'sender-pubkey', alias: 'alpha', account: { privkey: 'secret' }, createdAt: '2026-01-01T00:00:00.000Z' };
+
+function baseVaultData(): VaultData {
+  return { accounts: [account] };
+}
+
+function baseRequest(overrides: Partial<SendZapRequest> = {}): SendZapRequest {
+  return {
+    target: { type: 'profile', recipientPubkey: 'recipient-pubkey' },
+    amountSats: 21,
+    receiptRelays: ['wss://relay.example.com'],
+    ...overrides,
+  };
+}
+
+describe('handleNip57GetCapabilities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getVaultData).mockResolvedValue({ success: true, vaultData: baseVaultData() });
+  });
+
+  it('reports unavailable with no active wallet connection', async () => {
+    vi.mocked(listNip47Connections).mockReturnValue([]);
+
+    const result = await handleNip57GetCapabilities();
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        available: false,
+        requiresConfirmation: true,
+        supportsComments: true,
+        supportsEventZap: true,
+        supportsProfileZap: true,
+        supportsAddressableZap: true,
+      },
+    });
+  });
+
+  it('reports the active wallet connection when one exists', async () => {
+    vi.mocked(listNip47Connections).mockReturnValue([buildConnection()]);
+
+    const result = await handleNip57GetCapabilities();
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.available).toBe(true);
+      expect(result.data.activeWalletConnection).toEqual({
+        id: 'wallet-a',
+        label: 'Wallet A',
+        supportsPayInvoice: true,
+      });
+    }
+  });
+
+  it('propagates a vault-locked error', async () => {
+    vi.mocked(getVaultData).mockResolvedValue({ success: false, error: 'locked', errorCode: ErrorCode.VLT_LOCKED });
+
+    await expect(handleNip57GetCapabilities()).rejects.toThrow('Vault is locked');
+  });
+});
+
+describe('handleNip57ZapHistoryList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the zap history for the unlocked vault', async () => {
+    const vaultData = baseVaultData();
+    vi.mocked(getVaultData).mockResolvedValue({ success: true, vaultData });
+    vi.mocked(listNip57ZapHistory).mockReturnValue([]);
+
+    const result = await handleNip57ZapHistoryList();
+
+    expect(result).toEqual({ success: true, data: [] });
+    expect(listNip57ZapHistory).toHaveBeenCalledWith(vaultData);
+  });
+});
+
+describe('handleNip57SendZap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    globalThis.crypto.randomUUID = vi.fn(() => 'zap-entry-id') as () => `${string}-${string}-${string}-${string}-${string}`;
+    vi.mocked(getVaultData).mockResolvedValue({ success: true, vaultData: baseVaultData() });
+    vi.mocked(storageService.get).mockResolvedValue(undefined);
+    vi.mocked(updateVaultData).mockResolvedValue({ success: true });
+  });
+
+  it('returns a cancelled result without touching the vault when not approved', async () => {
+    const result = await handleNip57SendZap({ request: baseRequest(), origin: 'https://example.com', approved: false });
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        status: 'cancelled',
+        amountMsat: 0,
+        recipientPubkey: 'recipient-pubkey',
+        error: 'Zap payment was not approved',
+        code: 'USER_REJECTED',
+      },
+    });
+    expect(getVaultData).not.toHaveBeenCalled();
+  });
+
+  it('rejects when both amountSats and amountMsat are given', async () => {
+    const request = baseRequest({ amountSats: 21, amountMsat: 21000 });
+
+    await expect(
+      handleNip57SendZap({ request, origin: 'https://example.com', approved: true }),
+    ).rejects.toThrow('exactly one of amountSats or amountMsat');
+  });
+
+  it('rejects when neither amountSats nor amountMsat is given', async () => {
+    const request: SendZapRequest = {
+      target: { type: 'profile', recipientPubkey: 'recipient-pubkey' },
+      receiptRelays: ['wss://relay.example.com'],
+    };
+
+    await expect(
+      handleNip57SendZap({ request, origin: 'https://example.com', approved: true }),
+    ).rejects.toThrow('exactly one of amountSats or amountMsat');
+  });
+
+  it('rejects when there is no active NIP-47 wallet connection', async () => {
+    vi.mocked(listNip47Connections).mockReturnValue([]);
+
+    await expect(
+      handleNip57SendZap({ request: baseRequest(), origin: 'https://example.com', approved: true }),
+    ).rejects.toThrow('No active NIP-47 wallet connection');
+  });
+
+  it('rejects when the connection does not advertise pay_invoice support', async () => {
+    vi.mocked(listNip47Connections).mockReturnValue([buildConnection({ isActive: true, capabilities: ['get_balance'] })]);
+
+    await expect(
+      handleNip57SendZap({ request: baseRequest(), origin: 'https://example.com', approved: true }),
+    ).rejects.toThrow('does not advertise pay_invoice support');
+  });
+
+  it('rejects when no receipt relays can be determined', async () => {
+    vi.mocked(listNip47Connections).mockReturnValue([buildConnection()]);
+    const request = baseRequest({ receiptRelays: [] });
+
+    await expect(
+      handleNip57SendZap({ request, origin: 'https://example.com', approved: true }),
+    ).rejects.toThrow('At least one receipt relay is required');
+  });
+
+  it('pays a zap end-to-end and records a paid history entry', async () => {
+    vi.mocked(listNip47Connections).mockReturnValue([buildConnection()]);
+    vi.mocked(fetchLnurlPayTarget).mockResolvedValue({ lnurl: 'lnurl1...', callback: 'https://wallet.example.com/cb' } as never);
+    vi.mocked(signZapRequest).mockReturnValue({ id: 'zap-request-id' } as never);
+    vi.mocked(requestZapInvoice).mockResolvedValue({ invoice: 'lnbc210n1p...' } as never);
+    vi.mocked(parseBolt11AmountMsat).mockReturnValue(21000);
+    vi.mocked(nip47Client.payInvoice).mockResolvedValue({ preimage: 'preimage', paymentHash: 'hash', feesPaidMsat: 1, raw: {} });
+
+    const result = await handleNip57SendZap({ request: baseRequest(), origin: 'https://example.com', approved: true });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toMatchObject({ status: 'paid', amountMsat: 21000, zapRequestId: 'zap-request-id', invoice: 'lnbc210n1p...' });
+    }
+    expect(appendNip57ZapHistory).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ status: 'paid', connectionId: 'wallet-a', senderPubkey: 'sender-pubkey' }),
+    );
+    expect(updateVaultData).toHaveBeenCalledTimes(1);
+  });
+
+  it('records a failed history entry and returns a classified error when payment fails', async () => {
+    vi.mocked(listNip47Connections).mockReturnValue([buildConnection()]);
+    vi.mocked(fetchLnurlPayTarget).mockResolvedValue({ lnurl: 'lnurl1...', callback: 'https://wallet.example.com/cb' } as never);
+    vi.mocked(signZapRequest).mockReturnValue({ id: 'zap-request-id' } as never);
+    vi.mocked(requestZapInvoice).mockResolvedValue({ invoice: 'lnbc210n1p...' } as never);
+    vi.mocked(parseBolt11AmountMsat).mockReturnValue(21000);
+    vi.mocked(nip47Client.payInvoice).mockRejectedValue(new Error('remote does not support pay_invoice'));
+
+    const result = await handleNip57SendZap({ request: baseRequest(), origin: 'https://example.com', approved: true });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.status).toBe('failed');
+      expect(result.data.error).toBe('remote does not support pay_invoice');
+      expect(result.data.code).toBe('WALLET_UNSUPPORTED');
+    }
+    expect(appendNip57ZapHistory).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ status: 'failed', error: 'remote does not support pay_invoice' }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Part of #126 (bounded-context migration, PR 3 of 4: signing / NIP protocol handlers). Based on `issue-125-value-objects` (#129), independent of PR 1 (#130) and PR 2 (#131). **Please rebase onto `master` once #129 merges.**

Checked this bounded context (`nip04`, `nip05-service`, `nip44`, `nip47*`, `nip57*`, `webln`, `permission-handler`, `quick-sign-service`) for direct `chrome.*`/`browser.*` usage: none found. No port extraction needed, consistent with PR 1 and PR 2's findings.

Delivered as test coverage for the two real gaps per #124's baseline:

| File | Baseline coverage | 
|---|---|
| `src-bex/handlers/nip57.ts` | 0% (all three handlers) |
| `src-bex/handlers/nip47.ts` | 41.97% (only `handleNip47PayInvoice` was tested; 7 other handlers weren't) |

`nip57.ts` covers the zap-payment flow's validation branches (unapproved, ambiguous/missing amount, no wallet connection, unsupported capability, no receipt relays) plus both the paid and failed history-recording paths -- this is money-moving code, so locking down its behavior with tests felt worth prioritizing.

**Purely additive: no production code changed.** 24 new tests; full suite: 473 passed.

Remaining PR for #126: profile/misc -- separate follow-up `build-now` run.

## Test plan
- [x] `npm run lint` -- passes
- [x] `npm run typecheck` -- passes
- [x] `npm run test:run` -- 473 tests pass (24 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)