### PR TITLE
test: backfill coverage for composables and stores

### DIFF
--- a/tests/unit/composables/useEventService.test.ts
+++ b/tests/unit/composables/useEventService.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Event } from 'nostr-tools';
+
+const { subscribeManyMock, closeMock } = vi.hoisted(() => ({
+  subscribeManyMock: vi.fn(),
+  closeMock: vi.fn(),
+}));
+
+vi.mock('nostr-tools', () => ({
+  SimplePool: class {
+    subscribeMany = subscribeManyMock;
+    close = closeMock;
+  },
+}));
+
+function buildEvent(id: string): Event {
+  return { id, kind: 0, pubkey: 'pk', created_at: 0, tags: [], content: '', sig: 'sig' };
+}
+
+describe('useEventService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  it('resolves with the deduplicated events collected before EOSE', async () => {
+    const subClose = vi.fn();
+    let handlers!: { onevent: (event: Event) => void; oneose: () => void };
+    subscribeManyMock.mockImplementation((_relays, _filter, h) => {
+      handlers = h;
+      return { close: subClose };
+    });
+
+    const { useEventService } = await import('src/composables/useEventService');
+    const service = useEventService(['wss://relay.damus.io']);
+
+    const resultPromise = service.getEvents({ kinds: [0] });
+    handlers.onevent(buildEvent('a'));
+    handlers.onevent(buildEvent('a')); // duplicate id, should not double up
+    handlers.onevent(buildEvent('b'));
+    handlers.oneose();
+
+    const result = await resultPromise;
+    expect(result.map((e) => e.id).sort()).toEqual(['a', 'b']);
+    expect(subClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves with whatever was collected so far when the timeout elapses first', async () => {
+    const subClose = vi.fn();
+    let handlers!: { onevent: (event: Event) => void; oneose: () => void };
+    subscribeManyMock.mockImplementation((_relays, _filter, h) => {
+      handlers = h;
+      return { close: subClose };
+    });
+
+    const { useEventService } = await import('src/composables/useEventService');
+    const service = useEventService(['wss://relay.damus.io']);
+
+    const resultPromise = service.getEvents({ kinds: [0] }, 1000);
+    handlers.onevent(buildEvent('a'));
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const result = await resultPromise;
+    expect(result.map((e) => e.id)).toEqual(['a']);
+    expect(subClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not resolve twice when both EOSE and the timeout fire', async () => {
+    const subClose = vi.fn();
+    let handlers!: { onevent: (event: Event) => void; oneose: () => void };
+    subscribeManyMock.mockImplementation((_relays, _filter, h) => {
+      handlers = h;
+      return { close: subClose };
+    });
+
+    const { useEventService } = await import('src/composables/useEventService');
+    const service = useEventService(['wss://relay.damus.io']);
+
+    const resultPromise = service.getEvents({ kinds: [0] }, 1000);
+    handlers.oneose();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    await resultPromise;
+    expect(subClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the pool for the configured relay URLs', async () => {
+    const { useEventService } = await import('src/composables/useEventService');
+    const service = useEventService(['wss://relay.damus.io', 'wss://relay.snort.social']);
+
+    service.close();
+
+    expect(closeMock).toHaveBeenCalledWith(['wss://relay.damus.io', 'wss://relay.snort.social']);
+  });
+});

