### PR TITLE
test(profile): cover profile-service.ts and compressor.ts (PR 4/4 of #126)

### DIFF
--- a/tests/unit/services/compressor.test.ts
+++ b/tests/unit/services/compressor.test.ts
@@ -1,0 +1,119 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { nip19, generateSecretKey, getPublicKey } from 'nostr-tools';
+import { bytesToHex } from '@noble/hashes/utils';
+import { Blob as NodeBlob } from 'node:buffer';
+import { BlobReader, TextWriter, ZipReader } from '@zip.js/zip.js';
+import type { StoredKey } from 'src/types';
+import { createEncryptedZipBytes, formatKeyBackupText } from 'src/services/compressor';
+import generateKeyExportText from 'src/services/compressor';
+
+// jsdom's Blob polyfill in this test environment doesn't implement
+// arrayBuffer(), which @zip.js/zip.js relies on internally. Swap in Node's
+// spec-compliant Blob for this file only so the zip round-trip is exercised
+// against real behavior instead of a weaker signature-only check.
+const jsdomBlob = globalThis.Blob;
+beforeAll(() => {
+  globalThis.Blob = NodeBlob as unknown as typeof Blob;
+});
+afterAll(() => {
+  globalThis.Blob = jsdomBlob;
+});
+
+function buildKey(overrides: Partial<StoredKey> = {}): StoredKey {
+  const sk = generateSecretKey();
+  const pubkeyHex = getPublicKey(sk);
+  return {
+    id: pubkeyHex,
+    alias: 'alpha',
+    account: { privkey: bytesToHex(sk) },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('generateKeyExportText (default export)', () => {
+  it('throws when given no key', () => {
+    expect(() => generateKeyExportText(undefined as unknown as StoredKey)).toThrow(
+      'Stored key cannot be null or undefined',
+    );
+  });
+
+  it('encodes a valid key to npub/nsec and includes it in the backup text', () => {
+    const key = buildKey();
+
+    const text = generateKeyExportText(key);
+
+    expect(text).toContain(`Alias: ${key.alias}`);
+    expect(text).toContain(nip19.npubEncode(key.id));
+    expect(text).toContain('nsec (Private Key): nsec1');
+    expect(text).not.toContain('Error');
+  });
+
+  it('reports an npub encoding error when the id is not valid hex', () => {
+    const key = buildKey({ id: 'not-hex' });
+
+    const text = generateKeyExportText(key);
+
+    expect(text).toContain('npub (Public Key):  Error (Invalid ID)');
+  });
+
+  it('reports an nsec encoding error when the privkey is not valid hex', () => {
+    const key = buildKey({ account: { privkey: 'not-hex' } });
+
+    const text = generateKeyExportText(key);
+
+    expect(text).toContain('nsec (Private Key): Error (Invalid Private Key)');
+  });
+});
+
+describe('formatKeyBackupText', () => {
+  it('includes every field in the formatted backup', () => {
+    const text = formatKeyBackupText('alpha', '2026-01-01T00:00:00.000Z', 'npub1abc', 'nsec1xyz');
+
+    expect(text).toContain('Alias: alpha');
+    expect(text).toContain('Created At: 2026-01-01T00:00:00.000Z');
+    expect(text).toContain('npub (Public Key):  npub1abc');
+    expect(text).toContain('nsec (Private Key): nsec1xyz');
+    expect(text).toContain('DIOGEL KEY BACKUP');
+  });
+});
+
+describe('createEncryptedZipBytes', () => {
+  it('produces a password-protected zip containing the key backup text', async () => {
+    const key = buildKey();
+
+    const bytes = await createEncryptedZipBytes('correct horse battery staple', 'export.zip', key);
+    expect(bytes.byteLength).toBeGreaterThan(0);
+
+    const reader = new ZipReader(new BlobReader(new Blob([bytes])), {
+      password: 'correct horse battery staple',
+    });
+    const entries = await reader.getEntries();
+    expect(entries).toHaveLength(1);
+    const entry = entries[0];
+    expect(entry?.filename).toBe(`${key.alias}.txt`);
+    if (!entry || entry.directory) {
+      throw new Error('expected a file entry');
+    }
+
+    const content = await entry.getData(new TextWriter());
+    expect(content).toContain(nip19.npubEncode(key.id));
+    expect(content).toContain(`Alias: ${key.alias}`);
+    await reader.close();
+  });
+
+  it('rejects a wrong password when reading the archive back', async () => {
+    const key = buildKey();
+    const bytes = await createEncryptedZipBytes('correct-password', 'export.zip', key);
+
+    const reader = new ZipReader(new BlobReader(new Blob([bytes])), { password: 'wrong-password' });
+    const entries = await reader.getEntries();
+    const entry = entries[0];
+    if (!entry || entry.directory) {
+      throw new Error('expected a file entry');
+    }
+
+    await expect(entry.getData(new TextWriter())).rejects.toThrow();
+    await reader.close();
+  });
+});

--- a/tests/unit/services/profile-service.test.ts
+++ b/tests/unit/services/profile-service.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getPublicKey } from 'nostr-tools';
+import { hexToBytes } from '@noble/hashes/utils';
+
+const { poolGetMock, poolPublishMock, fallbackRelays } = vi.hoisted(() => ({
+  poolGetMock: vi.fn(),
+  poolPublishMock: vi.fn(),
+  fallbackRelays: ['wss://relay.damus.io'] as string[],
+}));
+
+vi.mock('src/stores/settings-store', () => ({
+  default: () => ({
+    getFallbackRelays: vi.fn(async () => fallbackRelays),
+  }),
+}));
+
+vi.mock('nostr-tools', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('nostr-tools')>();
+  return {
+    ...actual,
+    SimplePool: class {
+      get = poolGetMock;
+      publish = poolPublishMock;
+    },
+  };
+});
+
+describe('profileService.fetchProfile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null without querying relays when the pubkey is empty', async () => {
+    const { profileService } = await import('src/services/profile-service');
+
+    await expect(profileService.fetchProfile('')).resolves.toBeNull();
+    expect(poolGetMock).not.toHaveBeenCalled();
+  });
+
+  it('parses and returns the profile from a kind-0 metadata event', async () => {
+    poolGetMock.mockResolvedValue({ content: JSON.stringify({ name: 'Alice' }) });
+
+    const { profileService } = await import('src/services/profile-service');
+    const result = await profileService.fetchProfile('pubkey-a');
+
+    expect(poolGetMock).toHaveBeenCalledWith(fallbackRelays, { authors: ['pubkey-a'], kinds: [0] });
+    expect(result).toEqual({ name: 'Alice' });
+  });
+
+  it('returns null when no metadata event is found', async () => {
+    poolGetMock.mockResolvedValue(null);
+
+    const { profileService } = await import('src/services/profile-service');
+    await expect(profileService.fetchProfile('pubkey-a')).resolves.toBeNull();
+  });
+
+  it('returns null when the relay query rejects', async () => {
+    poolGetMock.mockRejectedValue(new Error('relay unreachable'));
+
+    const { profileService } = await import('src/services/profile-service');
+    await expect(profileService.fetchProfile('pubkey-a')).resolves.toBeNull();
+  });
+});
+
+describe('profileService.saveProfile', () => {
+  const privkey = 'aa'.repeat(32);
+  const pubkey = getPublicKey(hexToBytes(privkey));
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('merges the new profile fields over the latest fetched profile and publishes it', async () => {
+    poolGetMock.mockResolvedValue({ content: JSON.stringify({ name: 'Old Name', picture: 'old.png' }) });
+    poolPublishMock.mockReturnValue([Promise.resolve('relay-ack')]);
+
+    const { profileService } = await import('src/services/profile-service');
+    await profileService.saveProfile(privkey, { name: 'New Name' });
+
+    expect(poolGetMock).toHaveBeenCalledWith(fallbackRelays, { authors: [pubkey], kinds: [0] });
+    expect(poolPublishMock).toHaveBeenCalledTimes(1);
+
+    const [relays, signedEvent] = poolPublishMock.mock.calls[0] as [string[], { content: string; pubkey: string; kind: number }];
+    expect(relays).toEqual(fallbackRelays);
+    expect(signedEvent.pubkey).toBe(pubkey);
+    expect(signedEvent.kind).toBe(0);
+    const publishedContent = JSON.parse(signedEvent.content) as { name: string; picture: string };
+    expect(publishedContent).toEqual({ name: 'New Name', picture: 'old.png' });
+  });
+
+  it('rejects when every relay publish fails', async () => {
+    poolGetMock.mockResolvedValue(null);
+    poolPublishMock.mockReturnValue([Promise.reject(new Error('relay rejected'))]);
+
+    const { profileService } = await import('src/services/profile-service');
+    await expect(profileService.saveProfile(privkey, { name: 'New Name' })).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Part of #126 (bounded-context migration, PR 4 of 4: profile / contacts / misc) -- the final PR for this issue. Based on `issue-125-value-objects` (#129), independent of PR 1/2/3. **Please rebase onto `master` once #129 merges.**

Checked this bounded context (`profile-service`, `contact-list-service`, `dashboard-service`, `blossom-upload-service`, `compressor`, `log-service`) for direct `chrome.*`/`browser.*` usage: none found. No port extraction needed, consistent with PR 1/2/3.

Delivered as test coverage for the two files with no dedicated test file per #124's baseline:

| File | Baseline coverage | 
|---|---|
| `src/services/profile-service.ts` | 9.52% |
| `src/services/compressor.ts` | 65.21% (only exercised transitively, no direct test) |

`profile-service.ts` mocks `nostr-tools`' `SimplePool` and the settings-store's fallback relays using the same pattern already established in `tests/unit/services/dashboard-service.test.ts`.

`compressor.ts`'s zip round-trip test uncovered a pre-existing gap in the project's jsdom test environment: its `Blob` polyfill doesn't implement `arrayBuffer()`, which `@zip.js/zip.js` needs internally, so `createEncryptedZipBytes` could never actually be exercised in a test before now. Rather than settle for a weaker signature-only check, the test file swaps in Node's spec-compliant `Blob` for its own scope only (`beforeAll`/`afterAll`, restored after), so the real encrypt/decrypt behavior -- including a wrong-password rejection -- is genuinely verified.

**Purely additive: no production code changed.** 13 new tests; full suite: 462 passed.

This is the last PR for #126 -- once all four (#130, #131, #132, this one) are merged, #126 is complete and #123's Phase 2 is done.

## Test plan
- [x] `npm run lint` -- passes
- [x] `npm run typecheck` -- passes
- [x] `npm run test:run` -- 462 tests pass (13 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)