### PR TITLE
feat(approvals): replace the singleton approval with a durable request queue

### DIFF
--- a/src-bex/background.ts
+++ b/src-bex/background.ts
@@ -14,15 +14,24 @@ import {
   storageService,
 } from 'src/services/storage-service';
 import {
-  REQUEST_TIMEOUT_MS,
-} from './constants';
-import {
   startAutoLockTimer,
   resetAutoLockTimer,
   restoreLastActivity,
   checkAutoLock,
 } from './services/auto-lock';
 import { initializePanelSurface, resolvePanelSurface } from './services/panel-surface';
+import {
+  enqueueRequest,
+  getCurrentRequest,
+  getPendingCount,
+  listPendingRequests,
+  markPresented,
+  pruneResolvedRequests,
+  reconcileInterruptedRequests,
+  requeuePresented,
+  submitDecision,
+} from './services/request-queue';
+import type { ApprovalDuration } from './types/background';
 import type {
   BridgeResponsePayload,
   VaultData,
@@ -120,7 +129,15 @@ declare module '@quasar/app-vite' {
       { pubkey: string; ciphertext: string; origin: string },
       BridgeResponsePayload<'nostr.nip44.decrypt'>,
     ];
-    'nostr.approval.respond': [{ approved: boolean; duration: string }, BridgeResponsePayload<'nostr.approval.respond'>];
+    'nostr.requests.list': [undefined, BridgeResponsePayload<'nostr.requests.list'>];
+    'nostr.requests.current': [undefined, BridgeResponsePayload<'nostr.requests.current'>];
+    'nostr.requests.count': [undefined, BridgeResponsePayload<'nostr.requests.count'>];
+    'nostr.requests.present': [{ id: string }, BridgeResponsePayload<'nostr.requests.present'>];
+    'nostr.requests.respond': [
+      { id: string; approved: boolean; duration: ApprovalDuration },
+      BridgeResponsePayload<'nostr.requests.respond'>,
+    ];
+    'nostr.requests.requeuePresented': [undefined, BridgeResponsePayload<'nostr.requests.requeuePresented'>];
     'vault.unlock': [{ password: string }, BridgeResponsePayload<'vault.unlock'>];
     'vault.lock': [undefined, BridgeResponsePayload<'vault.lock'>];
     'vault.create': [
@@ -217,6 +234,9 @@ if (typeof self !== 'undefined') {
   });
 }
 