--- a/tests/unit/composables/useNavigation.test.ts
+++ b/tests/unit/composables/useNavigation.test.ts
@@ -1,0 +1,92 @@
+import { mount } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useNavigation } from 'src/composables/useNavigation';
+import type { NavigationItem, UtilityLinkItem } from 'src/types/navigation';
+
+const testState = vi.hoisted(() => ({
+  route: { name: 'dashboard' as string },
+}));
+
+vi.mock('vue-router', () => ({
+  useRoute: () => testState.route,
+}));
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+interface HarnessVm {
+  navigationItems: NavigationItem[];
+  utilityLinks: UtilityLinkItem[];
+}
+
+const TestHarness = defineComponent({
+  name: 'UseNavigationHarness',
+  setup() {
+    const { navigationItems, utilityLinks } = useNavigation();
+    return { navigationItems, utilityLinks };
+  },
+  template: '<div />',
+});
+
+describe('useNavigation', () => {
+  beforeEach(() => {
+    testState.route.name = 'dashboard';
+  });
+
+  it('includes an entry for every primary nav destination', () => {
+    const wrapper = mount(TestHarness);
+    const vm = wrapper.vm as unknown as HarnessVm;
+
+    expect(vm.navigationItems.map((item) => item.id)).toEqual([
+      'dashboard',
+      'keys',
+      'profile',
+      'relays',
+      'contacts',
+      'wallet-connections',
+      'event-history',
+      'settings',
+    ]);
+  });
+
+  it('marks only the current route as active', () => {
+    testState.route.name = 'profile';
+    const wrapper = mount(TestHarness);
+    const vm = wrapper.vm as unknown as HarnessVm;
+
+    const active = vm.navigationItems.filter((item) => item.isActive());
+    expect(active.map((item) => item.id)).toEqual(['profile']);
+  });
+
+  it('treats every key-management sub-route as the keys item being active', () => {
+    for (const routeName of ['keys', 'view-key', 'import-key', 'add-new-key', 'edit-account']) {
+      testState.route.name = routeName;
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+      const keysItem = vm.navigationItems.find((item) => item.id === 'keys');
+      expect(keysItem?.isActive(), `expected keys active for route "${routeName}"`).toBe(true);
+    }
+  });
+
+  it('treats both event-history and the legacy logs route as the event-history item being active', () => {
+    for (const routeName of ['event-history', 'logs']) {
+      testState.route.name = routeName;
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+      const item = vm.navigationItems.find((i) => i.id === 'event-history');
+      expect(item?.isActive()).toBe(true);
+    }
+  });
+
+  it('provides two utility links pointing at support and documentation', () => {
+    const wrapper = mount(TestHarness);
+    const vm = wrapper.vm as unknown as HarnessVm;
+
+    expect(vm.utilityLinks.map((link) => link.id)).toEqual(['support', 'documentation']);
+    expect(vm.utilityLinks.find((l) => l.id === 'support')?.href).toBe(
+      'https://github.com/threenine/diogel/issues',
+    );
+  });
+});

--- a/tests/unit/composables/useVault.test.ts
+++ b/tests/unit/composables/useVault.test.ts
@@ -1,0 +1,190 @@
+import { mount } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useVault } from 'src/composables/useVault';
+
+const testState = vi.hoisted(() => ({
+  notifyMock: vi.fn(),
+  pushMock: vi.fn(async () => undefined),
+  route: {
+    name: 'login' as string,
+    query: {} as Record<string, string>,
+  },
+  vaultStore: {
+    create: vi.fn(),
+    unlock: vi.fn(),
+    lock: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock('quasar', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('quasar')>();
+  return {
+    ...actual,
+    useQuasar: () => ({ notify: testState.notifyMock }),
+  };
+});
+
+vi.mock('vue-router', () => ({
+  useRoute: () => testState.route,
+  useRouter: () => ({ push: testState.pushMock }),
+}));
+
+vi.mock('src/stores/vault-store', () => ({
+  default: () => testState.vaultStore,
+}));
+
+interface HarnessVm {
+  password: string;
+  confirmPassword: string;
+  mnemonic: string;
+  passphrase: string;
+  loading: boolean;
+  loginError: string;
+  handleCreate: () => Promise<void>;
+  handleUnlock: () => Promise<void>;
+  handleLock: () => Promise<void>;
+  getPostLoginRouteName: () => string;
+}
+
+const TestHarness = defineComponent({
+  name: 'UseVaultHarness',
+  setup() {
+    return useVault();
+  },
+  template: '<div />',
+});
+
+describe('useVault', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    testState.route.name = 'login';
+    testState.route.query = {};
+  });
+
+  describe('handleCreate', () => {
+    it('does nothing when the password is too short', async () => {
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+      vm.password = 'short';
+      vm.confirmPassword = 'short';
+
+      await vm.handleCreate();
+
+      expect(testState.vaultStore.create).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the passwords do not match', async () => {
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+      vm.password = 'longenough1';
+      vm.confirmPassword = 'longenough2';
+
+      await vm.handleCreate();
+
+      expect(testState.vaultStore.create).not.toHaveBeenCalled();
+    });
+
+    it('creates the vault and navigates to dashboard by default on success', async () => {
+      testState.vaultStore.create.mockResolvedValue({ success: true });
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+      vm.password = 'longenough1';
+      vm.confirmPassword = 'longenough1';
+
+      await vm.handleCreate();
+
+      expect(testState.notifyMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'positive' }));
+      expect(testState.pushMock).toHaveBeenCalledWith({ name: 'dashboard' });
+      expect(vm.loading).toBe(false);
+    });
+
+    it('navigates to home when created from the extension login context', async () => {
+      testState.route.query = { loginContext: 'extension' };
+      testState.vaultStore.create.mockResolvedValue({ success: true });
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+      vm.password = 'longenough1';
+      vm.confirmPassword = 'longenough1';
+
+      await vm.handleCreate();
+
+      expect(testState.pushMock).toHaveBeenCalledWith({ name: 'home' });
+    });
+
+    it('surfaces a formatted error and notifies on failure', async () => {
+      testState.vaultStore.create.mockResolvedValue({ success: false, error: 'boom', errorCode: 'GEN_UNKNOWN' });
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+      vm.password = 'longenough1';
+      vm.confirmPassword = 'longenough1';
+
+      await vm.handleCreate();
+
+      expect(vm.loginError).not.toBe('');
+      expect(testState.notifyMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'negative' }));
+      expect(testState.pushMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleUnlock', () => {
+    it('redirects to the requested path on success when one is given', async () => {
+      testState.route.query = { redirect: '/settings' };
+      testState.vaultStore.unlock.mockResolvedValue({ success: true });
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+      vm.password = 'correct-password';
+
+      await vm.handleUnlock();
+
+      expect(testState.pushMock).toHaveBeenCalledWith({ path: '/settings', query: testState.route.query });
+    });
+
+    it('falls back to the post-login route when no redirect is given', async () => {
+      testState.vaultStore.unlock.mockResolvedValue({ success: true });
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+      vm.password = 'correct-password';
+
+      await vm.handleUnlock();
+
+      expect(testState.pushMock).toHaveBeenCalledWith({ name: 'dashboard' });
+    });
+
+    it('surfaces a formatted error and notifies on failure', async () => {
+      testState.vaultStore.unlock.mockResolvedValue({ success: false, error: 'Invalid password', errorCode: 'VLT_INVALID_PASSWORD' });
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+      vm.password = 'wrong-password';
+
+      await vm.handleUnlock();
+
+      expect(vm.loginError).not.toBe('');
+      expect(testState.notifyMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'negative' }));
+      expect(testState.pushMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleLock', () => {
+    it('locks the vault and navigates to login with the dashboard context', async () => {
+      testState.route.name = 'settings';
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+
+      await vm.handleLock();
+
+      expect(testState.vaultStore.lock).toHaveBeenCalledTimes(1);
+      expect(testState.pushMock).toHaveBeenCalledWith({ name: 'login', query: { loginContext: 'dashboard' } });
+    });
+
+    it('uses the extension login context outside dashboard routes', async () => {
+      testState.route.name = 'popup';
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+
+      await vm.handleLock();
+
+      expect(testState.pushMock).toHaveBeenCalledWith({ name: 'login', query: { loginContext: 'extension' } });
+    });
+  });
+});

