### PR TITLE
feat(sidebar): deliver signing approvals and vault unlock in the panel

### DIFF
--- a/src-bex/background.ts
+++ b/src-bex/background.ts
@@ -24,6 +24,7 @@ import {
   enqueueRequest,
   getCurrentRequest,
   getPendingCount,
+  getRequestContent,
   listPendingRequests,
   markPresented,
   pruneResolvedRequests,
@@ -31,7 +32,7 @@ import {
   requeuePresented,
   submitDecision,
 } from './services/request-queue';
-import type { ApprovalDuration } from './types/background';
+import type { ApprovalDuration, UnsignedEvent } from './types/background';
 import type {
   BridgeResponsePayload,
   VaultData,
@@ -132,11 +133,12 @@ declare module '@quasar/app-vite' {
     'nostr.requests.list': [undefined, BridgeResponsePayload<'nostr.requests.list'>];
     'nostr.requests.current': [undefined, BridgeResponsePayload<'nostr.requests.current'>];
     'nostr.requests.count': [undefined, BridgeResponsePayload<'nostr.requests.count'>];
-    'nostr.requests.present': [{ id: string }, BridgeResponsePayload<'nostr.requests.present'>];
+    'nostr.requests.present': [{ requestId: string }, BridgeResponsePayload<'nostr.requests.present'>];
     'nostr.requests.respond': [
-      { id: string; approved: boolean; duration: ApprovalDuration },
+      { requestId: string; approved: boolean; duration: ApprovalDuration },
       BridgeResponsePayload<'nostr.requests.respond'>,
     ];
+    'nostr.requests.content': [{ requestId: string }, BridgeResponsePayload<'nostr.requests.content'>];
     'nostr.requests.requeuePresented': [undefined, BridgeResponsePayload<'nostr.requests.requeuePresented'>];
     'vault.unlock': [{ password: string }, BridgeResponsePayload<'vault.unlock'>];
     'vault.lock': [undefined, BridgeResponsePayload<'vault.lock'>];
@@ -258,16 +260,22 @@ bridge.on('nostr.requests.count', () => {
 });
 
 bridge.on('nostr.requests.present', ({ payload }) => {
-  return markPresented(payload.id) as unknown as BridgeResponsePayload<'nostr.requests.present'>;
+  return markPresented(payload.requestId) as unknown as BridgeResponsePayload<'nostr.requests.present'>;
 });
 
 // Decisions name a request id. The queue refuses unknown, already-terminal, and expired ids, so
 // a panel acting on stale state changes nothing (ADR D5).
 bridge.on('nostr.requests.respond', ({ payload }) => {
-  return submitDecision(payload.id, {
+  return submitDecision(payload.requestId, {
     approved: payload.approved,
     duration: payload.duration,
   }) as unknown as BridgeResponsePayload<'nostr.requests.respond'>;
+});
+
+// Reviewable content is read from the live worker, never from storage. A restarted worker has
+// none, which matches the request being interrupted anyway (D6, D7).
+bridge.on('nostr.requests.content', ({ payload }) => {
+  return getRequestContent(payload.requestId);
 });
 
 bridge.on('nostr.requests.requeuePresented', () => {
@@ -452,6 +460,10 @@ interface ApprovalRequestDetails {
   contentDescription?: string;
   allowRemember?: boolean;
   skipPermissionCheck?: boolean;
+  /** Full unsigned event, for `sign_event`. Held in memory only, never persisted (D6). */
+  event?: UnsignedEvent;
+  /** Counterparty for encryption and decryption requests. Never the plaintext. */
+  counterpartyPubkey?: string;
 }
 
 const trimApprovalContentDescription = (content?: string): string | undefined => {
@@ -479,6 +491,16 @@ async function requestApproval(
     // StoredKey carries no public key, and deriving one would need an unlocked vault and key
     // material for a display field. #116 owns the account dimension and populates this.
     accountPubkey: null,
+  }, {
+    // Reviewable detail stays in worker memory for the life of the request.
+    ...(details.contentDescription !== undefined
+      ? { contentDescription: details.contentDescription }
+      : {}),
+    ...(details.event !== undefined ? { event: details.event } : {}),
+    ...(details.counterpartyPubkey !== undefined
+      ? { counterpartyPubkey: details.counterpartyPubkey }
+      : {}),
+    allowRemember: details.allowRemember !== false,
   });
 
   // A locked vault no longer opens its own window: the panel presents the unlock view with the
@@ -540,8 +562,8 @@ bridge.on('nostr.signEvent', ({ payload: { event, origin } }) => (
     void logService.logApproval(event.kind, getHostname(origin), activeStoredKey?.alias);
     const contentDescription = trimApprovalContentDescription(event.content);
     const approvalDetails: ApprovalRequestDetails = contentDescription
-      ? { requestType: 'sign_event', contentDescription }
-      : { requestType: 'sign_event' };
+      ? { requestType: 'sign_event', contentDescription, event }
+      : { requestType: 'sign_event', event };
     const approved = await requestApproval(origin, event.kind, approvalDetails);
     if (!approved) {
       const unlockedStatus = await handleVaultIsUnlocked({}, '');
@@ -583,7 +605,7 @@ bridge.on('nostr.nip04.encrypt', ({ payload }) => (
   (async () => {
     const activeStoredKey = await getActiveStoredKey();
     void logService.logApproval('nip04_encrypt', getHostname(payload.origin), activeStoredKey?.alias);
-    const approved = await requestApproval(payload.origin, -1, { requestType: 'nip04_encrypt' });
+    const approved = await requestApproval(payload.origin, -1, { requestType: 'nip04_encrypt', counterpartyPubkey: payload.pubkey });
     if (!approved) {
       const unlockedStatus = await handleVaultIsUnlocked({}, '');
       if (!unlockedStatus.success || !unlockedStatus.data) throw new Error('Vault is locked. Open the extension to unlock.');
@@ -597,7 +619,7 @@ bridge.on('nostr.nip04.decrypt', ({ payload }) => (
   (async () => {
     const activeStoredKey = await getActiveStoredKey();
     void logService.logApproval('nip04_decrypt', getHostname(payload.origin), activeStoredKey?.alias);
-    const approved = await requestApproval(payload.origin, -1, { requestType: 'nip04_decrypt' });
+    const approved = await requestApproval(payload.origin, -1, { requestType: 'nip04_decrypt', counterpartyPubkey: payload.pubkey });
     if (!approved) {
       const unlockedStatus = await handleVaultIsUnlocked({}, '');
       if (!unlockedStatus.success || !unlockedStatus.data) throw new Error('Vault is locked. Open the extension to unlock.');
@@ -611,7 +633,7 @@ bridge.on('nostr.nip44.encrypt', ({ payload }) => (
   (async () => {
     const activeStoredKey = await getActiveStoredKey();
     void logService.logApproval('nip44_encrypt', getHostname(payload.origin), activeStoredKey?.alias);
-    const approved = await requestApproval(payload.origin, -1, { requestType: 'nip44_encrypt' });
+    const approved = await requestApproval(payload.origin, -1, { requestType: 'nip44_encrypt', counterpartyPubkey: payload.pubkey });
     if (!approved) {
       const unlockedStatus = await handleVaultIsUnlocked({}, '');
       if (!unlockedStatus.success || !unlockedStatus.data) throw new Error('Vault is locked. Open the extension to unlock.');
@@ -625,7 +647,7 @@ bridge.on('nostr.nip44.decrypt', ({ payload }) => (
   (async () => {
     const activeStoredKey = await getActiveStoredKey();
     void logService.logApproval('nip44_decrypt', getHostname(payload.origin), activeStoredKey?.alias);
-    const approved = await requestApproval(payload.origin, -1, { requestType: 'nip44_decrypt' });
+    const approved = await requestApproval(payload.origin, -1, { requestType: 'nip44_decrypt', counterpartyPubkey: payload.pubkey });
     if (!approved) {
       const unlockedStatus = await handleVaultIsUnlocked({}, '');
       if (!unlockedStatus.success || !unlockedStatus.data) throw new Error('Vault is locked. Open the extension to unlock.');

--- a/src-bex/services/request-queue.ts
+++ b/src-bex/services/request-queue.ts
@@ -16,6 +16,7 @@ import { REQUEST_EXPIRY_MINUTES } from 'src/services/storage-service';
 import { LogLevel, logService } from 'src/services/log-service';
 import {
   TERMINAL_REQUEST_STATES,
+  type ApprovalRequestContent,
   type ApprovalDecision,
   type ApprovalRequestRecord,
   type ApprovalRequestState,
@@ -42,6 +43,24 @@ interface PendingCallback {
  * whose callback is gone must never be signable (D7).
  */
 const liveCallbacks = new Map<string, PendingCallback>();
+
+/**
+ * Reviewable content, keyed by request id.
+ *
+ * Deliberately memory-only and dropped as soon as a request reaches a terminal state. Event
+ * content, plaintext, ciphertext, and invoices must never reach durable storage (D6, SR-14), so
+ * the panel reads them from the live worker or not at all.
+ */
+const requestContent = new Map<string, ApprovalRequestContent>();
+
+const forgetRequest = (id: string): void => {
+  liveCallbacks.delete(id);
+  requestContent.delete(id);
+};
+
+/** Reviewable detail for a request, or null once it has been resolved or the worker restarted. */
+export const getRequestContent = (id: string): ApprovalRequestContent | null =>
+  requestContent.get(id) ?? null;
 
 const isTerminal = (state: ApprovalRequestState): boolean =>
   TERMINAL_REQUEST_STATES.includes(state);
@@ -96,7 +115,7 @@ const loadQueue = async (now: number = Date.now()): Promise<ApprovalRequestRecor
     await writeRecords(records.map(toDurableRecord));
     for (const record of expired) {
       const callback = liveCallbacks.get(record.id);
-      liveCallbacks.delete(record.id);
+      forgetRequest(record.id);
       callback?.settle({ approved: false, duration: 'once' });
     }
   }
@@ -175,6 +194,7 @@ export const requeuePresented = async (now: number = Date.now()): Promise<void> 
  */
 export const enqueueRequest = async (
   input: EnqueueRequestInput,
+  content: ApprovalRequestContent = { allowRemember: true },
   now: number = Date.now(),
 ): Promise<{ record: ApprovalRequestRecord; decision: Promise<ApprovalDecision> }> => {
   const expiryMinutes = await resolveExpiryMinutes();
@@ -193,6 +213,8 @@ export const enqueueRequest = async (
 
   const records = await loadQueue(now);
   await writeRecords([...records, record].map(toDurableRecord));
+
+  requestContent.set(record.id, content);
 
   const decision = new Promise<ApprovalDecision>((resolve, reject) => {
     liveCallbacks.set(record.id, {
@@ -243,7 +265,7 @@ export const submitDecision = async (
   );
 
   const callback = liveCallbacks.get(id);
-  liveCallbacks.delete(id);
+  forgetRequest(id);
   callback?.settle(decision);
 
   return { applied: true, record: updated };
@@ -264,6 +286,7 @@ export const reconcileInterruptedRequests = async (
   const next = records.map((record) => {
     if (isTerminal(record.state) || liveCallbacks.has(record.id)) return record;
     const updated: ApprovalRequestRecord = { ...record, state: 'interrupted' };
+    forgetRequest(record.id);
     interrupted.push(updated);
     return updated;
   });
@@ -290,4 +313,5 @@ export const pruneResolvedRequests = async (now: number = Date.now()): Promise<v
 /** Test seam: clear in-memory callbacks. Not used by production code. */
 export const __resetLiveCallbacksForTests = (): void => {
   liveCallbacks.clear();
+  requestContent.clear();
 };

--- a/src-bex/types/background.ts
+++ b/src-bex/types/background.ts
@@ -87,6 +87,23 @@ export interface ApprovalRequestRecord {
   state: ApprovalRequestState;
 }
 
+/**
+ * Reviewable detail for a queued request.
+ *
+ * Memory-only, never persisted: event content, plaintext, ciphertext, and invoices are excluded
+ * from durable storage by D6, and the panel reads them from the live service worker instead.
+ */
+export interface ApprovalRequestContent {
+  /** Short human-readable summary shown before the user expands anything. */
+  contentDescription?: string;
+  /** The complete unsigned event, for `sign_event` requests only. */
+  event?: UnsignedEvent;
+  /** Counterparty for encryption and decryption requests. Never the plaintext itself. */
+  counterpartyPubkey?: string;
+  /** Whether durations beyond `once` may be offered at all (payments never may). */
+  allowRemember: boolean;
+}
+
 /** Approval durations the user can choose. */
 export type ApprovalDuration = 'once' | '8h' | 'always';
 

--- a/src/components/sidebar/CurrentRequest.vue
+++ b/src/components/sidebar/CurrentRequest.vue
@@ -1,0 +1,133 @@
+<script lang="ts" setup>
+import { computed, nextTick, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import RequestOriginHeader from './RequestOriginHeader.vue';
+import RequestPreview from './RequestPreview.vue';
+import RequestRiskWarning from './RequestRiskWarning.vue';
+import RequestDecisionBar from './RequestDecisionBar.vue';
+import {
+  classifyRequest,
+  getEventKindLabel,
+  getRequestTypeLabel,
+} from 'src/services/approval-preview';
+import type {
+  ApprovalDuration,
+  ApprovalRequestContent,
+  ApprovalRequestRecord,
+} from 'app/src-bex/types/background';
+
+defineOptions({ name: 'CurrentRequest' });
+
+const props = defineProps<{
+  request: ApprovalRequestRecord;
+  content: ApprovalRequestContent | null;
+  busy?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (event: 'decide', id: string, approved: boolean, duration: ApprovalDuration): void;
+}>();
+
+const { t } = useI18n();
+
+const heading = ref<HTMLElement | null>(null);
+
+const riskClass = computed(() => classifyRequest(props.request.requestType, props.request.eventKind));
+
+const requestTypeLabel = computed(() => getRequestTypeLabel(props.request.requestType));
+
+const kindLabel = computed(() =>
+  props.request.eventKind >= 0 ? getEventKindLabel(props.request.eventKind) : null,
+);
+
+const isTerminal = computed(() =>
+  props.request.state === 'expired' || props.request.state === 'interrupted',
+);
+
+// Focus lands on the heading, never on an approve control (NFR-2).
+watch(
+  () => props.request.id,
+  async () => {
+    await nextTick();
+    heading.value?.focus();
+  },
+  { immediate: true },
+);
+</script>
+
+<template>
+  <article class="current-request">
+    <h2 ref="heading" tabindex="-1" class="current-request__heading">
+      {{ requestTypeLabel }}
+    </h2>
+
+    <RequestOriginHeader :origin="request.origin" :account-alias="request.accountAlias" />
+
+    <div v-if="kindLabel" class="current-request__kind">
+      <span class="current-request__kind-label">{{ t('request.kind') }}</span>
+      <span class="current-request__kind-value">{{ kindLabel }}</span>
+    </div>
+
+    <RequestRiskWarning :risk-class="riskClass" :event-kind="request.eventKind" />
+
+    <!-- A terminal request shows why it cannot be acted on, and offers no approval control. -->
+    <div v-if="isTerminal" class="current-request__terminal" role="status">
+      {{
+        request.state === 'expired'
+          ? t('request.states.expired')
+          : t('request.states.interrupted')
+      }}
+    </div>
+
+    <template v-else>
+      <RequestPreview :content="content" :risk-class="riskClass" />
+      <RequestDecisionBar
+        :risk-class="riskClass"
+        :allow-remember="content?.allowRemember ?? false"
+        :busy="busy"
+        @decide="(approved, duration) => emit('decide', request.id, approved, duration)"
+      />
+    </template>
+  </article>
+</template>
+
+<style scoped>
+.current-request {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  min-width: 0;
+}
+
+.current-request__heading {
+  margin: 0;
+  font-size: 1rem;
+  outline: none;
+}
+
+.current-request__kind {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 0.8rem;
+}
+
+.current-request__kind-label {
+  color: var(--text-muted, #888);
+}
+
+.current-request__kind-value {
+  font-weight: 600;
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.current-request__terminal {
+  padding: 8px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  font-size: 0.85rem;
+}
+</style>

--- a/src/components/sidebar/PendingRequestList.vue
+++ b/src/components/sidebar/PendingRequestList.vue
@@ -1,0 +1,95 @@
+<script lang="ts" setup>
+import { useI18n } from 'vue-i18n';
+
+import { getRequestTypeLabel } from 'src/services/approval-preview';
+import type { ApprovalRequestRecord } from 'app/src-bex/types/background';
+
+defineOptions({ name: 'PendingRequestList' });
+
+defineProps<{
+  requests: ApprovalRequestRecord[];
+  currentId: string | null;
+}>();
+
+const emit = defineEmits<{
+  (event: 'select', id: string): void;
+}>();
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <section v-if="requests.length > 1" class="pending-list">
+    <!-- Polite, not assertive: arrivals must not interrupt a review in progress (NFR-4). -->
+    <h3 class="pending-list__title" aria-live="polite">
+      {{ t('request.pending.title', { count: requests.length }) }}
+    </h3>
+    <ul class="pending-list__items">
+      <li v-for="request in requests" :key="request.id">
+        <button
+          type="button"
+          class="pending-list__item"
+          :class="{ 'pending-list__item--current': request.id === currentId }"
+          @click="emit('select', request.id)"
+        >
+          <span class="pending-list__origin">{{ request.origin }}</span>
+          <span class="pending-list__type">{{ getRequestTypeLabel(request.requestType) }}</span>
+        </button>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<style scoped>
+.pending-list {
+  padding: 0 12px 12px;
+  min-width: 0;
+}
+
+.pending-list__title {
+  margin: 0 0 6px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted, #888);
+}
+
+.pending-list__items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pending-list__item {
+  width: 100%;
+  text-align: left;
+  padding: 6px 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  min-width: 0;
+}
+
+.pending-list__item--current {
+  border-color: var(--q-primary, #6a4cff);
+}
+
+.pending-list__origin {
+  display: block;
+  font-weight: 600;
+  font-size: 0.8rem;
+  overflow-wrap: anywhere;
+}
+
+.pending-list__type {
+  display: block;
+  font-size: 0.72rem;
+  color: var(--text-muted, #888);
+}
+</style>

--- a/src/components/sidebar/RequestDecisionBar.vue
+++ b/src/components/sidebar/RequestDecisionBar.vue
@@ -1,0 +1,127 @@
+<script lang="ts" setup>
+import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { getAllowedDurations, type RequestRiskClass } from 'src/services/approval-preview';
+import type { ApprovalDuration } from 'app/src-bex/types/background';
+
+defineOptions({ name: 'RequestDecisionBar' });
+
+const props = defineProps<{
+  riskClass: RequestRiskClass;
+  allowRemember: boolean;
+  busy?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (event: 'decide', approved: boolean, duration: ApprovalDuration): void;
+}>();
+
+const { t } = useI18n();
+
+/**
+ * Options that are not available are absent rather than shown disabled: payments are one-time,
+ * unknown kinds may only be approved once, and elevated kinds are never granted `always`
+ * (ADR D11, D12).
+ */
+const allowed = computed(() => getAllowedDurations(props.riskClass, props.allowRemember));
+
+const duration = ref<ApprovalDuration>('once');
+
+watch(
+  allowed,
+  (options) => {
+    // Nothing beyond `once` is ever pre-selected.
+    if (!options.includes(duration.value)) duration.value = 'once';
+  },
+  { immediate: true },
+);
+
+const durationOptions = computed(() =>
+  allowed.value.map((value) => ({
+    label: t(`request.durations.${value === '8h' ? 'eightHours' : value}`),
+    value,
+  })),
+);
+</script>
+
+<template>
+  <div class="decision-bar">
+    <div v-if="allowed.length > 1" class="decision-bar__duration">
+      <label class="decision-bar__label" for="approval-duration">
+        {{ t('request.durations.label') }}
+      </label>
+      <q-select
+        id="approval-duration"
+        v-model="duration"
+        :options="durationOptions"
+        dense
+        outlined
+        emit-value
+        map-options
+        options-dense
+      />
+    </div>
+    <p v-else class="decision-bar__single">{{ t('request.durations.onceOnly') }}</p>
+
+    <div class="decision-bar__actions">
+      <q-btn
+        no-caps
+        class="diogel-btn-danger"
+        :disable="busy"
+        :label="t('request.reject')"
+        @click="emit('decide', false, 'once')"
+      />
+      <q-btn
+        no-caps
+        class="diogel-btn-primary"
+        :disable="busy"
+        :label="t('request.approve')"
+        @click="emit('decide', true, duration)"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/*
+ * Pinned to the bottom of the request view: content scrolls, the controls do not scroll away,
+ * however long the event is (specification §7, NFR-12).
+ */
+.decision-bar {
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 0 0;
+  background: var(--page-bg);
+  border-top: 1px solid var(--border-color);
+}
+
+.decision-bar__label {
+  display: block;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted, #888);
+  margin-bottom: 4px;
+}
+
+.decision-bar__single {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--text-muted, #888);
+}
+
+/* Reject comes first in reading order (specification §7). */
+.decision-bar__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.decision-bar__actions .q-btn {
+  flex: 1 1 0;
+  min-width: 0;
+}
+</style>

--- a/src/components/sidebar/RequestOriginHeader.vue
+++ b/src/components/sidebar/RequestOriginHeader.vue
@@ -1,0 +1,95 @@
+<script lang="ts" setup>
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+defineOptions({ name: 'RequestOriginHeader' });
+
+const props = defineProps<{
+  origin: string;
+  accountAlias: string | null;
+}>();
+
+const { t } = useI18n();
+
+/**
+ * The origin is rendered from the origin string itself. No favicon, title, or metadata is
+ * fetched from anywhere: an approval must not disclose which site the user is transacting with
+ * (ADR D13).
+ */
+const hostname = computed(() => {
+  try {
+    return new URL(props.origin).hostname;
+  } catch {
+    return props.origin;
+  }
+});
+
+const isSecure = computed(() => props.origin.startsWith('https://'));
+
+const initials = computed(() => hostname.value.replace(/^www\./, '').slice(0, 2).toUpperCase());
+</script>
+
+<template>
+  <section class="request-origin" :aria-label="t('request.origin.ariaLabel')">
+    <div class="request-origin__badge" aria-hidden="true">{{ initials }}</div>
+    <div class="request-origin__detail">
+      <div class="request-origin__label">{{ t('request.origin.label') }}</div>
+      <div class="request-origin__value">{{ origin }}</div>
+      <div v-if="!isSecure" class="request-origin__insecure">
+        <q-icon name="warning" size="xs" />
+        {{ t('request.origin.insecure') }}
+      </div>
+      <div class="request-origin__label q-mt-sm">{{ t('request.account.label') }}</div>
+      <div class="request-origin__value">
+        {{ accountAlias ?? t('request.account.none') }}
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.request-origin {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  min-width: 0;
+}
+
+.request-origin__badge {
+  flex: 0 0 auto;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.8rem;
+  background: var(--header-bg);
+  border: 1px solid var(--border-color);
+}
+
+.request-origin__detail {
+  min-width: 0;
+}
+
+.request-origin__label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted, #888);
+}
+
+.request-origin__value {
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+.request-origin__insecure {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.75rem;
+  color: var(--q-warning, #b26a00);
+}
+</style>

--- a/src/components/sidebar/RequestPreview.vue
+++ b/src/components/sidebar/RequestPreview.vue
@@ -1,0 +1,163 @@
+<script lang="ts" setup>
+import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import {
+  formatEventFields,
+  shouldDefaultToFullEvent,
+  truncateForPreview,
+  type RequestRiskClass,
+} from 'src/services/approval-preview';
+import type { ApprovalRequestContent } from 'app/src-bex/types/background';
+
+defineOptions({ name: 'RequestPreview' });
+
+const props = defineProps<{
+  content: ApprovalRequestContent | null;
+  riskClass: RequestRiskClass;
+}>();
+
+const { t } = useI18n();
+
+type PreviewMode = 'formatted' | 'raw' | 'full';
+
+const mode = ref<PreviewMode>('formatted');
+const expanded = ref(false);
+
+// Unknown kinds open on the full event, because the formatted view cannot explain something
+// Porwr does not recognise (ADR D12).
+watch(
+  () => props.riskClass,
+  (riskClass) => {
+    mode.value = shouldDefaultToFullEvent(riskClass) ? 'full' : 'formatted';
+  },
+  { immediate: true },
+);
+
+const event = computed(() => props.content?.event ?? null);
+
+const rawContent = computed(() => event.value?.content ?? props.content?.contentDescription ?? '');
+
+const truncated = computed(() => truncateForPreview(rawContent.value));
+
+const shownContent = computed(() =>
+  expanded.value ? rawContent.value : truncated.value.text,
+);
+
+const formattedFields = computed(() => (event.value ? formatEventFields(event.value) : []));
+
+const fullEventJson = computed(() =>
+  event.value ? JSON.stringify(event.value, null, 2) : '',
+);
+</script>
+
+<template>
+  <section class="request-preview" :aria-label="t('request.preview.ariaLabel')">
+    <q-btn-toggle
+      v-if="event"
+      v-model="mode"
+      dense
+      no-caps
+      unelevated
+      spread
+      class="request-preview__modes"
+      :options="[
+        { label: t('request.preview.formatted'), value: 'formatted' },
+        { label: t('request.preview.raw'), value: 'raw' },
+        { label: t('request.preview.full'), value: 'full' },
+      ]"
+    />
+
+    <div v-if="mode === 'formatted'" class="request-preview__body">
+      <div v-for="field in formattedFields" :key="field.label" class="request-preview__field">
+        <span class="request-preview__field-label">{{ field.label }}</span>
+        <span class="request-preview__field-value">{{ field.value }}</span>
+      </div>
+      <p v-if="shownContent" class="request-preview__content">{{ shownContent }}</p>
+      <p v-else-if="content?.counterpartyPubkey" class="request-preview__content">
+        {{ t('request.preview.counterparty', { pubkey: content.counterpartyPubkey }) }}
+      </p>
+    </div>
+
+    <pre v-else-if="mode === 'raw'" class="request-preview__pre">{{ shownContent }}</pre>
+
+    <pre v-else class="request-preview__pre">{{ fullEventJson }}</pre>
+
+    <!-- Truncation is never silent: the user is told and can expand. -->
+    <q-btn
+      v-if="truncated.truncated && mode !== 'full'"
+      flat
+      dense
+      no-caps
+      size="sm"
+      class="request-preview__expand"
+      :label="
+        expanded
+          ? t('request.preview.collapse')
+          : t('request.preview.expand', { count: truncated.fullLength })
+      "
+      @click="expanded = !expanded"
+    />
+  </section>
+</template>
+
+<style scoped>
+.request-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.request-preview__modes {
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+}
+
+.request-preview__body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.request-preview__field {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 0.8rem;
+}
+
+.request-preview__field-label {
+  color: var(--text-muted, #888);
+}
+
+.request-preview__field-value {
+  font-weight: 600;
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.request-preview__content {
+  margin: 4px 0 0;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+/* Wide content scrolls inside its own box rather than widening the panel. */
+.request-preview__pre {
+  margin: 0;
+  padding: 8px;
+  max-height: 220px;
+  overflow: auto;
+  font-size: 0.75rem;
+  background: var(--header-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.request-preview__expand {
+  align-self: flex-start;
+}
+</style>

--- a/src/components/sidebar/RequestRiskWarning.vue
+++ b/src/components/sidebar/RequestRiskWarning.vue
@@ -1,0 +1,46 @@
+<script lang="ts" setup>
+import { computed } from 'vue';
+
+import { getRiskWarning, type RequestRiskClass } from 'src/services/approval-preview';
+
+defineOptions({ name: 'RequestRiskWarning' });
+
+const props = defineProps<{
+  riskClass: RequestRiskClass;
+  eventKind: number;
+}>();
+
+const warning = computed(() => getRiskWarning(props.riskClass, props.eventKind));
+</script>
+
+<template>
+  <!--
+    Part of the request body rather than a dismissible banner, and it names the specific effect
+    rather than warning in general terms (ADR D12). Not colour-only: it carries an icon and text.
+  -->
+  <div v-if="warning" class="risk-warning" :class="`risk-warning--${riskClass}`" role="note">
+    <q-icon name="report_problem" size="sm" aria-hidden="true" />
+    <span>{{ warning }}</span>
+  </div>
+</template>
+
+<style scoped>
+.risk-warning {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  padding: 8px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--border-color);
+  font-size: 0.8rem;
+  overflow-wrap: anywhere;
+}
+
+.risk-warning--elevated {
+  border-color: var(--q-warning, #b26a00);
+}
+
+.risk-warning--unknown {
+  border-color: var(--q-negative, #c10015);
+}
+</style>

--- a/src/components/sidebar/SidebarUnlock.vue
+++ b/src/components/sidebar/SidebarUnlock.vue
@@ -1,0 +1,114 @@
+<script lang="ts" setup>
+import { useI18n } from 'vue-i18n';
+
+import { useVault } from 'src/composables/useVault';
+import type { ApprovalRequestRecord } from 'app/src-bex/types/background';
+
+defineOptions({ name: 'SidebarUnlock' });
+
+defineProps<{
+  waitingRequest: ApprovalRequestRecord | null;
+}>();
+
+const emit = defineEmits<{
+  (event: 'reject', id: string): void;
+}>();
+
+const { t } = useI18n();
+const { vaultStore, password, loading, loginError, handleUnlock } = useVault();
+</script>
+
+<template>
+  <section class="sidebar-unlock" :aria-label="t('sidebar.unlock.ariaLabel')">
+    <h2 class="sidebar-unlock__title">{{ t('sidebar.unlock.title') }}</h2>
+
+    <!--
+      A waiting request is named, but its content is not shown before the vault is unlocked
+      (specification §8). Unlocking never approves it (ADR D14).
+    -->
+    <div v-if="waitingRequest" class="sidebar-unlock__waiting">
+      <p class="sidebar-unlock__waiting-text">
+        {{ t('sidebar.unlock.waiting', { origin: waitingRequest.origin }) }}
+      </p>
+      <p class="sidebar-unlock__waiting-note">{{ t('sidebar.unlock.noAutoApprove') }}</p>
+    </div>
+
+    <q-input
+      v-model="password"
+      filled
+      dense
+      type="password"
+      :label="t('sidebar.unlock.password')"
+      @keyup.enter="handleUnlock"
+    />
+
+    <div v-if="loginError" class="sidebar-unlock__error">{{ loginError }}</div>
+
+    <div class="sidebar-unlock__actions">
+      <!-- Reject stays available while locked: it must not require unlocking first (FR-10). -->
+      <q-btn
+        v-if="waitingRequest"
+        no-caps
+        flat
+        class="diogel-btn-danger"
+        :label="t('request.reject')"
+        @click="emit('reject', waitingRequest.id)"
+      />
+      <q-btn
+        no-caps
+        class="diogel-btn-primary"
+        :loading="loading"
+        :disable="!vaultStore.vaultExists"
+        :label="t('sidebar.unlock.action')"
+        @click="handleUnlock"
+      />
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.sidebar-unlock {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  min-width: 0;
+}
+
+.sidebar-unlock__title {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.sidebar-unlock__waiting {
+  padding: 8px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+}
+
+.sidebar-unlock__waiting-text {
+  margin: 0;
+  font-size: 0.85rem;
+  overflow-wrap: anywhere;
+}
+
+.sidebar-unlock__waiting-note {
+  margin: 4px 0 0;
+  font-size: 0.75rem;
+  color: var(--text-muted, #888);
+}
+
+.sidebar-unlock__error {
+  color: var(--q-negative, #c10015);
+  font-size: 0.8rem;
+}
+
+.sidebar-unlock__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.sidebar-unlock__actions .q-btn {
+  flex: 1 1 0;
+}
+</style>

--- a/src/composables/useApprovalQueue.ts
+++ b/src/composables/useApprovalQueue.ts
@@ -1,0 +1,105 @@
+import { computed, onMounted, onUnmounted, ref, type Ref } from 'vue';
+
+import { sendBexMessage } from 'src/services/bridge-client';
+import { LogLevel, logService } from 'src/services/log-service';
+import type {
+  ApprovalDuration,
+  ApprovalRequestContent,
+  ApprovalRequestRecord,
+  DecisionResult,
+} from 'app/src-bex/types/background';
+
+/**
+ * Panel-side view of the background request queue.
+ *
+ * The panel observes and submits decisions; the background owns lifecycle (ADR D1). Nothing here
+ * caches authoritative state: every decision is followed by a refresh from the background, so a
+ * request that expired or was interrupted meanwhile cannot linger on screen as actionable.
+ */
+
+const POLL_INTERVAL_MS = 1000;
+
+export interface UseApprovalQueueResult {
+  pending: Ref<ApprovalRequestRecord[]>;
+  current: Ref<ApprovalRequestRecord | null>;
+  content: Ref<ApprovalRequestContent | null>;
+  pendingCount: Ref<number>;
+  loading: Ref<boolean>;
+  refresh: () => Promise<void>;
+  decide: (id: string, approved: boolean, duration: ApprovalDuration) => Promise<DecisionResult>;
+}
+
+export function useApprovalQueue(): UseApprovalQueueResult {
+  const pending = ref<ApprovalRequestRecord[]>([]);
+  const current = ref<ApprovalRequestRecord | null>(null);
+  const content = ref<ApprovalRequestContent | null>(null);
+  const loading = ref(true);
+  const pendingCount = computed(() => pending.value.length) as unknown as Ref<number>;
+
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  const loadContent = async (id: string | undefined): Promise<void> => {
+    if (!id) {
+      content.value = null;
+      return;
+    }
+    content.value = (await sendBexMessage('nostr.requests.content', { requestId: id })) ?? null;
+  };
+
+  const refresh = async (): Promise<void> => {
+    try {
+      const records = (await sendBexMessage('nostr.requests.list')) ?? [];
+      pending.value = records;
+
+      const next = (await sendBexMessage('nostr.requests.current')) ?? null;
+      const changed = next?.id !== current.value?.id;
+      current.value = next;
+
+      if (next && next.state !== 'presented') {
+        await sendBexMessage('nostr.requests.present', { requestId: next.id });
+      }
+      if (changed) {
+        await loadContent(next?.id);
+      }
+    } catch (error: unknown) {
+      logService.log(LogLevel.DEBUG, '[Panel] Failed to refresh request queue', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  const decide = async (
+    id: string,
+    approved: boolean,
+    duration: ApprovalDuration,
+  ): Promise<DecisionResult> => {
+    const result = (await sendBexMessage('nostr.requests.respond', {
+      requestId: id,
+      approved,
+      duration,
+    })) ?? { applied: false as const, reason: 'unknown-request' as const };
+
+    // Always re-read: the background is the authority on what happened, including refusals.
+    await refresh();
+    return result;
+  };
+
+  onMounted(() => {
+    void refresh();
+    timer = setInterval(() => {
+      void refresh();
+    }, POLL_INTERVAL_MS);
+  });
+
+  onUnmounted(() => {
+    if (timer !== undefined) clearInterval(timer);
+    // Closing the panel is never a decision: hand the request back to the queue (FR-6).
+    void sendBexMessage('nostr.requests.requeuePresented').catch(() => {
+      /* the background reconciles on its own if this never lands */
+    });
+  });
+
+  return { pending, current, content, pendingCount, loading, refresh, decide };
+}

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -515,7 +515,52 @@ export default {
       results_per_page: 'Results per page',
     },
   },
+  request: {
+    kind: 'Event kind',
+    approve: 'Approve',
+    reject: 'Reject',
+    origin: {
+      label: 'Requesting site',
+      ariaLabel: 'Requesting site and signing account',
+      insecure: 'This site is not using a secure connection.',
+    },
+    account: {
+      label: 'Signing account',
+      none: 'No active account',
+    },
+    preview: {
+      ariaLabel: 'What you are being asked to sign',
+      formatted: 'Summary',
+      raw: 'Raw',
+      full: 'Full event',
+      counterparty: 'Counterparty: {pubkey}',
+      expand: 'Show all {count} characters',
+      collapse: 'Show less',
+    },
+    durations: {
+      label: 'Remember this choice',
+      once: 'Just this once',
+      eightHours: 'For the next 8 hours',
+      always: 'Always for this site',
+      onceOnly: 'This request can only be approved once.',
+    },
+    pending: {
+      title: '{count} requests waiting',
+    },
+    states: {
+      expired: 'This request expired before it was answered. The site must ask again.',
+      interrupted: 'This request was interrupted and can no longer be approved. The site must ask again.',
+    },
+  },
   sidebar: {
+    unlock: {
+      ariaLabel: 'Unlock your vault',
+      title: 'Unlock Vault',
+      password: 'Password',
+      action: 'Unlock',
+      waiting: '{origin} is waiting for a decision.',
+      noAutoApprove: 'Unlocking does not approve it. You will still be asked.',
+    },
     activeSite: {
       label: 'Current tab',
       ariaLabel: 'Site in the active tab',

--- a/src/pages/SidebarHome.vue
+++ b/src/pages/SidebarHome.vue
@@ -1,11 +1,17 @@
 <script lang="ts" setup>
-import { computed, onMounted } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import useAccountStore from '../stores/account-store';
 import ProfileView from '../components/ProfileView.vue';
+import CurrentRequest from '../components/sidebar/CurrentRequest.vue';
+import PendingRequestList from '../components/sidebar/PendingRequestList.vue';
+import SidebarUnlock from '../components/sidebar/SidebarUnlock.vue';
 import { useActiveTab } from '../composables/useActiveTab';
+import { useApprovalQueue } from '../composables/useApprovalQueue';
 import { useVault } from '../composables/useVault';
+import useVaultStore from '../stores/vault-store';
+import type { ApprovalDuration } from 'app/src-bex/types/background';
 
 defineOptions({ name: 'SidebarHome' });
 
@@ -13,6 +19,36 @@ const { t } = useI18n();
 const accountStore = useAccountStore();
 const { activeOrigin } = useActiveTab();
 const { handleLock } = useVault();
+const vaultStore = useVaultStore();
+const { pending, current, content, decide, refresh } = useApprovalQueue();
+
+const busy = ref(false);
+
+/**
+ * Body precedence from the interaction specification §3: unlock, then the current request, then
+ * the pending list, then the idle view.
+ */
+const showUnlock = computed(() => !vaultStore.isUnlocked);
+
+async function onDecide(id: string, approved: boolean, duration: ApprovalDuration): Promise<void> {
+  busy.value = true;
+  try {
+    await decide(id, approved, duration);
+  } finally {
+    busy.value = false;
+  }
+}
+
+async function onSelect(id: string): Promise<void> {
+  await sendPresent(id);
+}
+
+async function sendPresent(id: string): Promise<void> {
+  const target = pending.value.find((request) => request.id === id);
+  if (!target) return;
+  current.value = target;
+  await refresh();
+}
 
 const activeStoredKey = computed(() => {
   const activeAlias = accountStore.activeKey;
@@ -32,10 +68,29 @@ onMounted(async () => {
 
 <template>
   <q-page class="sidebar-home">
-    <!--
-      Idle view. The unlock view and the request views take precedence over this body when they
-      exist; those regions belong to #114 and #115 (specification section 3).
-    -->
+    <!-- Unlock takes precedence over everything, and names any waiting request (S5, S15). -->
+    <SidebarUnlock
+      v-if="showUnlock"
+      :waiting-request="current"
+      @reject="(id) => onDecide(id, false, 'once')"
+    />
+
+    <template v-else-if="current">
+      <CurrentRequest
+        :request="current"
+        :content="content"
+        :busy="busy"
+        @decide="onDecide"
+      />
+      <PendingRequestList
+        :requests="pending"
+        :current-id="current.id"
+        @select="onSelect"
+      />
+    </template>
+
+    <template v-else>
+    <!-- Idle view: shown only when the vault is unlocked and nothing is waiting. -->
     <section v-if="activeOrigin" class="sidebar-home__context" :aria-label="t('sidebar.activeSite.ariaLabel')">
       <div class="sidebar-home__context-label">{{ t('sidebar.activeSite.label') }}</div>
       <div class="sidebar-home__context-origin">{{ activeOrigin }}</div>
@@ -65,6 +120,7 @@ onMounted(async () => {
         @click="openInTab('/keys')"
       />
     </div>
+    </template>
   </q-page>
 </template>
 

--- a/src/pages/SignerApproval.vue
+++ b/src/pages/SignerApproval.vue
@@ -11,7 +11,6 @@ const { t } = useI18n();
 const route = useRoute();
 
 const origin = ref('');
-const faviconUrl = ref('');
 const rememberChoice = ref('once');
 const kindType = ref('Unknown request');
 const requestTypeLabel = ref('Signer request');
@@ -84,15 +83,6 @@ onMounted(() => {
 
   logService.log(LogLevel.DEBUG, 'SignerApproval mounted, origin:', { origin: origin.value });
 
-  if (origin.value !== 'Unknown') {
-    try {
-      const url = new URL(origin.value);
-      faviconUrl.value = `https://www.google.com/s2/favicons?domain=${url.hostname}&sz=64`;
-    } catch (e) {
-      logService.log(LogLevel.ERROR, 'Failed to parse origin for favicon:', { error: e });
-    }
-  }
-
   if (!$q.bex) {
     logService.log(LogLevel.ERROR, 'BEX bridge NOT available');
   }
@@ -149,13 +139,9 @@ async function reject() {
 
       <q-card-section class="q-pt-none">
         <div class="row items-center q-mb-md">
+          <!-- No remote lookup: an approval must not disclose the site to a third party (D13). -->
           <q-avatar size="48px" class="q-mr-md" bordered>
-            <q-img v-if="faviconUrl" :src="faviconUrl">
-              <template #error>
-                <q-icon name="public" size="32px" color="grey-7" />
-              </template>
-            </q-img>
-            <q-icon v-else name="public" size="32px" color="grey-7" />
+            <q-icon name="public" size="32px" color="grey-7" />
           </q-avatar>
           <div>
             <div class="text-caption text-grey-7">

--- a/src/services/approval-preview.ts
+++ b/src/services/approval-preview.ts
@@ -1,0 +1,172 @@
+/**
+ * Approval presentation rules.
+ *
+ * Owns the labels, the event-kind risk classification, and the grant options each class may be
+ * offered (ADR D11, D12). Kept out of the components so the panel and any remaining approval
+ * surface describe a request identically, and so the rules are testable on their own.
+ */
+
+import type { ApprovalDuration } from 'app/src-bex/types/background';
+
+export type RequestRiskClass = 'standard' | 'elevated' | 'unknown' | 'payment';
+
+export interface UnsignedEventPreview {
+  kind: number;
+  content: string;
+  tags: string[][];
+  created_at: number;
+  pubkey?: string;
+}
+
+export const REQUEST_TYPE_LABELS: Readonly<Record<string, string>> = {
+  get_public_key: 'Public key request',
+  get_relays: 'Relay list request',
+  sign_event: 'Sign event request',
+  nip04_encrypt: 'NIP-04 encryption request',
+  nip04_decrypt: 'NIP-04 decryption request',
+  nip44_encrypt: 'NIP-44 encryption request',
+  nip44_decrypt: 'NIP-44 decryption request',
+  send_zap: 'Lightning zap payment request',
+  webln_enable: 'WebLN wallet access request',
+  webln_send_payment: 'WebLN payment request',
+};
+
+export const NOSTR_KIND_LABELS: Readonly<Record<number, string>> = {
+  0: 'Profile metadata',
+  1: 'Text note',
+  3: 'Contact list',
+  4: 'Encrypted direct message',
+  5: 'Event deletion',
+  6: 'Repost',
+  7: 'Reaction',
+  40: 'Channel creation',
+  41: 'Channel metadata',
+  42: 'Channel message',
+  44: 'Channel mute user',
+  1063: 'File metadata',
+  1984: 'Reporting',
+  9734: 'Zap request',
+  9735: 'Zap receipt',
+  10002: 'Relay list metadata',
+  22242: 'Client authentication',
+  30023: 'Long-form content',
+};
+
+/**
+ * Kinds that change identity-visible state or grant session access (D12).
+ *
+ * These are not the kinds users see most often; they are the ones where a standing grant does
+ * the most damage.
+ */
+export const ELEVATED_EVENT_KINDS: readonly number[] = [3, 5, 9734, 10002, 22242];
+
+const PAYMENT_REQUEST_TYPES: readonly string[] = ['webln_send_payment', 'send_zap'];
+
+/** Effects named in the warning, so the user is told what the kind actually does. */
+const ELEVATED_KIND_EFFECTS: Readonly<Record<number, string>> = {
+  3: 'replace the list of accounts you follow',
+  5: 'request deletion of events you previously published',
+  9734: 'authorise a Lightning payment',
+  10002: 'replace the list of relays your identity advertises',
+  22242: 'prove your identity to this site for a session',
+};
+
+export const isKnownEventKind = (kind: number): boolean =>
+  Object.prototype.hasOwnProperty.call(NOSTR_KIND_LABELS, kind);
+
+export const getRequestTypeLabel = (requestType: string): string =>
+  REQUEST_TYPE_LABELS[requestType] ?? 'Signer request';
+
+export const getEventKindLabel = (kind: number): string => {
+  if (!Number.isInteger(kind) || kind < 0) return 'No Nostr event kind';
+  const label = NOSTR_KIND_LABELS[kind];
+  return label ? `${label} (${kind})` : `Unrecognised event kind (${kind})`;
+};
+
+export const classifyRequest = (requestType: string, eventKind: number): RequestRiskClass => {
+  if (PAYMENT_REQUEST_TYPES.includes(requestType)) return 'payment';
+  // -1 means the request carries no event kind, not "any kind".
+  if (eventKind < 0) return 'standard';
+  if (ELEVATED_EVENT_KINDS.includes(eventKind)) return 'elevated';
+  if (!isKnownEventKind(eventKind)) return 'unknown';
+  return 'standard';
+};
+
+export const getRiskWarning = (
+  riskClass: RequestRiskClass,
+  eventKind: number,
+): string | undefined => {
+  if (riskClass === 'elevated') {
+    const effect = ELEVATED_KIND_EFFECTS[eventKind];
+    return effect
+      ? `Approving this lets the site ${effect}.`
+      : 'This request has a lasting effect on your identity.';
+  }
+  if (riskClass === 'unknown') {
+    return 'Porwr does not recognise this event kind. Read the full event before approving.';
+  }
+  return undefined;
+};
+
+/**
+ * Grant options a request may be offered.
+ *
+ * Payments are one-time whatever else is true (D11). Unknown kinds may only be approved once, and
+ * elevated kinds may never be granted `always` (D12). Options that are not available are omitted
+ * rather than shown disabled.
+ */
+export const getAllowedDurations = (
+  riskClass: RequestRiskClass,
+  allowRemember: boolean,
+): ApprovalDuration[] => {
+  if (!allowRemember || riskClass === 'payment' || riskClass === 'unknown') return ['once'];
+  if (riskClass === 'elevated') return ['once', '8h'];
+  return ['once', '8h', 'always'];
+};
+
+/** Whether the full event should be open by default rather than the formatted summary (D12). */
+export const shouldDefaultToFullEvent = (riskClass: RequestRiskClass): boolean =>
+  riskClass === 'unknown';
+
+export interface FormattedEventField {
+  label: string;
+  value: string;
+}
+
+/** Human-readable view of the meaningful fields, for the formatted preview mode. */
+export const formatEventFields = (event: UnsignedEventPreview): FormattedEventField[] => {
+  const fields: FormattedEventField[] = [
+    { label: 'Kind', value: getEventKindLabel(event.kind) },
+    { label: 'Created', value: new Date(event.created_at * 1000).toLocaleString() },
+  ];
+
+  const mentions = event.tags.filter((tag) => tag[0] === 'p').length;
+  if (mentions > 0) fields.push({ label: 'Mentions', value: String(mentions) });
+
+  const references = event.tags.filter((tag) => tag[0] === 'e').length;
+  if (references > 0) fields.push({ label: 'References events', value: String(references) });
+
+  if (event.tags.length > 0) fields.push({ label: 'Tags', value: String(event.tags.length) });
+
+  return fields;
+};
+
+export const MAX_PREVIEW_CHARACTERS = 600;
+
+export interface TruncatedContent {
+  text: string;
+  truncated: boolean;
+  fullLength: number;
+}
+
+/** Truncation is always visible to the user; nothing is silently shortened (specification §6). */
+export const truncateForPreview = (
+  content: string,
+  limit: number = MAX_PREVIEW_CHARACTERS,
+): TruncatedContent => {
+  const normalized = content ?? '';
+  if (normalized.length <= limit) {
+    return { text: normalized, truncated: false, fullLength: normalized.length };
+  }
+  return { text: normalized.slice(0, limit), truncated: true, fullLength: normalized.length };
+};

--- a/src/types/bridge-types.d.ts
+++ b/src/types/bridge-types.d.ts
@@ -1,6 +1,7 @@
 import type { StoredKey } from './index.d';
 import type {
   ApprovalDuration,
+  ApprovalRequestContent,
   ApprovalRequestRecord,
   DecisionResult,
 } from 'app/src-bex/types/background';
@@ -112,6 +113,7 @@ export type BridgeAction =
   | 'nostr.requests.count'
   | 'nostr.requests.present'
   | 'nostr.requests.respond'
+  | 'nostr.requests.content'
   | 'nostr.requests.requeuePresented'
   | 'relay.browser.list'
   | 'relay.browser.getStatus'
@@ -280,6 +282,11 @@ export interface BridgeRequestMap {
     approved: boolean;
     duration: ApprovalDuration;
   };
+  'nostr.requests.content': {
+    id: string;
+    action: 'nostr.requests.content';
+    requestId: string;
+  };
   'nostr.requests.requeuePresented': {
     id: string;
     action: 'nostr.requests.requeuePresented';
@@ -390,6 +397,7 @@ export interface BridgeResponseMap {
   'nostr.requests.count': number;
   'nostr.requests.present': ApprovalRequestRecord | null;
   'nostr.requests.respond': DecisionResult;
+  'nostr.requests.content': ApprovalRequestContent | null;
   'nostr.requests.requeuePresented': void;
   'relay.browser.list': RelayCatalogEntry[];
   'relay.browser.getStatus': RelayDiscoveryState | null;

--- a/tests/unit/services/approval-preview.test.ts
+++ b/tests/unit/services/approval-preview.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  classifyRequest,
+  ELEVATED_EVENT_KINDS,
+  formatEventFields,
+  getAllowedDurations,
+  getEventKindLabel,
+  getRequestTypeLabel,
+  getRiskWarning,
+  shouldDefaultToFullEvent,
+  truncateForPreview,
+} from 'src/services/approval-preview';
+
+describe('approval preview rules', () => {
+  describe('classification (D12)', () => {
+    it('treats known ordinary kinds as standard', () => {
+      expect(classifyRequest('sign_event', 1)).toBe('standard');
+      expect(classifyRequest('sign_event', 7)).toBe('standard');
+    });
+
+    it('treats the elevated kinds as elevated', () => {
+      for (const kind of ELEVATED_EVENT_KINDS) {
+        expect(classifyRequest('sign_event', kind)).toBe('elevated');
+      }
+    });
+
+    it('treats an unrecognised kind as unknown', () => {
+      expect(classifyRequest('sign_event', 31337)).toBe('unknown');
+    });
+
+    it('treats payment requests as payments whatever their kind', () => {
+      expect(classifyRequest('webln_send_payment', -1)).toBe('payment');
+      expect(classifyRequest('send_zap', 9734)).toBe('payment');
+    });
+
+    it('does not treat the no-kind sentinel as an unknown kind', () => {
+      // -1 means "this request has no event kind", not "any kind" and not "unrecognised".
+      expect(classifyRequest('get_public_key', -1)).toBe('standard');
+    });
+  });
+
+  describe('grant options (D11, D12)', () => {
+    it('offers all three durations for a standard request', () => {
+      expect(getAllowedDurations('standard', true)).toEqual(['once', '8h', 'always']);
+    });
+
+    it('never offers always for an elevated kind', () => {
+      expect(getAllowedDurations('elevated', true)).toEqual(['once', '8h']);
+    });
+
+    it('offers only once for an unknown kind', () => {
+      expect(getAllowedDurations('unknown', true)).toEqual(['once']);
+    });
+
+    it('offers only once for a payment, even when remembering is allowed', () => {
+      expect(getAllowedDurations('payment', true)).toEqual(['once']);
+    });
+
+    it('offers only once when the request forbids remembering', () => {
+      expect(getAllowedDurations('standard', false)).toEqual(['once']);
+    });
+  });
+
+  describe('warnings', () => {
+    it('names the specific effect for an elevated kind', () => {
+      expect(getRiskWarning('elevated', 5)).toContain('deletion');
+      expect(getRiskWarning('elevated', 3)).toContain('follow');
+      expect(getRiskWarning('elevated', 22242)).toContain('identity');
+    });
+
+    it('tells the user to read the full event for an unknown kind', () => {
+      expect(getRiskWarning('unknown', 31337)).toContain('full event');
+    });
+
+    it('says nothing for a standard request', () => {
+      expect(getRiskWarning('standard', 1)).toBeUndefined();
+    });
+
+    it('opens on the full event only for unknown kinds', () => {
+      expect(shouldDefaultToFullEvent('unknown')).toBe(true);
+      expect(shouldDefaultToFullEvent('standard')).toBe(false);
+      expect(shouldDefaultToFullEvent('elevated')).toBe(false);
+    });
+  });
+
+  describe('labels', () => {
+    it('labels known request types and falls back safely', () => {
+      expect(getRequestTypeLabel('sign_event')).toBe('Sign event request');
+      expect(getRequestTypeLabel('something_new')).toBe('Signer request');
+    });
+
+    it('marks an unrecognised kind as unrecognised rather than inventing a name', () => {
+      expect(getEventKindLabel(1)).toBe('Text note (1)');
+      expect(getEventKindLabel(31337)).toContain('Unrecognised');
+      expect(getEventKindLabel(-1)).toBe('No Nostr event kind');
+    });
+  });
+
+  describe('truncation', () => {
+    it('leaves short content alone', () => {
+      const result = truncateForPreview('short');
+      expect(result).toEqual({ text: 'short', truncated: false, fullLength: 5 });
+    });
+
+    it('reports truncation rather than hiding it', () => {
+      const content = 'x'.repeat(700);
+      const result = truncateForPreview(content);
+      expect(result.truncated).toBe(true);
+      expect(result.fullLength).toBe(700);
+      expect(result.text).toHaveLength(600);
+    });
+  });
+
+  describe('formatted fields', () => {
+    it('summarises the meaningful fields without exposing raw content', () => {
+      const fields = formatEventFields({
+        kind: 1,
+        content: 'hello world',
+        created_at: 1_700_000_000,
+        tags: [
+          ['p', 'abc'],
+          ['e', 'def'],
+        ],
+      });
+
+      const labels = fields.map((field) => field.label);
+      expect(labels).toContain('Kind');
+      expect(labels).toContain('Mentions');
+      expect(labels).toContain('References events');
+      expect(JSON.stringify(fields)).not.toContain('hello world');
+    });
+  });
+});

--- a/tests/unit/services/request-content.test.ts
+++ b/tests/unit/services/request-content.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  enqueueRequest,
+  getRequestContent,
+  reconcileInterruptedRequests,
+  submitDecision,
+  __resetLiveCallbacksForTests,
+} from 'app/src-bex/services/request-queue';
+import { REQUEST_QUEUE_KEY } from 'src/services/storage-service';
+import type { ApprovalRequestRecord } from 'app/src-bex/types/background';
+
+vi.mock('src/services/log-service', () => ({
+  LogLevel: { DEBUG: 0, INFO: 1, WARN: 2, ERROR: 3 },
+  logService: { log: vi.fn() },
+}));
+
+const store = new Map<string, unknown>();
+
+vi.mock('src/services/storage-service', async () => {
+  const actual = await vi.importActual<typeof import('src/services/storage-service')>(
+    'src/services/storage-service',
+  );
+  return {
+    ...actual,
+    storageService: {
+      get: vi.fn((key: string) => Promise.resolve(store.get(key))),
+      set: vi.fn((key: string, value: unknown) => {
+        store.set(key, value);
+        return Promise.resolve();
+      }),
+    },
+  };
+});
+
+const input = {
+  origin: 'https://example.com',
+  requestType: 'sign_event',
+  eventKind: 1,
+  accountAlias: 'alice',
+  accountPubkey: null,
+};
+
+const content = {
+  contentDescription: 'a note',
+  event: { kind: 1, content: 'secret note', tags: [], created_at: 1 },
+  allowRemember: true,
+};
+
+/**
+ * Reviewable content is what the panel shows and what must never be written down: event content,
+ * plaintext, and invoices stay in worker memory only (ADR D6, SR-14).
+ */
+describe('request content', () => {
+  beforeEach(() => {
+    store.clear();
+    __resetLiveCallbacksForTests();
+    vi.clearAllMocks();
+  });
+
+  it('is readable while the request is live', async () => {
+    const { record } = await enqueueRequest(input, content);
+    expect(getRequestContent(record.id)?.event?.content).toBe('secret note');
+  });
+
+  it('never reaches durable storage', async () => {
+    await enqueueRequest(input, content);
+    const stored = JSON.stringify(store.get(REQUEST_QUEUE_KEY));
+    // Values, not key substrings: "event" legitimately appears inside `sign_event` and
+    // `eventKind`. Field-level coverage is the final test in this file.
+    expect(stored).not.toContain('secret note');
+    expect(stored).not.toContain('a note');
+  });
+
+  it('is dropped once the request is decided', async () => {
+    const { record } = await enqueueRequest(input, content);
+    await submitDecision(record.id, { approved: true, duration: 'once' });
+    expect(getRequestContent(record.id)).toBeNull();
+  });
+
+  it('is dropped when a request is interrupted', async () => {
+    const { record } = await enqueueRequest(input, content);
+    __resetLiveCallbacksForTests();
+    // Content is gone with the worker, exactly as the record becomes non-signable.
+    await reconcileInterruptedRequests();
+    expect(getRequestContent(record.id)).toBeNull();
+  });
+
+  it('returns null for an unknown id rather than throwing', () => {
+    expect(getRequestContent('missing')).toBeNull();
+  });
+
+  it('keeps the durable record to its permitted fields', async () => {
+    await enqueueRequest(input, content);
+    const records = store.get(REQUEST_QUEUE_KEY) as ApprovalRequestRecord[];
+    for (const record of records) {
+      expect(Object.keys(record)).not.toContain('event');
+      expect(Object.keys(record)).not.toContain('contentDescription');
+    }
+  });
+});

--- a/tests/unit/services/request-queue.test.ts
+++ b/tests/unit/services/request-queue.test.ts
@@ -69,8 +69,8 @@ describe('request queue', () => {
 
     it('presents requests in deterministic order', async () => {
       const now = 1_000_000;
-      await enqueueRequest({ ...baseInput, origin: 'https://a.example' }, now);
-      await enqueueRequest({ ...baseInput, origin: 'https://b.example' }, now + 10);
+      await enqueueRequest({ ...baseInput, origin: 'https://a.example' }, { allowRemember: true }, now);
+      await enqueueRequest({ ...baseInput, origin: 'https://b.example' }, { allowRemember: true }, now + 10);
 
       const current = await getCurrentRequest(now + 20);
       expect(current?.origin).toBe('https://a.example');
@@ -108,7 +108,7 @@ describe('request queue', () => {
 
     it('refuses a decision on an expired request', async () => {
       const now = 1_000_000;
-      const { record } = await enqueueRequest(baseInput, now);
+      const { record } = await enqueueRequest(baseInput, { allowRemember: true }, now);
 
       const result = await submitDecision(
         record.id,
@@ -122,7 +122,7 @@ describe('request queue', () => {
   describe('expiry', () => {
     it('expires from creation, not from presentation', async () => {
       const now = 1_000_000;
-      const { record } = await enqueueRequest(baseInput, now);
+      const { record } = await enqueueRequest(baseInput, { allowRemember: true }, now);
       await markPresented(record.id, now + 60_000);
 
       const pending = await listPendingRequests(now + 6 * 60 * 1000);
@@ -133,7 +133,7 @@ describe('request queue', () => {
     it('stamps the expiry at creation so a later settings change cannot move it', async () => {
       const now = 1_000_000;
       store.set(REQUEST_EXPIRY_MINUTES, 1);
-      const { record } = await enqueueRequest(baseInput, now);
+      const { record } = await enqueueRequest(baseInput, { allowRemember: true }, now);
       expect(record.expiresAt).toBe(now + 60_000);
 
       store.set(REQUEST_EXPIRY_MINUTES, 10);
@@ -144,11 +144,11 @@ describe('request queue', () => {
     it('clamps an out-of-range stored expiry preference', async () => {
       const now = 1_000_000;
       store.set(REQUEST_EXPIRY_MINUTES, 0);
-      const zero = await enqueueRequest(baseInput, now);
+      const zero = await enqueueRequest(baseInput, { allowRemember: true }, now);
       expect(zero.record.expiresAt).toBe(now + 60_000);
 
       store.set(REQUEST_EXPIRY_MINUTES, 9999);
-      const huge = await enqueueRequest(baseInput, now);
+      const huge = await enqueueRequest(baseInput, { allowRemember: true }, now);
       expect(huge.record.expiresAt).toBe(now + 10 * 60 * 1000);
     });
   });
@@ -192,7 +192,7 @@ describe('request queue', () => {
 
     it('keeps the original expiry across requeue', async () => {
       const now = 1_000_000;
-      const { record } = await enqueueRequest(baseInput, now);
+      const { record } = await enqueueRequest(baseInput, { allowRemember: true }, now);
       await markPresented(record.id, now + 1000);
       await requeuePresented(now + 2000);
 


### PR DESCRIPTION
## Summary

Moves signing, encryption, and payment review, plus in-flow vault unlock, into the sidebar. Follows
the plan on #115 and decisions D5, D8, D9, D10, D11, D12, D13, D14.

All four items the plan listed as blocking are resolved: #111 is closed, #112 and #114 are on
master, and D9, D10, and D12 settle the grant durations, record ownership, and kind list.

## Where the reviewable content lives

D6 deliberately keeps event content out of the durable record, so the panel could not read what it
needs from storage. Content now lives in a **memory-only map keyed by request id** in the service
worker, exposed through a new `nostr.requests.content` bridge event, and dropped the moment a
request reaches a terminal state.

That gives the right failure mode for free: a restarted worker has no content, which matches the
request being interrupted and non-signable anyway.

Tests assert both halves — the content is readable while live, and the durable record contains
neither the event nor the description.

## Presentation rules

`src/services/approval-preview.ts` owns the labels (moved out of `SignerApproval.vue`), the risk
classification, and the grant options:

| Class | Kinds | Durations offered |
|-------|-------|-------------------|
| Standard | Everything else | once, 8h, always |
| Elevated | 3, 5, 9734, 10002, 22242 | once, 8h |
| Unknown | Any unrecognised kind | once |
| Payment | WebLN payment, zap | once |

Unavailable options are **absent**, not shown disabled. Elevated warnings name the specific effect —
"request deletion of events you previously published" rather than a generic caution — and unknown
kinds open on the full event, because a formatted summary cannot explain something Porwr does not
recognise.

`-1` is treated as "this request has no event kind", never as "unrecognised", which keeps it away
from the unknown-kind path.

## The panel

- Current request: origin, signing account, kind, risk warning, and formatted / raw / full-event
  previews. Truncation is visible and expandable, never silent.
- Decision bar is sticky so it never scrolls away from a long event; reject comes first in reading
  order; nothing beyond `once` is pre-selected.
- Focus moves to the request heading when a request is presented, not to an approve control.
- Unlock names the waiting request without showing its content, and never approves it. Reject works
  while locked, without unlocking first.
- Pending list appears once more than one request waits, announced politely rather than assertively.
- Closing the panel returns a presented request to the queue — closing is not a decision.
- Terminal requests show why they cannot be acted on and render no approval control.

## Privacy

The `https://www.google.com/s2/favicons` lookup is gone. The origin badge is derived locally from
the origin string. I checked the built output references no remote host.

## Verification

- `npm run lint`, `npm run typecheck` clean
- `npm run test:run` — 660 tests across 80 files, 25 new
- `npm run build:chrome` and `npm run build:firefox` succeed; permissions unchanged
  (`storage`+`sidePanel`, `storage`)

## Known limits

- **Not yet opened in a real browser.** Verification here is CI plus unit tests. Manual confirmation
  in Chromium and Firefox is still outstanding, and is on #112's plan too.
- The panel polls the background once a second. A push channel belongs with #113's port work, which
  owns panel presence; polling keeps this PR independent of that.
- `accountAlias` is displayed; `accountPubkey` stays null until #116 populates it.

Refs: threenine/diogel#115

🤖 Generated with [Claude Code](https://claude.com/claude-code)