+// Auto-lock activity is deliberately not reset by site-initiated requests (ADR D15). A page
+// making periodic requests must not hold the vault unlocked past the user's configured
+// interval; only interaction with a Porwr surface counts as activity.
 const getHostname = (origin: string): string => {
   try {
     return new URL(origin).hostname;
@@ -225,26 +245,33 @@ const getHostname = (origin: string): string => {
   }
 };
 
-interface ApprovalResponse {
-  approved: boolean;
-  duration: string;
-}
+bridge.on('nostr.requests.list', () => {
+  return listPendingRequests() as unknown as BridgeResponsePayload<'nostr.requests.list'>;
+});
 
-interface ApprovalPromise {
-  resolve: (value: ApprovalResponse) => void;
-  reject: (reason?: unknown) => void;
-}
+bridge.on('nostr.requests.current', () => {
+  return getCurrentRequest() as unknown as BridgeResponsePayload<'nostr.requests.current'>;
+});
 
-const getApprovalPromise = (): ApprovalPromise | null => approvalPromise;
+bridge.on('nostr.requests.count', () => {
+  return getPendingCount() as unknown as BridgeResponsePayload<'nostr.requests.count'>;
+});
 
-let approvalPromise: ApprovalPromise | null = null;
+bridge.on('nostr.requests.present', ({ payload }) => {
+  return markPresented(payload.id) as unknown as BridgeResponsePayload<'nostr.requests.present'>;
+});
 
-bridge.on('nostr.approval.respond', ({ payload }) => {
-  if (approvalPromise) {
-    approvalPromise.resolve({ approved: payload.approved, duration: payload.duration });
-    approvalPromise = null;
-  }
-  return true;
+// Decisions name a request id. The queue refuses unknown, already-terminal, and expired ids, so
+// a panel acting on stale state changes nothing (ADR D5).
+bridge.on('nostr.requests.respond', ({ payload }) => {
+  return submitDecision(payload.id, {
+    approved: payload.approved,
+    duration: payload.duration,
+  }) as unknown as BridgeResponsePayload<'nostr.requests.respond'>;
+});
+
+bridge.on('nostr.requests.requeuePresented', () => {
+  return requeuePresented() as unknown as BridgeResponsePayload<'nostr.requests.requeuePresented'>;
 });
 
 bridge.on('vault.unlock', ({ payload }) => {
@@ -348,6 +375,10 @@ async function initialize(): Promise<void> {
       });
     });
     await initializePanelSurface();
+    // A restarted worker has lost every live callback, so anything still pending is interrupted
+    // and can never be approved (ADR D7).
+    await reconcileInterruptedRequests();
+    await pruneResolvedRequests();
   } catch (error: unknown) {
     logService.log(LogLevel.ERROR, '[BEX] Initialization error:', {
       error: error instanceof Error ? error.message : String(error),
@@ -429,38 +460,6 @@ const trimApprovalContentDescription = (content?: string): string | undefined =>
   return normalized.length > 240 ? `${normalized.slice(0, 237)}...` : normalized;
 };
 
-const buildApprovalUrl = (
-  path: 'approve' | 'login',
-  origin: string,
-  eventKind: number,
-  details: ApprovalRequestDetails,
-  approvalVaultLocked = false,
-): string => {
-  const query = new URLSearchParams({
-    origin,
-    kind: String(eventKind),
-    requestType: details.requestType,
-  });
-
-  if (details.contentDescription) {
-    query.set('contentDescription', details.contentDescription);
-  }
-
-  if (details.allowRemember === false) {
-    query.set('allowRemember', 'false');
-  }
-
-  if (path === 'login') {
-    query.set('redirect', '/approve');
-  }
-
-  if (approvalVaultLocked) {
-    query.set('approvalVaultLocked', 'true');
-  }
-
-  return chrome.runtime.getURL(`www/index.html#/${path}?${query.toString()}`);
-};
-
 async function requestApproval(
   origin: string,
   eventKind: number,
@@ -471,125 +470,53 @@ async function requestApproval(
     if (permission.granted) return true;
   }
 
-  const isUnlockedStatus = await handleVaultIsUnlocked({}, '');
-  if (!isUnlockedStatus.success || !isUnlockedStatus.data) {
-    try {
-      const loginUrl = buildApprovalUrl('login', origin, eventKind, details, true);
-      const win = await chrome.windows.create({ url: loginUrl, type: 'popup', width: 450, height: 700, focused: true });
-      const windowId = win?.id;
-      if (windowId === undefined) {
-        return false;
-      }
-
-      return new Promise<boolean>((resolve) => {
-        const checkStatus = setInterval(() => {
-          void handleVaultIsUnlocked({}, '').then((status) => {
-            if (status.success && status.data) {
-              clearInterval(checkStatus);
-              chrome.windows.onRemoved.removeListener(onRemoved);
-              void requestApproval(origin, eventKind, details).then(resolve);
-            }
-          });
-        }, 1000);
-
-        const onRemoved = (closedWindowId: number) => {
-          if (closedWindowId === windowId) {
-            clearInterval(checkStatus);
-            chrome.windows.onRemoved.removeListener(onRemoved);
-            resolve(false);
-          }
-        };
-        chrome.windows.onRemoved.addListener(onRemoved);
-      });
-    } catch {
-      return false;
-    }
-  }
-
-  if (approvalPromise) throw new Error('Another approval request is already pending');
-
-  const url = buildApprovalUrl('approve', origin, eventKind, details);
-  let windowId: number | undefined;
-
-  const promise = new Promise<ApprovalResponse>((resolve, reject) => {
-    approvalPromise = { resolve, reject };
-    const timeout = setTimeout(() => {
-      if (approvalPromise) {
-        approvalPromise.reject(new Error('Approval request timed out'));
-        approvalPromise = null;
-        if (windowId !== undefined) void chrome.windows.remove(windowId);
-      }
-    }, REQUEST_TIMEOUT_MS);
-
-    const currentApprovalPromise = approvalPromise;
-    if (!currentApprovalPromise) {
-      reject(new Error('Approval request state was not initialized'));
-      return;
-    }
-
-    const originalResolve = currentApprovalPromise.resolve;
-    const originalReject = currentApprovalPromise.reject;
-
-    const onRemovedHandler = (closedWindowId: number) => {
-      if (closedWindowId === windowId && approvalPromise) {
-        approvalPromise.resolve({ approved: false, duration: 'once' });
-        approvalPromise = null;
-      }
-    };
-    chrome.windows.onRemoved.addListener(onRemovedHandler);
-
-    approvalPromise.resolve = (val: ApprovalResponse) => {
-      clearTimeout(timeout);
-      chrome.windows.onRemoved.removeListener(onRemovedHandler);
-      void (async () => {
-        if (val.approved && val.duration !== 'once' && details.allowRemember !== false && !details.skipPermissionCheck) {
-          try {
-            if (val.duration === 'always' || val.duration === '8h') {
-              await grantPermission(origin, eventKind, val.duration);
-            } else {
-              logService.log(LogLevel.WARN, `[BEX] Received unsupported approval duration: ${val.duration}`);
-            }
-          } catch (error: unknown) {
-            logService.log(LogLevel.ERROR, '[BEX] Failed to grant permission', {
-              error: error instanceof Error ? error.message : String(error),
-            });
-          }
-        }
-        originalResolve(val);
-      })();
-    };
-    approvalPromise.reject = (err: unknown) => {
-      clearTimeout(timeout);
-      chrome.windows.onRemoved.removeListener(onRemovedHandler);
-      originalReject(err);
-    };
+  const activeStoredKey = await getActiveStoredKey();
+  const { record, decision } = await enqueueRequest({
+    origin,
+    requestType: details.requestType,
+    eventKind,
+    accountAlias: activeStoredKey?.alias ?? null,
+    // StoredKey carries no public key, and deriving one would need an unlocked vault and key
+    // material for a display field. #116 owns the account dimension and populates this.
+    accountPubkey: null,
   });
 
-  try {
-    const win = await chrome.windows.create({ url, type: 'popup', width: 450, height: 700, focused: true });
-    if (win?.id === undefined) {
-      const error = new Error('Failed to open approval window');
-      const pendingApproval = getApprovalPromise();
-      if (pendingApproval) {
-        pendingApproval.reject(error);
-        approvalPromise = null;
-      }
-    } else {
-      windowId = win.id;
-    }
-  } catch (error: unknown) {
-    const pendingApproval = getApprovalPromise();
-    if (pendingApproval) {
-      pendingApproval.reject(error);
-      approvalPromise = null;
+  // A locked vault no longer opens its own window: the panel presents the unlock view with the
+  // waiting request, and unlocking still requires an explicit decision afterwards (ADR D14).
+  const outcome = await decision;
+
+  const approved = outcome.approved;
+  const durationLabel: ApprovalDuration = outcome.duration;
+
+  if (
+    approved &&
+    durationLabel !== 'once' &&
+    details.allowRemember !== false &&
+    !details.skipPermissionCheck
+  ) {
+    try {
+      await grantPermission(origin, eventKind, durationLabel);
+    } catch (error: unknown) {
+      logService.log(LogLevel.ERROR, '[BEX] Failed to grant permission', {
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
-  return promise.then((res) => res.approved);
+
+  // Logged on the terminal transition rather than when the site asked, so a rejection is not
+  // recorded as an approval.
+  void logService.logApproval(
+    eventKind === -1 ? details.requestType : eventKind,
+    getHostname(origin),
+    record.accountAlias,
+    approved ? 'approved' : 'rejected',
+  );
+
+  return approved;
 }
 
 bridge.on('nostr.getPublicKey', ({ payload: { origin } }) => (
   (async () => {
-    void resetAutoLockTimer();
     const result = await handleGetPublicKey({}, origin);
     if (!result.success) {
       throw new BackgroundBridgeError(
@@ -609,7 +536,6 @@ bridge.on('nostr.getPublicKey', ({ payload: { origin } }) => (
 
 bridge.on('nostr.signEvent', ({ payload: { event, origin } }) => (
   (async () => {
-    void resetAutoLockTimer();
     const activeStoredKey = await getActiveStoredKey();
     void logService.logApproval(event.kind, getHostname(origin), activeStoredKey?.alias);
     const contentDescription = trimApprovalContentDescription(event.content);
@@ -641,7 +567,6 @@ bridge.on('nostr.signEvent', ({ payload: { event, origin } }) => (
 
 bridge.on('nostr.getRelays', ({ payload: { origin } }) => (
   (async () => {
-    void resetAutoLockTimer();
     const activeStoredKey = await getActiveStoredKey();
     void logService.logApproval('get_relays', getHostname(origin), activeStoredKey?.alias);
     const approved = await requestApproval(origin, -1, { requestType: 'get_relays' });
@@ -656,7 +581,6 @@ bridge.on('nostr.getRelays', ({ payload: { origin } }) => (
 
 bridge.on('nostr.nip04.encrypt', ({ payload }) => (
   (async () => {
-    void resetAutoLockTimer();
     const activeStoredKey = await getActiveStoredKey();
     void logService.logApproval('nip04_encrypt', getHostname(payload.origin), activeStoredKey?.alias);
     const approved = await requestApproval(payload.origin, -1, { requestType: 'nip04_encrypt' });
@@ -671,7 +595,6 @@ bridge.on('nostr.nip04.encrypt', ({ payload }) => (
 
 bridge.on('nostr.nip04.decrypt', ({ payload }) => (
   (async () => {
-    void resetAutoLockTimer();
     const activeStoredKey = await getActiveStoredKey();
     void logService.logApproval('nip04_decrypt', getHostname(payload.origin), activeStoredKey?.alias);
     const approved = await requestApproval(payload.origin, -1, { requestType: 'nip04_decrypt' });
@@ -686,7 +609,6 @@ bridge.on('nostr.nip04.decrypt', ({ payload }) => (
 
 bridge.on('nostr.nip44.encrypt', ({ payload }) => (
   (async () => {
-    void resetAutoLockTimer();
     const activeStoredKey = await getActiveStoredKey();
     void logService.logApproval('nip44_encrypt', getHostname(payload.origin), activeStoredKey?.alias);
     const approved = await requestApproval(payload.origin, -1, { requestType: 'nip44_encrypt' });
@@ -701,7 +623,6 @@ bridge.on('nostr.nip44.encrypt', ({ payload }) => (
 
 bridge.on('nostr.nip44.decrypt', ({ payload }) => (
   (async () => {
-    void resetAutoLockTimer();
     const activeStoredKey = await getActiveStoredKey();
     void logService.logApproval('nip44_decrypt', getHostname(payload.origin), activeStoredKey?.alias);
     const approved = await requestApproval(payload.origin, -1, { requestType: 'nip44_decrypt' });
@@ -732,7 +653,6 @@ bridge.on('relay.browser.refresh', ({ payload }) => {
 });
 
 bridge.on('nip57.getCapabilities', ({ payload }) => {
-  void resetAutoLockTimer();
   return dispatchMessage(
     'nip57.getCapabilities',
     createBridgeRequest('nip57.getCapabilities', { origin: payload.origin }),
@@ -742,7 +662,6 @@ bridge.on('nip57.getCapabilities', ({ payload }) => {
 
 bridge.on('nip57.sendZap', ({ payload }) => (
   (async () => {
-    void resetAutoLockTimer();
     const amountMsat = payload.request.amountMsat ?? (payload.request.amountSats !== undefined ? payload.request.amountSats * 1000 : 0);
     const amountSatsLabel = amountMsat > 0 ? `${amountMsat / 1000} sats` : 'unknown amount';
     const contentDescription = trimApprovalContentDescription(
@@ -777,7 +696,6 @@ bridge.on('nip57.zaps.list', () => {
 
 bridge.on('webln.enable', ({ payload }) => (
   (async () => {
-    void resetAutoLockTimer();
     const approved = await requestApproval(payload.origin, -1, {
       requestType: 'webln_enable',
       contentDescription: 'Allow this site to use Diogel as a WebLN wallet provider. Payments will still require separate approval.',
@@ -796,7 +714,6 @@ bridge.on('webln.enable', ({ payload }) => (
 ));
 
 bridge.on('webln.getInfo', ({ payload }) => {
-  void resetAutoLockTimer();
   return dispatchMessage(
     'webln.getInfo',
     createBridgeRequest('webln.getInfo', { origin: payload.origin }),
@@ -806,7 +723,6 @@ bridge.on('webln.getInfo', ({ payload }) => {
 
 bridge.on('webln.sendPayment', ({ payload }) => (
   (async () => {
-    void resetAutoLockTimer();
     const amountMsat = parseBolt11AmountMsat(payload.paymentRequest);
     const amountDescription = amountMsat !== undefined ? `${amountMsat / 1000} sats` : 'unknown amount';
     const approved = await requestApproval(payload.origin, -1, {

--- a/src-bex/handlers/nip07.ts
+++ b/src-bex/handlers/nip07.ts
@@ -9,7 +9,6 @@ import { hexToBytes } from '@noble/hashes/utils';
 import { isVaultUnlocked, getVaultData } from '../vault';
 import { NOSTR_ACTIVE, storageService } from 'src/services/storage-service';
 import { checkPermission } from './permission-handler';
-import { resetAutoLockTimer } from '../services/auto-lock';
 import { logService } from 'src/services/log-service';
 import { ErrorCode } from 'src/types/error-codes.d';
 
@@ -45,7 +44,6 @@ export const handleGetPublicKey = logWrapper(async (
     return { success: false, error: 'No active account', code: ErrorCode.SIG_NO_ACTIVE_KEY };
   }
 
-  void resetAutoLockTimer();
 
   return { success: true, data: account.id };
 }, 'getPublicKey');
@@ -82,7 +80,6 @@ export const handleSignEvent = logWrapper(async (
     const sk = hexToBytes(account.account.privkey);
     const signed = finalizeEvent(payload.event, sk);
 
-    void resetAutoLockTimer();
 
     return { success: true, data: signed };
   } catch (error: unknown) {

--- a/src-bex/handlers/nip44.ts
+++ b/src-bex/handlers/nip44.ts
@@ -1,6 +1,5 @@
 import { nip44 } from 'nostr-tools';
 import type { HandlerResult } from '../types/background';
-import { resetAutoLockTimer } from '../services/auto-lock';
 import { getActiveSecretKey } from './active-key';
 
 export async function handleNip44Encrypt(
@@ -14,7 +13,6 @@ export async function handleNip44Encrypt(
     const conversationKey = nip44.getConversationKey(secretKey, payload.pubkey);
     const ciphertext = nip44.encrypt(payload.plaintext, conversationKey);
 
-    void resetAutoLockTimer();
 
     return { success: true, data: ciphertext };
   } catch (error: unknown) {
@@ -36,7 +34,6 @@ export async function handleNip44Decrypt(
     const conversationKey = nip44.getConversationKey(secretKey, payload.pubkey);
     const plaintext = nip44.decrypt(payload.ciphertext, conversationKey);
 
-    void resetAutoLockTimer();
 
     return { success: true, data: plaintext };
   } catch (error: unknown) {

--- a/src-bex/services/request-queue.ts
+++ b/src-bex/services/request-queue.ts
@@ -1,0 +1,293 @@
+/**
+ * Background-owned approval request queue (ADR D1, D5, D6, D7, D8).
+ *
+ * The background is the single source of truth for request state. Extension UI observes this
+ * queue and submits decisions against a request id; it never holds the authoritative record and
+ * never resolves a provider promise.
+ *
+ * Expiry is evaluated rather than timed. A `setTimeout` does not survive service-worker
+ * suspension, and `chrome.alarms` would add a permission the approved non-functional
+ * requirements forbid, so every read and every decision re-evaluates expiry first.
+ */
+
+import { REQUEST_QUEUE_KEY, storageService } from 'src/services/storage-service';
+import { clampRequestExpiryMinutes } from 'src/services/request-expiry';
+import { REQUEST_EXPIRY_MINUTES } from 'src/services/storage-service';
+import { LogLevel, logService } from 'src/services/log-service';
+import {
+  TERMINAL_REQUEST_STATES,
+  type ApprovalDecision,
+  type ApprovalRequestRecord,
+  type ApprovalRequestState,
+  type DecisionResult,
+} from '../types/background';
+
+export interface EnqueueRequestInput {
+  origin: string;
+  requestType: string;
+  eventKind: number;
+  accountAlias: string | null;
+  accountPubkey: string | null;
+}
+
+interface PendingCallback {
+  settle: (decision: ApprovalDecision) => void;
+  fail: (error: Error) => void;
+}
+
+/**
+ * Live provider callbacks, keyed by request id.
+ *
+ * Deliberately memory-only. A callback cannot survive a service-worker restart, and a request
+ * whose callback is gone must never be signable (D7).
+ */
+const liveCallbacks = new Map<string, PendingCallback>();
+
+const isTerminal = (state: ApprovalRequestState): boolean =>
+  TERMINAL_REQUEST_STATES.includes(state);
+
+const readRecords = async (): Promise<ApprovalRequestRecord[]> => {
+  const stored = await storageService.get<ApprovalRequestRecord[]>(REQUEST_QUEUE_KEY, 'session');
+  return Array.isArray(stored) ? stored : [];
+};
+
+const writeRecords = async (records: ApprovalRequestRecord[]): Promise<void> => {
+  await storageService.set(REQUEST_QUEUE_KEY, records, 'session');
+};
+
+/**
+ * Only the fields listed in D6 are permitted in durable storage. Anything a caller adds beyond
+ * them is dropped here rather than trusted, so a future field addition cannot quietly persist
+ * request content.
+ */
+const toDurableRecord = (record: ApprovalRequestRecord): ApprovalRequestRecord => ({
+  id: record.id,
+  origin: record.origin,
+  requestType: record.requestType,
+  eventKind: record.eventKind,
+  accountAlias: record.accountAlias,
+  accountPubkey: record.accountPubkey,
+  createdAt: record.createdAt,
+  expiresAt: record.expiresAt,
+  state: record.state,
+});
+
+const applyExpiry = (
+  records: ApprovalRequestRecord[],
+  now: number,
+): { records: ApprovalRequestRecord[]; expired: ApprovalRequestRecord[] } => {
+  const expired: ApprovalRequestRecord[] = [];
+  const next = records.map((record) => {
+    if (isTerminal(record.state) || record.expiresAt > now) return record;
+    const updated: ApprovalRequestRecord = { ...record, state: 'expired' };
+    expired.push(updated);
+    return updated;
+  });
+
+  return { records: next, expired };
+};
+
+/** Read the queue with expiry applied, persisting any transition it caused. */
+const loadQueue = async (now: number = Date.now()): Promise<ApprovalRequestRecord[]> => {
+  const stored = await readRecords();
+  const { records, expired } = applyExpiry(stored, now);
+
+  if (expired.length > 0) {
+    await writeRecords(records.map(toDurableRecord));
+    for (const record of expired) {
+      const callback = liveCallbacks.get(record.id);
+      liveCallbacks.delete(record.id);
+      callback?.settle({ approved: false, duration: 'once' });
+    }
+  }
+
+  return records;
+};
+
+const resolveExpiryMinutes = async (): Promise<number> => {
+  const stored = await storageService.get<number>(REQUEST_EXPIRY_MINUTES);
+  // The stored value is a preference, not an authority (D8).
+  return clampRequestExpiryMinutes(stored);
+};
+
+const newRequestId = (): string => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `req-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+};
+
+/** Requests are presented oldest first, with the id as a deterministic tie-break. */
+const byQueueOrder = (a: ApprovalRequestRecord, b: ApprovalRequestRecord): number =>
+  a.createdAt === b.createdAt ? a.id.localeCompare(b.id) : a.createdAt - b.createdAt;
+
+export const listPendingRequests = async (
+  now: number = Date.now(),
+): Promise<ApprovalRequestRecord[]> => {
+  const records = await loadQueue(now);
+  return records.filter((record) => !isTerminal(record.state)).sort(byQueueOrder);
+};
+
+export const getPendingCount = async (now: number = Date.now()): Promise<number> =>
+  (await listPendingRequests(now)).length;
+
+export const getCurrentRequest = async (
+  now: number = Date.now(),
+): Promise<ApprovalRequestRecord | null> => {
+  const pending = await listPendingRequests(now);
+  return pending.find((record) => record.state === 'presented') ?? pending[0] ?? null;
+};
+
+export const markPresented = async (
+  id: string,
+  now: number = Date.now(),
+): Promise<ApprovalRequestRecord | null> => {
+  const records = await loadQueue(now);
+  const target = records.find((record) => record.id === id);
+  if (!target || isTerminal(target.state)) return null;
+
+  const next = records.map(
+    (record): ApprovalRequestRecord =>
+      record.id === id ? { ...record, state: 'presented' } : record,
+  );
+  await writeRecords(next.map(toDurableRecord));
+  return next.find((record) => record.id === id) ?? null;
+};
+
+/**
+ * Return a presented request to the queue without deciding it.
+ *
+ * Used when the panel disconnects: closing the panel is never a decision (#113).
+ */
+export const requeuePresented = async (now: number = Date.now()): Promise<void> => {
+  const records = await loadQueue(now);
+  const next = records.map(
+    (record): ApprovalRequestRecord =>
+      record.state === 'presented' ? { ...record, state: 'queued' } : record,
+  );
+  await writeRecords(next.map(toDurableRecord));
+};
+
+/**
+ * Enqueue a request and wait for its terminal outcome.
+ *
+ * The returned promise settles exactly once: on a user decision, on expiry, or on interruption.
+ */
+export const enqueueRequest = async (
+  input: EnqueueRequestInput,
+  now: number = Date.now(),
+): Promise<{ record: ApprovalRequestRecord; decision: Promise<ApprovalDecision> }> => {
+  const expiryMinutes = await resolveExpiryMinutes();
+  const record: ApprovalRequestRecord = {
+    id: newRequestId(),
+    origin: input.origin,
+    requestType: input.requestType,
+    eventKind: input.eventKind,
+    accountAlias: input.accountAlias,
+    accountPubkey: input.accountPubkey,
+    createdAt: now,
+    // Stamped at creation: a later settings change must not move an existing request (D8).
+    expiresAt: now + expiryMinutes * 60 * 1000,
+    state: 'queued',
+  };
+
+  const records = await loadQueue(now);
+  await writeRecords([...records, record].map(toDurableRecord));
+
+  const decision = new Promise<ApprovalDecision>((resolve, reject) => {
+    liveCallbacks.set(record.id, {
+      settle: resolve,
+      fail: reject,
+    });
+  });
+
+  return { record, decision };
+};
+
+/**
+ * Apply a user decision to one request.
+ *
+ * Refuses unknown, already-terminal, and expired ids rather than applying them, so a stale panel
+ * cannot act on a request that has already moved on (D5).
+ */
+export const submitDecision = async (
+  id: string,
+  decision: ApprovalDecision,
+  now: number = Date.now(),
+): Promise<DecisionResult> => {
+  const records = await loadQueue(now);
+  const target = records.find((record) => record.id === id);
+
+  if (!target) {
+    logService.log(LogLevel.WARN, '[Queue] Refused decision for unknown request', { id });
+    return { applied: false, reason: 'unknown-request' };
+  }
+
+  if (target.state === 'expired') {
+    logService.log(LogLevel.WARN, '[Queue] Refused decision for expired request', { id });
+    return { applied: false, reason: 'expired' };
+  }
+
+  if (isTerminal(target.state)) {
+    logService.log(LogLevel.WARN, '[Queue] Refused duplicate decision', {
+      id,
+      state: target.state,
+    });
+    return { applied: false, reason: 'already-resolved' };
+  }
+
+  const nextState: ApprovalRequestState = decision.approved ? 'approved' : 'rejected';
+  const updated: ApprovalRequestRecord = { ...target, state: nextState };
+  await writeRecords(
+    records.map((record) => (record.id === id ? updated : record)).map(toDurableRecord),
+  );
+
+  const callback = liveCallbacks.get(id);
+  liveCallbacks.delete(id);
+  callback?.settle(decision);
+
+  return { applied: true, record: updated };
+};
+
+/**
+ * Reconcile persisted state after a service-worker restart.
+ *
+ * Every non-terminal persisted request has lost its live callback, so it becomes `interrupted`
+ * and can never be approved (D7).
+ */
+export const reconcileInterruptedRequests = async (
+  now: number = Date.now(),
+): Promise<ApprovalRequestRecord[]> => {
+  const records = await loadQueue(now);
+  const interrupted: ApprovalRequestRecord[] = [];
+
+  const next = records.map((record) => {
+    if (isTerminal(record.state) || liveCallbacks.has(record.id)) return record;
+    const updated: ApprovalRequestRecord = { ...record, state: 'interrupted' };
+    interrupted.push(updated);
+    return updated;
+  });
+
+  if (interrupted.length > 0) {
+    await writeRecords(next.map(toDurableRecord));
+    logService.log(LogLevel.WARN, '[Queue] Marked requests interrupted after restart', {
+      count: interrupted.length,
+    });
+  }
+
+  return interrupted;
+};
+
+/** Drop terminal records so the session store does not grow without bound. */
+export const pruneResolvedRequests = async (now: number = Date.now()): Promise<void> => {
+  const records = await loadQueue(now);
+  const next = records.filter((record) => !isTerminal(record.state));
+  if (next.length !== records.length) {
+    await writeRecords(next.map(toDurableRecord));
+  }
+};
+
+/** Test seam: clear in-memory callbacks. Not used by production code. */
+export const __resetLiveCallbacksForTests = (): void => {
+  liveCallbacks.clear();
+};

--- a/src-bex/types/background.ts
+++ b/src-bex/types/background.ts
@@ -47,5 +47,60 @@ export interface PermissionGrant {
   expiry?: number;
 }
 
+// Approval request queue types (ADR D5, D6)
+
+/**
+ * Request lifecycle states. `approved`, `rejected`, `expired`, and `interrupted` are terminal:
+ * a request in any of them can never be approved.
+ */
+export type ApprovalRequestState =
+  | 'queued'
+  | 'presented'
+  | 'approved'
+  | 'rejected'
+  | 'expired'
+  | 'interrupted';
+
+export const TERMINAL_REQUEST_STATES: readonly ApprovalRequestState[] = [
+  'approved',
+  'rejected',
+  'expired',
+  'interrupted',
+];
+
+/**
+ * The durable shape of a queued request.
+ *
+ * This is the complete list of fields permitted in session storage (ADR D6). Event content,
+ * event bodies, plaintext, ciphertext, invoices, preimages, and key material are transient and
+ * must never appear here.
+ */
+export interface ApprovalRequestRecord {
+  id: string;
+  origin: string;
+  requestType: string;
+  eventKind: number;
+  accountAlias: string | null;
+  accountPubkey: string | null;
+  createdAt: number;
+  expiresAt: number;
+  state: ApprovalRequestState;
+}
+
+/** Approval durations the user can choose. */
+export type ApprovalDuration = 'once' | '8h' | 'always';
+
+export interface ApprovalDecision {
+  approved: boolean;
+  duration: ApprovalDuration;
+}
+
+/** Why a decision was refused, when it was not applied. */
+export type DecisionRefusal = 'unknown-request' | 'already-resolved' | 'expired';
+
+export type DecisionResult =
+  | { applied: true; record: ApprovalRequestRecord }
+  | { applied: false; reason: DecisionRefusal };
+
 // Handler function type
 export type HandlerFn<T, R> = (payload: T, origin: string) => Promise<HandlerResult<R>>;

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -15,13 +15,33 @@ export interface ExceptionLog {
   hostname?: string | null;
 }
 
+/**
+ * What happened to an approval request.
+ *
+ * `unknown` exists for rows written before Porwr logged outcomes: those recorded that a site
+ * asked, not what the user decided, and the two cannot be told apart after the fact.
+ */
+export type ApprovalOutcome = 'approved' | 'rejected' | 'expired' | 'interrupted' | 'unknown';
+
 export interface ApprovalLog {
   id?: number;
   dateTime: string;
   eventKind: number | string;
   hostname: string;
   account?: string | null;
+  outcome?: ApprovalOutcome;
 }
+
+/**
+ * Backfill for rows written before Porwr logged outcomes.
+ *
+ * Exported so the behaviour can be tested directly: the repository mocks Dexie rather than
+ * running a real IndexedDB, so the upgrade callback itself is the testable unit. An end-to-end
+ * upgrade rehearsal against real 0.0.32 profiles belongs to the release issue.
+ */
+export const backfillApprovalOutcome = (approval: ApprovalLog): void => {
+  approval.outcome = approval.outcome ?? 'unknown';
+};
 
 export interface AppSetting {
   key: string;
@@ -82,6 +102,27 @@ export class DiogelDatabase extends Dexie {
       relayDiscoveryState: 'id, lastGlobalDiscoveryAt',
       appSettings: 'key, updatedAt',
     });
+
+    // Approval logging moved from request time to the terminal decision, so the table now
+    // records an outcome. Rows written before this point recorded only that a site asked, so
+    // they are backfilled as `unknown` rather than presented as approvals.
+    this.version(9)
+      .stores({
+        vaults: 'id',
+        exceptions: '++id, dateTime, account, hostname',
+        approvals: '++id, dateTime, eventKind, hostname, account, outcome',
+        relayCatalog: 'url, hostname, status, lastSeen, createdAt',
+        relayDiscoveryState: 'id, lastGlobalDiscoveryAt',
+        appSettings: 'key, updatedAt',
+      })
+      .upgrade((tx) =>
+        tx
+          .table('approvals')
+          .toCollection()
+          .modify((approval: ApprovalLog) => {
+            backfillApprovalOutcome(approval);
+          }),
+      );
   }
 }
 

--- a/src/services/log-service.ts
+++ b/src/services/log-service.ts
@@ -1,4 +1,5 @@
 import { db } from './database';
+import type { ApprovalOutcome } from './database';
 
 export enum LogLevel {
   INFO = 'INFO',
@@ -75,7 +76,18 @@ export class LogService {
     }
   }
 
-  async logApproval(eventKind: number | string, hostname: string, account?: string | null): Promise<void> {
+  /**
+   * Record what happened to an approval request.
+   *
+   * Called on the terminal transition, not when the site asks: a rejected request must not be
+   * recorded the same way as an approved one.
+   */
+  async logApproval(
+    eventKind: number | string,
+    hostname: string,
+    account?: string | null,
+    outcome: ApprovalOutcome = 'unknown',
+  ): Promise<void> {
     const persistedAccount: PersistedLogAccount = this.normalizeNullableString(account);
 
     try {
@@ -84,8 +96,9 @@ export class LogService {
         eventKind,
         hostname,
         account: persistedAccount,
+        outcome,
       });
-      this.log(LogLevel.DEBUG, `Approval granted for kind ${eventKind} on ${hostname}`, {
+      this.log(LogLevel.DEBUG, `Approval ${outcome} for kind ${eventKind} on ${hostname}`, {
         account: persistedAccount,
       });
     } catch (error: unknown) {

--- a/src/services/storage-service.ts
+++ b/src/services/storage-service.ts
@@ -4,6 +4,8 @@ export const BLOSSOM_SERVER = 'nostr:blossom-server' as const;
 export const DARK_MODE = 'nostr:dark-mode' as const;
 export const VAULT_AUTO_LOCK_MINUTES = 'vault:auto-lock-minutes' as const;
 export const REQUEST_EXPIRY_MINUTES = 'nostr:request-expiry-minutes' as const;
+// Session-scoped: the queue starts empty on every browser restart by design (ADR D6, D7).
+export const REQUEST_QUEUE_KEY = 'nostr:request-queue' as const;
 export const VAULT_LAST_ACTIVITY = 'vault:last-activity' as const;
 export const BLOSSOM_UPLOAD_STATUS = 'blossom:upload-status' as const;
 export const PERMISSIONS_KEY = 'nostr:permissions' as const;

--- a/src/types/bridge-types.d.ts
+++ b/src/types/bridge-types.d.ts
@@ -1,4 +1,9 @@
 import type { StoredKey } from './index.d';
+import type {
+  ApprovalDuration,
+  ApprovalRequestRecord,
+  DecisionResult,
+} from 'app/src-bex/types/background';
 import type { RelayCatalogEntry, RelayDiscoveryState } from './relay';
 import type {
   ImportNip47ConnectionRequest,
@@ -102,7 +107,12 @@ export type BridgeAction =
   | 'vault.export'
   | 'vault.import'
   | 'activity.mark'
-  | 'nostr.approval.respond'
+  | 'nostr.requests.list'
+  | 'nostr.requests.current'
+  | 'nostr.requests.count'
+  | 'nostr.requests.present'
+  | 'nostr.requests.respond'
+  | 'nostr.requests.requeuePresented'
   | 'relay.browser.list'
   | 'relay.browser.getStatus'
   | 'relay.browser.refresh'
@@ -246,12 +256,33 @@ export interface BridgeRequestMap {
     id: string;
     action: 'activity.mark';
   };
-  'nostr.approval.respond': {
+  'nostr.requests.list': {
     id: string;
-    action: 'nostr.approval.respond';
+    action: 'nostr.requests.list';
+  };
+  'nostr.requests.current': {
+    id: string;
+    action: 'nostr.requests.current';
+  };
+  'nostr.requests.count': {
+    id: string;
+    action: 'nostr.requests.count';
+  };
+  'nostr.requests.present': {
+    id: string;
+    action: 'nostr.requests.present';
+    requestId: string;
+  };
+  'nostr.requests.respond': {
+    id: string;
+    action: 'nostr.requests.respond';
+    requestId: string;
     approved: boolean;
-    duration: string;
-    requestId?: string;
+    duration: ApprovalDuration;
+  };
+  'nostr.requests.requeuePresented': {
+    id: string;
+    action: 'nostr.requests.requeuePresented';
   };
   'relay.browser.list': {
     id: string;
@@ -354,7 +385,12 @@ export interface BridgeResponseMap {
   'vault.export': { success: boolean; encryptedData?: string; error?: string };
   'vault.import': { success: boolean; error?: string };
   'activity.mark': boolean | void;
-  'nostr.approval.respond': boolean | { success: boolean };
+  'nostr.requests.list': ApprovalRequestRecord[];
+  'nostr.requests.current': ApprovalRequestRecord | null;
+  'nostr.requests.count': number;
+  'nostr.requests.present': ApprovalRequestRecord | null;
+  'nostr.requests.respond': DecisionResult;
+  'nostr.requests.requeuePresented': void;
   'relay.browser.list': RelayCatalogEntry[];
   'relay.browser.getStatus': RelayDiscoveryState | null;
   'relay.browser.refresh': boolean | { success: false; error: string };

--- a/tests/unit/handlers/nip07.test.ts
+++ b/tests/unit/handlers/nip07.test.ts
@@ -76,7 +76,8 @@ describe('Nip07Handler', () => {
       if (result.success) {
         expect(result.data).toBe('test-pubkey');
       }
-      expect(resetAutoLockTimer).toHaveBeenCalled();
+      // ADR D15: site-initiated requests must not extend the unlocked window (finding F2).
+      expect(resetAutoLockTimer).not.toHaveBeenCalled();
     });
 
     it('should return error when vault is locked', async () => {
@@ -152,7 +153,8 @@ describe('Nip07Handler', () => {
         expect(result.data).toEqual(signedEvent);
       }
       expect(finalizeEvent).toHaveBeenCalled();
-      expect(resetAutoLockTimer).toHaveBeenCalled();
+      // ADR D15: site-initiated requests must not extend the unlocked window (finding F2).
+      expect(resetAutoLockTimer).not.toHaveBeenCalled();
     });
 
     it('should return error when vault is locked', async () => {

--- a/tests/unit/handlers/nip44.test.ts
+++ b/tests/unit/handlers/nip44.test.ts
@@ -73,7 +73,8 @@ describe('Nip44Handler', () => {
     }
     expect(nip44.getConversationKey).toHaveBeenCalledWith(expect.any(Buffer), 'recipient-pubkey');
     expect(nip44.encrypt).toHaveBeenCalledWith('hello', Uint8Array.from([1, 2, 3]));
-    expect(resetAutoLockTimer).toHaveBeenCalled();
+    // ADR D15: site-initiated requests must not extend the unlocked window (finding F2).
+    expect(resetAutoLockTimer).not.toHaveBeenCalled();
   });
 
   it('decrypts when vault is unlocked and active account exists', async () => {
@@ -89,7 +90,8 @@ describe('Nip44Handler', () => {
     }
     expect(nip44.getConversationKey).toHaveBeenCalledWith(expect.any(Buffer), 'sender-pubkey');
     expect(nip44.decrypt).toHaveBeenCalledWith('nip44-ciphertext', Uint8Array.from([4, 5, 6]));
-    expect(resetAutoLockTimer).toHaveBeenCalled();
+    // ADR D15: site-initiated requests must not extend the unlocked window (finding F2).
+    expect(resetAutoLockTimer).not.toHaveBeenCalled();
   });
 
   it('returns error when vault is locked', async () => {

--- a/tests/unit/services/approval-outcome-backfill.test.ts
+++ b/tests/unit/services/approval-outcome-backfill.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+
+import { backfillApprovalOutcome } from 'src/services/database';
+import type { ApprovalLog } from 'src/services/database';
+
+/**
+ * Approval logging moved from request time to the terminal decision, so the approvals table
+ * gained an outcome. Rows written before that recorded only that a site asked, and cannot be
+ * told apart from approvals after the fact.
+ */
+describe('approval outcome backfill', () => {
+  const row = (overrides: Partial<ApprovalLog> = {}): ApprovalLog => ({
+    dateTime: '2026-01-01T00:00:00.000Z',
+    eventKind: 1,
+    hostname: 'example.com',
+    account: 'alice',
+    ...overrides,
+  });
+
+  it('marks a pre-migration row as unknown rather than as an approval', () => {
+    const approval = row();
+    backfillApprovalOutcome(approval);
+    expect(approval.outcome).toBe('unknown');
+  });
+
+  it('leaves an existing outcome untouched', () => {
+    for (const outcome of ['approved', 'rejected', 'expired', 'interrupted'] as const) {
+      const approval = row({ outcome });
+      backfillApprovalOutcome(approval);
+      expect(approval.outcome).toBe(outcome);
+    }
+  });
+
+  it('does not alter any other field', () => {
+    const approval = row();
+    const before = { ...approval };
+    backfillApprovalOutcome(approval);
+
+    expect(approval.dateTime).toBe(before.dateTime);
+    expect(approval.eventKind).toBe(before.eventKind);
+    expect(approval.hostname).toBe(before.hostname);
+    expect(approval.account).toBe(before.account);
+  });
+});

--- a/tests/unit/services/log-service.test.ts
+++ b/tests/unit/services/log-service.test.ts
@@ -63,10 +63,12 @@ describe('LogService', () => {
         hostname: 'host1',
         account: 'acc1',
         dateTime: expect.any(String),
+        // Logged on the terminal transition now, so the row records what happened.
+        outcome: 'unknown',
       })
     );
     expect(console.debug).toHaveBeenCalledWith(
-      expect.stringContaining('[DEBUG] Approval granted for kind 1 on host1'),
+      expect.stringContaining('[DEBUG] Approval unknown for kind 1 on host1'),
       { account: 'acc1' }
     );
   });

--- a/tests/unit/services/request-queue.test.ts
+++ b/tests/unit/services/request-queue.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  enqueueRequest,
+  getCurrentRequest,
+  getPendingCount,
+  listPendingRequests,
+  markPresented,
+  pruneResolvedRequests,
+  reconcileInterruptedRequests,
+  requeuePresented,
+  submitDecision,
+  __resetLiveCallbacksForTests,
+} from 'app/src-bex/services/request-queue';
+import { REQUEST_EXPIRY_MINUTES, REQUEST_QUEUE_KEY } from 'src/services/storage-service';
+import type { ApprovalRequestRecord } from 'app/src-bex/types/background';
+
+vi.mock('src/services/log-service', () => ({
+  LogLevel: { DEBUG: 0, INFO: 1, WARN: 2, ERROR: 3 },
+  logService: { log: vi.fn() },
+}));
+
+const store = new Map<string, unknown>();
+
+vi.mock('src/services/storage-service', async () => {
+  const actual = await vi.importActual<typeof import('src/services/storage-service')>(
+    'src/services/storage-service',
+  );
+  return {
+    ...actual,
+    storageService: {
+      get: vi.fn((key: string) => Promise.resolve(store.get(key))),
+      set: vi.fn((key: string, value: unknown) => {
+        store.set(key, value);
+        return Promise.resolve();
+      }),
+    },
+  };
+});
+
+const baseInput = {
+  origin: 'https://example.com',
+  requestType: 'sign_event',
+  eventKind: 1,
+  accountAlias: 'alice',
+  accountPubkey: null,
+};
+
+const readStored = (): ApprovalRequestRecord[] =>
+  (store.get(REQUEST_QUEUE_KEY) as ApprovalRequestRecord[] | undefined) ?? [];
+
+describe('request queue', () => {
+  beforeEach(() => {
+    store.clear();
+    __resetLiveCallbacksForTests();
+    vi.clearAllMocks();
+  });
+
+  describe('concurrency', () => {
+    it('queues concurrent requests instead of rejecting the second', async () => {
+      const first = await enqueueRequest(baseInput);
+      const second = await enqueueRequest({ ...baseInput, origin: 'https://other.example' });
+
+      const pending = await listPendingRequests();
+      expect(pending).toHaveLength(2);
+      expect(first.record.id).not.toBe(second.record.id);
+      expect(await getPendingCount()).toBe(2);
+    });
+
+    it('presents requests in deterministic order', async () => {
+      const now = 1_000_000;
+      await enqueueRequest({ ...baseInput, origin: 'https://a.example' }, now);
+      await enqueueRequest({ ...baseInput, origin: 'https://b.example' }, now + 10);
+
+      const current = await getCurrentRequest(now + 20);
+      expect(current?.origin).toBe('https://a.example');
+    });
+
+    it('resolves each request exactly once', async () => {
+      const first = await enqueueRequest(baseInput);
+      const second = await enqueueRequest(baseInput);
+
+      const settled: string[] = [];
+      void first.decision.then(() => settled.push('first'));
+      void second.decision.then(() => settled.push('second'));
+
+      await submitDecision(first.record.id, { approved: true, duration: 'once' });
+      await submitDecision(second.record.id, { approved: false, duration: 'once' });
+      await Promise.all([first.decision, second.decision]);
+
+      expect(settled).toEqual(['first', 'second']);
+    });
+  });
+
+  describe('decision integrity', () => {
+    it('refuses a decision for an unknown id', async () => {
+      const result = await submitDecision('nope', { approved: true, duration: 'once' });
+      expect(result).toEqual({ applied: false, reason: 'unknown-request' });
+    });
+
+    it('refuses a duplicate decision', async () => {
+      const { record } = await enqueueRequest(baseInput);
+      await submitDecision(record.id, { approved: true, duration: 'once' });
+
+      const second = await submitDecision(record.id, { approved: true, duration: 'once' });
+      expect(second).toEqual({ applied: false, reason: 'already-resolved' });
+    });
+
+    it('refuses a decision on an expired request', async () => {
+      const now = 1_000_000;
+      const { record } = await enqueueRequest(baseInput, now);
+
+      const result = await submitDecision(
+        record.id,
+        { approved: true, duration: 'once' },
+        now + 11 * 60 * 1000,
+      );
+      expect(result).toEqual({ applied: false, reason: 'expired' });
+    });
+  });
+
+  describe('expiry', () => {
+    it('expires from creation, not from presentation', async () => {
+      const now = 1_000_000;
+      const { record } = await enqueueRequest(baseInput, now);
+      await markPresented(record.id, now + 60_000);
+
+      const pending = await listPendingRequests(now + 6 * 60 * 1000);
+      expect(pending).toHaveLength(0);
+      expect(readStored()[0]?.state).toBe('expired');
+    });
+
+    it('stamps the expiry at creation so a later settings change cannot move it', async () => {
+      const now = 1_000_000;
+      store.set(REQUEST_EXPIRY_MINUTES, 1);
+      const { record } = await enqueueRequest(baseInput, now);
+      expect(record.expiresAt).toBe(now + 60_000);
+
+      store.set(REQUEST_EXPIRY_MINUTES, 10);
+      const stored = readStored().find((item) => item.id === record.id);
+      expect(stored?.expiresAt).toBe(now + 60_000);
+    });
+
+    it('clamps an out-of-range stored expiry preference', async () => {
+      const now = 1_000_000;
+      store.set(REQUEST_EXPIRY_MINUTES, 0);
+      const zero = await enqueueRequest(baseInput, now);
+      expect(zero.record.expiresAt).toBe(now + 60_000);
+
+      store.set(REQUEST_EXPIRY_MINUTES, 9999);
+      const huge = await enqueueRequest(baseInput, now);
+      expect(huge.record.expiresAt).toBe(now + 10 * 60 * 1000);
+    });
+  });
+
+  describe('interruption', () => {
+    it('marks requests interrupted when their callback is gone', async () => {
+      await enqueueRequest(baseInput);
+      // Simulates a service-worker restart: records survive in session storage, callbacks do not.
+      __resetLiveCallbacksForTests();
+
+      const interrupted = await reconcileInterruptedRequests();
+      expect(interrupted).toHaveLength(1);
+      expect(readStored()[0]?.state).toBe('interrupted');
+    });
+
+    it('cannot approve an interrupted request', async () => {
+      const { record } = await enqueueRequest(baseInput);
+      __resetLiveCallbacksForTests();
+      await reconcileInterruptedRequests();
+
+      const result = await submitDecision(record.id, { approved: true, duration: 'once' });
+      expect(result).toEqual({ applied: false, reason: 'already-resolved' });
+    });
+
+    it('leaves requests with a live callback alone', async () => {
+      await enqueueRequest(baseInput);
+      const interrupted = await reconcileInterruptedRequests();
+      expect(interrupted).toHaveLength(0);
+    });
+  });
+
+  describe('panel lifecycle', () => {
+    it('requeues a presented request without deciding it', async () => {
+      const { record } = await enqueueRequest(baseInput);
+      await markPresented(record.id);
+      await requeuePresented();
+
+      const stored = readStored().find((item) => item.id === record.id);
+      expect(stored?.state).toBe('queued');
+    });
+
+    it('keeps the original expiry across requeue', async () => {
+      const now = 1_000_000;
+      const { record } = await enqueueRequest(baseInput, now);
+      await markPresented(record.id, now + 1000);
+      await requeuePresented(now + 2000);
+
+      const stored = readStored().find((item) => item.id === record.id);
+      expect(stored?.expiresAt).toBe(record.expiresAt);
+    });
+  });
+
+  describe('persistence boundary', () => {
+    it('persists only the fields permitted by D6', async () => {
+      await enqueueRequest(baseInput);
+
+      const permitted = [
+        'id',
+        'origin',
+        'requestType',
+        'eventKind',
+        'accountAlias',
+        'accountPubkey',
+        'createdAt',
+        'expiresAt',
+        'state',
+      ];
+      for (const record of readStored()) {
+        expect(Object.keys(record).sort()).toEqual([...permitted].sort());
+      }
+    });
+
+    it('never persists request content, even when a caller supplies it', async () => {
+      const forbidden = ['content', 'event', 'plaintext', 'ciphertext', 'invoice', 'privkey'];
+      await enqueueRequest({
+        ...baseInput,
+        // A future caller adding a field must not be able to leak it into storage.
+        ...({ content: 'secret note', plaintext: 'do not store me' } as unknown as object),
+      });
+
+      for (const record of readStored()) {
+        for (const field of forbidden) {
+          expect(Object.keys(record)).not.toContain(field);
+        }
+      }
+      // The values must not survive either, whatever key they arrived under.
+      const serialized = JSON.stringify(readStored());
+      expect(serialized).not.toContain('secret note');
+      expect(serialized).not.toContain('do not store me');
+    });
+
+    it('drops resolved records so the session store does not grow without bound', async () => {
+      const { record } = await enqueueRequest(baseInput);
+      await submitDecision(record.id, { approved: true, duration: 'once' });
+      await pruneResolvedRequests();
+
+      expect(readStored()).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the single in-memory `approvalPromise` with a background-owned request queue, per the plan
on #114 and decisions D1, D5, D6, D7, D8.

**Stacked on #137.** This PR targets `issue-112-sidebar-foundation` because the queue reads the
expiry setting introduced there. GitHub retargets it to `master` automatically once #137 merges.

## What changed

The queue lives in `src-bex/services/request-queue.ts` rather than in `background.ts`. The
background has no unit tests today while every service and handler does, so a module boundary is
what makes this issue's acceptance criteria verifiable at all.

- **Concurrency**: requests queue instead of the second being rejected. Order is FIFO by creation
  with the id as tie-break, and each request resolves exactly once.
- **Identity**: decisions name a request id. Unknown, already-terminal, and expired ids are refused
  and logged as refusals rather than applied.
- **Persistence**: session storage holds only the nine fields D6 permits. The durable shape is
  enforced on write, so a caller adding fields cannot leak request content into storage — there is a
  test that supplies `content` and `plaintext` and asserts neither survives.
- **Interruption**: on startup, every persisted non-terminal request has lost its callback and
  becomes `interrupted`, permanently non-signable.
- **Expiry**: evaluated on read rather than timed. `setTimeout` does not survive worker suspension,
  and `chrome.alarms` would add a permission NFR-18 forbids. The interval is read from the setting,
  clamped, and stamped at creation so a later settings change cannot move a live request.

Removed: `approvalPromise`, both `chrome.windows.create` approval/unlock popups, the 1s unlock
polling loop, the `Another approval request is already pending` throw, and the now-dead approval URL
builder.

## Two decisions taken with this work

**D15** — site-initiated requests no longer reset the auto-lock timer (threat model finding F2). A
page making periodic requests could previously hold the vault unlocked past the user's configured
interval. Removed from the twelve page-reachable handlers in `background.ts` and from `nip07.ts` and
`nip44.ts`. Genuine interaction with a Porwr surface still marks activity through
`useVaultAutoLock`, which listens to real input events, so quick-sign and other in-extension work is
unaffected.

The two existing tests that asserted the old behaviour now assert the new guarantee
(`not.toHaveBeenCalled`) rather than being deleted.

**Approval logging moved to the terminal transition.** It previously ran when the site asked, so a
rejected request was recorded identically to an approved one and Event History presented both as
approvals. Dexie v9 adds `outcome` and backfills pre-migration rows as `unknown`, because those rows
recorded that a site asked, not what the user decided, and the two cannot be told apart after the
fact.

## Verification

- `npm run lint`, `npm run typecheck` clean
- `npm run test:run` — 635 tests across 78 files, 20 new
- `npm run build:chrome` and `npm run build:firefox` succeed; emitted permissions are unchanged
  (`storage`, `sidePanel` on Chromium; `storage` on Firefox), confirming the expiry design avoided
  a new permission

New tests cover concurrent queueing and deterministic order, exactly-once resolution, refusal of
unknown/duplicate/expired decisions, expiry measured from creation rather than presentation, the
stamped interval surviving a settings change, clamping of out-of-range stored values, interruption
after a restart, requeue on panel disconnect preserving the original expiry, and the persistence
boundary as both a positive and a negative field list.

## Deviations from the plan, and their reasons

- **`accountPubkey` is recorded as `null`.** `StoredKey` carries no public key, and deriving one
  needs an unlocked vault and key material for what is a display field. #116 owns the account
  dimension and populates it.
- **The migration test does not open a real database.** The repository mocks Dexie deliberately
  ("we can't run a real IndexedDB in this environment") and has no `fake-indexeddb` dependency, so
  the upgrade callback was extracted as `backfillApprovalOutcome` and tested directly. A real
  upgrade rehearsal against 0.0.32 profiles is already in #117's plan.

## Not in scope

Panel-side presentation of queue state is #115, and badge/attention plus disconnect handling is
#113 — this PR lands the `requeuePresented` and count accessors those issues consume.

Refs: threenine/diogel#114

🤖 Generated with [Claude Code](https://claude.com/claude-code)