--- a/tests/unit/composables/useVaultAutoLock.test.ts
+++ b/tests/unit/composables/useVaultAutoLock.test.ts
@@ -1,0 +1,117 @@
+import { mount } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useVaultAutoLock } from 'src/composables/useVaultAutoLock';
+
+const testState = vi.hoisted(() => ({
+  vaultStore: { isUnlocked: true },
+}));
+
+vi.mock('src/stores/vault-store', () => ({
+  default: () => testState.vaultStore,
+}));
+
+interface HarnessVm {
+  markActivity: () => void;
+}
+
+const TestHarness = defineComponent({
+  name: 'UseVaultAutoLockHarness',
+  setup() {
+    return useVaultAutoLock();
+  },
+  template: '<div />',
+});
+
+type BridgeWindow = Window & {
+  bridge?: { send: (request: unknown) => void } | undefined;
+  $q?: { bex?: { send: (request: unknown) => void } } | undefined;
+};
+
+function setBridge(send: ((request: unknown) => void) | undefined) {
+  (window as BridgeWindow).bridge = send ? { send } : undefined;
+}
+
+describe('useVaultAutoLock', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    testState.vaultStore.isUnlocked = true;
+    setBridge(undefined);
+    (window as BridgeWindow).$q = undefined;
+  });
+
+  afterEach(() => {
+    setBridge(undefined);
+    (window as BridgeWindow).$q = undefined;
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('sends an initial activity mark on mount via the Quasar bridge', () => {
+    const send = vi.fn();
+    setBridge(send);
+
+    mount(TestHarness);
+
+    expect(send).toHaveBeenCalledWith({ event: 'activity.mark', to: 'background' });
+  });
+
+  it('falls back to chrome.runtime.sendMessage when no bridge is present', () => {
+    const sendMessage = vi.fn();
+    vi.stubGlobal('chrome', { runtime: { sendMessage } });
+
+    mount(TestHarness);
+
+    expect(sendMessage).toHaveBeenCalledWith({ type: 'activity.mark' });
+  });
+
+  it('does not mark activity while the vault is locked', () => {
+    testState.vaultStore.isUnlocked = false;
+    const send = vi.fn();
+    setBridge(send);
+
+    mount(TestHarness);
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('throttles repeated activity events within the throttle window', () => {
+    const send = vi.fn();
+    setBridge(send);
+
+    const wrapper = mount(TestHarness);
+    const vm = wrapper.vm as unknown as HarnessVm;
+    send.mockClear(); // clear the initial on-mount mark
+
+    vm.markActivity();
+    vm.markActivity();
+    vm.markActivity();
+
+    expect(send).not.toHaveBeenCalled(); // still within 10s of the mount-time mark
+  });
+
+  it('sends another mark once the throttle window has elapsed', () => {
+    const send = vi.fn();
+    setBridge(send);
+
+    const wrapper = mount(TestHarness);
+    const vm = wrapper.vm as unknown as HarnessVm;
+    send.mockClear();
+
+    vi.advanceTimersByTime(10_001);
+    vm.markActivity();
+
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes its activity listeners on unmount', () => {
+    setBridge(vi.fn());
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+    const wrapper = mount(TestHarness);
+    wrapper.unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith('mousemove', expect.any(Function));
+    expect(removeSpy).toHaveBeenCalledWith('click', expect.any(Function));
+  });
+});

--- a/tests/unit/composables/useVaultManagement.test.ts
+++ b/tests/unit/composables/useVaultManagement.test.ts
@@ -1,0 +1,221 @@
+import { mount } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useVaultManagement } from 'src/composables/useVaultManagement';
+
+const testState = vi.hoisted(() => ({
+  notifyMock: vi.fn(),
+  pushMock: vi.fn(async () => undefined),
+  exportFileMock: vi.fn(
+    (_fileName: string, _rawData: string, _opts?: string): true | Error => true,
+  ),
+  dialogOnOk: undefined as (() => void) | undefined,
+  exportVaultMock: vi.fn(),
+  importVaultMock: vi.fn(),
+}));
+
+vi.mock('quasar', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('quasar')>();
+  return {
+    ...actual,
+    useQuasar: () => ({
+      notify: testState.notifyMock,
+      dialog: () => ({
+        onOk: (cb: () => void) => {
+          testState.dialogOnOk = cb;
+        },
+      }),
+    }),
+    exportFile: testState.exportFileMock,
+  };
+});
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: testState.pushMock }),
+}));
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('src/services/vault-service', () => ({
+  exportVault: testState.exportVaultMock,
+  importVault: testState.importVaultMock,
+}));
+
+interface HarnessVm {
+  fileInput: HTMLInputElement | null;
+  handleExportVault: () => Promise<void>;
+  triggerImport: () => void;
+  handleFileImport: (event: Event) => void;
+}
+
+const TestHarness = defineComponent({
+  name: 'UseVaultManagementHarness',
+  setup() {
+    return useVaultManagement();
+  },
+  template: '<input ref="fileInput" type="file" />',
+});
+
+describe('useVaultManagement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    testState.dialogOnOk = undefined;
+    testState.exportFileMock.mockReturnValue(true);
+  });
+
+  describe('handleExportVault', () => {
+    it('exports a versioned backup file on success', async () => {
+      testState.exportVaultMock.mockResolvedValue({ success: true, encryptedData: 'v2:abc' });
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+
+      await vm.handleExportVault();
+
+      expect(testState.exportFileMock).toHaveBeenCalledTimes(1);
+      const [filename, contentJson, mime] = testState.exportFileMock.mock.calls[0]!;
+      expect(filename).toMatch(/^diogel-vault-backup-\d{4}-\d{2}-\d{2}\.json$/);
+      expect(mime).toBe('application/json');
+      const content = JSON.parse(contentJson) as { version: number; encryptedData: string };
+      expect(content).toMatchObject({ version: 1, encryptedData: 'v2:abc' });
+      expect(testState.notifyMock).not.toHaveBeenCalled();
+    });
+
+    it('notifies when the browser denies the file save', async () => {
+      testState.exportVaultMock.mockResolvedValue({ success: true, encryptedData: 'v2:abc' });
+      testState.exportFileMock.mockReturnValue(new Error('User denied the save dialog'));
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+
+      await vm.handleExportVault();
+
+      expect(testState.notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'negative', message: 'settings.exportDeny' }),
+      );
+    });
+
+    it('notifies with a formatted error when exportVault fails', async () => {
+      testState.exportVaultMock.mockResolvedValue({ success: false, error: 'No vault found', code: 'VLT_NOT_CREATED' });
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+
+      await vm.handleExportVault();
+
+      expect(testState.exportFileMock).not.toHaveBeenCalled();
+      expect(testState.notifyMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'negative' }));
+    });
+  });
+
+  describe('triggerImport', () => {
+    it('clicks the hidden file input', () => {
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+      const clickSpy = vi.spyOn(wrapper.find('input').element, 'click');
+
+      vm.triggerImport();
+
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('handleFileImport', () => {
+    function fileImportEvent(file: File | undefined): Event {
+      return { target: { files: file ? [file] : [] } } as unknown as Event;
+    }
+
+    it('does nothing when no file was selected', () => {
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+
+      vm.handleFileImport(fileImportEvent(undefined));
+
+      expect(testState.dialogOnOk).toBeUndefined();
+    });
+
+    it('imports the vault and redirects to login on success after confirmation', async () => {
+      testState.importVaultMock.mockResolvedValue({ success: true });
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+      const file = new File([JSON.stringify({ encryptedData: 'v2:abc' })], 'backup.json', {
+        type: 'application/json',
+      });
+
+      vm.handleFileImport(fileImportEvent(file));
+      expect(testState.dialogOnOk).toBeDefined();
+      testState.dialogOnOk!();
+
+      await vi.waitFor(() => expect(testState.notifyMock).toHaveBeenCalled());
+
+      expect(testState.importVaultMock).toHaveBeenCalledWith('v2:abc');
+      expect(testState.pushMock).toHaveBeenCalledWith({ name: 'login' });
+      expect(testState.notifyMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'positive' }));
+    });
+
+    it('notifies with a formatted error and does not redirect when importVault resolves unsuccessfully', async () => {
+      testState.importVaultMock.mockResolvedValue({ success: false, error: 'Invalid vault format', code: 'GEN_INVALID_INPUT' });
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+      const file = new File([JSON.stringify({ encryptedData: 'v2:corrupt' })], 'backup.json', {
+        type: 'application/json',
+      });
+
+      vm.handleFileImport(fileImportEvent(file));
+      testState.dialogOnOk!();
+      await vi.waitFor(() => expect(testState.notifyMock).toHaveBeenCalled());
+
+      expect(testState.pushMock).not.toHaveBeenCalled();
+      expect(testState.notifyMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'negative' }));
+    });
+
+    it('notifies with the rejection message when importVault itself rejects', async () => {
+      testState.importVaultMock.mockRejectedValue(new Error('network unreachable'));
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+      const file = new File([JSON.stringify({ encryptedData: 'v2:abc' })], 'backup.json', {
+        type: 'application/json',
+      });
+
+      vm.handleFileImport(fileImportEvent(file));
+      testState.dialogOnOk!();
+      await vi.waitFor(() => expect(testState.notifyMock).toHaveBeenCalled());
+
+      expect(testState.notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'negative', message: 'network unreachable' }),
+      );
+    });
+
+    it('notifies without redirecting when the backup file has no encryptedData', async () => {
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+      const file = new File([JSON.stringify({ notAValidBackup: true })], 'backup.json', {
+        type: 'application/json',
+      });
+
+      vm.handleFileImport(fileImportEvent(file));
+      testState.dialogOnOk!();
+      await vi.waitFor(() => expect(testState.notifyMock).toHaveBeenCalled());
+
+      expect(testState.importVaultMock).not.toHaveBeenCalled();
+      expect(testState.notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'negative', message: 'settings.importInvalid' }),
+      );
+    });
+
+    it('notifies with a parse error when the file is not valid JSON', async () => {
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+      const file = new File(['not json'], 'backup.json', { type: 'application/json' });
+
+      vm.handleFileImport(fileImportEvent(file));
+      testState.dialogOnOk!();
+      await vi.waitFor(() => expect(testState.notifyMock).toHaveBeenCalled());
+
+      expect(testState.notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'negative' }),
+      );
+      const message = testState.notifyMock.mock.calls[0]?.[0] as { message: string };
+      expect(message.message).toContain('settings.importParseError');
+    });
+  });
+});

--- a/tests/unit/stores/account-store.test.ts
+++ b/tests/unit/stores/account-store.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import useAccountStore from 'src/stores/account-store';
+import type { StoredKey } from 'src/types';
+
+const { mockSave, mockGet, mockGetActive, mockSetActive, mockRenameAlias, mockOnChanged } = vi.hoisted(() => ({
+  mockSave: vi.fn(),
+  mockGet: vi.fn(),
+  mockGetActive: vi.fn(),
+  mockSetActive: vi.fn(),
+  mockRenameAlias: vi.fn(),
+  mockOnChanged: vi.fn(),
+}));
+
+vi.mock('src/services/dexie-storage', () => ({
+  save: mockSave,
+  get: mockGet,
+  getActive: mockGetActive,
+  setActive: mockSetActive,
+  renameAlias: mockRenameAlias,
+}));
+
+vi.mock('src/services/storage-service', () => ({
+  NOSTR_ACTIVE: 'NOSTR_ACTIVE',
+  storageService: { onChanged: mockOnChanged },
+}));
+
+function buildKey(overrides: Partial<StoredKey> = {}): StoredKey {
+  return {
+    id: 'pubkey-hex',
+    alias: 'alpha',
+    account: { privkey: 'secret' },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('account-store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it('starts with no stored keys and no active alias', () => {
+    const store = useAccountStore();
+    expect(store.storedKeys.size).toBe(0);
+    expect(store.activeKey).toBeUndefined();
+  });
+
+  describe('saveKey', () => {
+    it('persists the key and adds it to the in-memory set', async () => {
+      mockSave.mockResolvedValue(undefined);
+      const store = useAccountStore();
+      const key = buildKey();
+
+      await store.saveKey(key);
+
+      expect(mockSave).toHaveBeenCalledWith(key);
+      expect(store.storedKeys.has(key)).toBe(true);
+    });
+
+    it('propagates a save failure without adding the key', async () => {
+      mockSave.mockRejectedValue(new Error('duplicate alias'));
+      const store = useAccountStore();
+      const key = buildKey();
+
+      await expect(store.saveKey(key)).rejects.toThrow('duplicate alias');
+      expect(store.storedKeys.size).toBe(0);
+    });
+  });
+
+  describe('getKeys', () => {
+    it('loads stored keys and the active alias from the vault', async () => {
+      const alpha = buildKey({ alias: 'alpha' });
+      const beta = buildKey({ id: 'pubkey-hex-2', alias: 'beta' });
+      mockGet.mockResolvedValue({ alpha, beta });
+      mockGetActive.mockResolvedValue('alpha');
+
+      const store = useAccountStore();
+      await store.getKeys();
+
+      expect(store.storedKeys).toEqual(new Set([alpha, beta]));
+      expect(store.activeKey).toBe('alpha');
+    });
+  });
+
+  describe('setActiveKey', () => {
+    it('updates the active alias locally and persists it', async () => {
+      mockSetActive.mockResolvedValue(undefined);
+      const store = useAccountStore();
+
+      await store.setActiveKey('beta');
+
+      expect(store.activeKey).toBe('beta');
+      expect(mockSetActive).toHaveBeenCalledWith('beta');
+    });
+  });
+
+  describe('renameKeyAlias', () => {
+    it('renames the alias, reloads keys, and updates the active alias if it was renamed', async () => {
+      mockRenameAlias.mockResolvedValue(undefined);
+      const renamed = buildKey({ alias: 'beta' });
+      mockGet.mockResolvedValue({ beta: renamed });
+      mockGetActive.mockResolvedValue('beta');
+
+      const store = useAccountStore();
+      store.activeKey = 'alpha';
+
+      await store.renameKeyAlias('alpha', 'beta');
+
+      expect(mockRenameAlias).toHaveBeenCalledWith('alpha', 'beta');
+      expect(store.storedKeys).toEqual(new Set([renamed]));
+      expect(store.activeKey).toBe('beta');
+    });
+
+    it('does not touch the active alias when a different key was renamed', async () => {
+      mockRenameAlias.mockResolvedValue(undefined);
+      mockGet.mockResolvedValue({});
+      mockGetActive.mockResolvedValue('gamma');
+
+      const store = useAccountStore();
+      store.activeKey = 'gamma';
+
+      await store.renameKeyAlias('alpha', 'beta');
+
+      expect(store.activeKey).toBe('gamma');
+    });
+  });
+
+  describe('listenToStorageChanges', () => {
+    it('registers a storage listener only once', () => {
+      const store = useAccountStore();
+
+      store.listenToStorageChanges();
+      store.listenToStorageChanges();
+
+      expect(mockOnChanged).toHaveBeenCalledTimes(1);
+    });
+
+    it('reloads keys when NOSTR_ACTIVE changes in local storage', () => {
+      mockGet.mockResolvedValue({});
+      mockGetActive.mockResolvedValue(undefined);
+      const store = useAccountStore();
+
+      store.listenToStorageChanges();
+      const listener = mockOnChanged.mock.calls[0]?.[0] as (
+        changes: Record<string, unknown>,
+        areaName: string,
+      ) => void;
+      listener({ NOSTR_ACTIVE: { newValue: 'alpha' } }, 'local');
+
+      expect(mockGet).toHaveBeenCalled();
+    });
+
+    it('ignores changes in other storage areas', () => {
+      const store = useAccountStore();
+
+      store.listenToStorageChanges();
+      const listener = mockOnChanged.mock.calls[0]?.[0] as (
+        changes: Record<string, unknown>,
+        areaName: string,
+      ) => void;
+      listener({ NOSTR_ACTIVE: { newValue: 'alpha' } }, 'session');
+
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/stores/vault-store.test.ts
+++ b/tests/unit/stores/vault-store.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import useVaultStore from 'src/stores/vault-store';
+
+const { mockCreateVault, mockHasVault, mockLockVault, mockUnlockVault, mockStorageGet, mockOnChanged } = vi.hoisted(
+  () => ({
+    mockCreateVault: vi.fn(),
+    mockHasVault: vi.fn(),
+    mockLockVault: vi.fn(),
+    mockUnlockVault: vi.fn(),
+    mockStorageGet: vi.fn(),
+    mockOnChanged: vi.fn(),
+  }),
+);
+
+vi.mock('src/services/vault-service', () => ({
+  createVault: mockCreateVault,
+  hasVault: mockHasVault,
+  lockVault: mockLockVault,
+  unlockVault: mockUnlockVault,
+}));
+
+vi.mock('src/services/storage-service', () => ({
+  VAULT_UNLOCKED: 'VAULT_UNLOCKED',
+  storageService: { get: mockStorageGet, onChanged: mockOnChanged },
+}));
+
+describe('vault-store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it('starts locked, with no vault, not loading', () => {
+    const store = useVaultStore();
+    expect(store.isUnlocked).toBe(false);
+    expect(store.vaultExists).toBe(false);
+    expect(store.isLoading).toBe(false);
+    expect(store.lastLockReason).toBeNull();
+  });
+
+  describe('checkVaultStatus', () => {
+    it('reflects vault existence and unlocked state from the background', async () => {
+      mockHasVault.mockResolvedValue(true);
+      mockStorageGet.mockResolvedValue(true);
+
+      const store = useVaultStore();
+      await store.checkVaultStatus();
+
+      expect(store.vaultExists).toBe(true);
+      expect(store.isUnlocked).toBe(true);
+      expect(mockStorageGet).toHaveBeenCalledWith('VAULT_UNLOCKED', 'session');
+    });
+
+    it('leaves state unchanged and logs when the check fails', async () => {
+      mockHasVault.mockRejectedValue(new Error('db unavailable'));
+      mockStorageGet.mockResolvedValue(false);
+
+      const store = useVaultStore();
+      await expect(store.checkVaultStatus()).resolves.toBeUndefined();
+
+      expect(store.vaultExists).toBe(false);
+      expect(store.isUnlocked).toBe(false);
+    });
+  });
+
+  describe('unlock', () => {
+    it('marks the vault unlocked and clears the lock reason on success', async () => {
+      mockUnlockVault.mockResolvedValue({ success: true, vaultData: { accounts: [] } });
+
+      const store = useVaultStore();
+      store.lastLockReason = 'inactivity';
+      const result = await store.unlock('correct-password');
+
+      expect(result).toEqual({ success: true });
+      expect(store.isUnlocked).toBe(true);
+      expect(store.lastLockReason).toBeNull();
+    });
+
+    it('returns the failure result without changing unlocked state', async () => {
+      mockUnlockVault.mockResolvedValue({ success: false, error: 'Invalid password', code: 'VLT_INVALID_PASSWORD' });
+
+      const store = useVaultStore();
+      const result = await store.unlock('wrong-password');
+
+      expect(result).toEqual({ success: false, error: 'Invalid password', errorCode: 'VLT_INVALID_PASSWORD' });
+      expect(store.isUnlocked).toBe(false);
+    });
+  });
+
+  describe('lock', () => {
+    it('locks the vault and records the reason (defaulting to manual)', async () => {
+      mockLockVault.mockResolvedValue(undefined);
+      const store = useVaultStore();
+      store.isUnlocked = true;
+
+      await store.lock();
+
+      expect(mockLockVault).toHaveBeenCalledTimes(1);
+      expect(store.isUnlocked).toBe(false);
+      expect(store.lastLockReason).toBe('manual');
+    });
+
+    it('records a non-default lock reason when given one', async () => {
+      mockLockVault.mockResolvedValue(undefined);
+      const store = useVaultStore();
+
+      await store.lock('inactivity');
+
+      expect(store.lastLockReason).toBe('inactivity');
+    });
+  });
+
+  describe('create', () => {
+    it('creates the vault with the given accounts and marks it unlocked', async () => {
+      mockCreateVault.mockResolvedValue({ success: true, encryptedVault: 'v2:abc' });
+      const store = useVaultStore();
+      const account = { id: 'pubkey', alias: 'alpha', account: { privkey: 'secret' }, createdAt: '2026-01-01T00:00:00.000Z' };
+
+      const result = await store.create('pw', 'mnemonic words', 'passphrase', account);
+
+      expect(result).toEqual({ success: true });
+      expect(store.vaultExists).toBe(true);
+      expect(store.isUnlocked).toBe(true);
+      const [, vaultData] = mockCreateVault.mock.calls[0] as [string, { mnemonic: string; passphrase: string; accounts: unknown[] }];
+      expect(vaultData.mnemonic).toBe('mnemonic words');
+      expect(vaultData.passphrase).toBe('passphrase');
+      expect(vaultData.accounts).toEqual([account]);
+    });
+
+    it('creates the vault with no initial account and an empty passphrase by default', async () => {
+      mockCreateVault.mockResolvedValue({ success: true });
+      const store = useVaultStore();
+
+      await store.create('pw', 'mnemonic words');
+
+      const [, vaultData] = mockCreateVault.mock.calls[0] as [string, { passphrase: string; accounts: unknown[] }];
+      expect(vaultData.passphrase).toBe('');
+      expect(vaultData.accounts).toEqual([]);
+    });
+
+    it('returns the failure result without marking the vault as existing', async () => {
+      mockCreateVault.mockResolvedValue({ success: false, error: 'boom', code: 'GEN_UNKNOWN' });
+      const store = useVaultStore();
+
+      const result = await store.create('pw', 'mnemonic words');
+
+      expect(result).toEqual({ success: false, error: 'boom', errorCode: 'GEN_UNKNOWN' });
+      expect(store.vaultExists).toBe(false);
+    });
+  });
+
+  describe('listenToLockChanges', () => {
+    it('updates isUnlocked and records a background lock reason when locked remotely', () => {
+      const store = useVaultStore();
+      store.isUnlocked = true;
+
+      store.listenToLockChanges();
+      const listener = mockOnChanged.mock.calls[0]?.[0] as (
+        changes: Record<string, { newValue?: unknown }>,
+        areaName: string,
+      ) => void;
+      listener({ VAULT_UNLOCKED: { newValue: false } }, 'session');
+
+      expect(store.isUnlocked).toBe(false);
+      expect(store.lastLockReason).toBe('background');
+    });
+
+    it('ignores changes outside the session storage area', () => {
+      const store = useVaultStore();
+      store.isUnlocked = true;
+
+      store.listenToLockChanges();
+      const listener = mockOnChanged.mock.calls[0]?.[0] as (
+        changes: Record<string, { newValue?: unknown }>,
+        areaName: string,
+      ) => void;
+      listener({ VAULT_UNLOCKED: { newValue: false } }, 'local');
+
+      expect(store.isUnlocked).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Part of #123 Phase 3 (#127): raise test coverage in the areas the codebase audit found thinnest.

A fresh coverage run (73.93% overall, up from Phase 0's 65.98% baseline now that Phase 2's PRs have merged) confirmed composables and stores are still the weak spots:

| Area | Before | After |
|---|---|---|
| `src/composables` | 55.35% | 86.15% |
| `src/stores` | 51.28% | 70.67% |
| `src/utils` | 100% (already) | 100% |

- **Composables** — added tests for the five with zero prior coverage: `useEventService.ts`, `useNavigation.ts`, `useVaultAutoLock.ts` (activity-mark throttling and the Quasar-bridge/`chrome.runtime` fallback), `useVaultManagement.ts` (export/import flows, including `FileReader`-based JSON parsing and the wrong-password/parse-error paths), and `useVault.ts` (create/unlock/lock flows and their redirect logic). `useAccounts.ts` already had a test file and was left as-is.
- **Stores** — added tests for `account-store.ts` and `vault-store.ts`, the two Pinia stores with zero prior coverage. `settings-store.ts` already had a test file; `index.ts` is Quasar's Pinia-instance boilerplate, not meaningfully testable.
- **Utils** — already 100% covered; nothing to add.

**Purely additive: no production code changed.** 57 new tests; full suite: 599 passed. Overall coverage: **75.57%** statements (up from 73.93% before this PR, 65.98% at the Phase 0 baseline).

This is the last open follow-up from #123 (Phase 0/#124 and Phase 2/#126 are both merged and closed).

## Test plan
- [x] `npm run lint` -- passes
- [x] `npm run typecheck` -- passes
- [x] `npm run test:run` -- 599 tests pass (57 new)
- [x] `npm run test:coverage` -- shows measured improvement over the Phase 0 baseline for every area touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)