### PR TITLE
fix(theme): interpolate --header-bg so application chrome renders a background

### DIFF
--- a/src/components/sidebar/RequestPreview.vue
+++ b/src/components/sidebar/RequestPreview.vue
@@ -150,7 +150,9 @@ const fullEventJson = computed(() =>
   max-height: 220px;
   overflow: auto;
   font-size: 0.75rem;
-  background: var(--header-bg);
+  /* Deliberately not --header-bg: this is where the user verifies what they are signing, so it
+     takes the softer surface and keeps the contrast the chrome colour would spend. */
+  background: var(--surface-soft);
   border: 1px solid var(--border-color);
   border-radius: 6px;
   white-space: pre-wrap;

--- a/src/css/quasar.variables.scss
+++ b/src/css/quasar.variables.scss
@@ -46,7 +46,8 @@ $dark-header: #353e43;
   --dashboard-accent-bg: #fff3e9;
 
   // App chrome (header/toolbars)
-  --header-bg: $light-header; // deep blue header background
+  // Interpolated: Sass does not evaluate variables inside a custom-property value.
+  --header-bg: #{$light-header};
   --on-header: #0b1220; // header foreground (icons/text)
 
   // Configuration forms
@@ -72,7 +73,7 @@ $dark-header: #353e43;
   --dashboard-accent-bg: #40220f;
 
   // App chrome (header/toolbars)
-  --header-bg: $dark-header;
+  --header-bg: #{$dark-header};
   --on-header: #ffffff;
 
   // Configuration forms

--- a/tests/unit/theme-custom-properties.test.ts
+++ b/tests/unit/theme-custom-properties.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Guards a failure mode that is silent at build time and invisible in review.
+ *
+ * Sass does not evaluate SassScript inside a custom-property value; the value is emitted as plain
+ * CSS text. `--header-bg: $light-header;` therefore ships the literal string `$light-header`, which
+ * is an invalid property value, so every `var(--header-bg)` consumer resolves to nothing and the
+ * application chrome renders with no background. Interpolation is required: `#{$light-header}`.
+ *
+ * Nothing else catches this. Sass compiles it without a warning, the stylesheet is valid CSS, and
+ * the only symptom is a missing background that a reviewer has to notice by eye.
+ */
+
+const THEME_FILE = resolve(__dirname, '../../src/css/quasar.variables.scss');
+
+/** A custom-property declaration, capturing the property name and its value. */
+const CUSTOM_PROPERTY = /^\s*(--[\w-]+)\s*:\s*([^;]+);/gm;
+
+/** Bare `$var` outside `#{}`, which Sass will not substitute. */
+const UNINTERPOLATED_SASS_VARIABLE = /\$[\w-]+/;
+
+const stripInterpolations = (value: string): string => value.replace(/#\{[^}]*\}/g, '');
+
+describe('theme custom properties', () => {
+  const source = readFileSync(THEME_FILE, 'utf8');
+
+  it('interpolates every Sass variable used in a custom-property value', () => {
+    const offenders: string[] = [];
+
+    for (const [, name, value] of source.matchAll(CUSTOM_PROPERTY)) {
+      if (UNINTERPOLATED_SASS_VARIABLE.test(stripInterpolations(value))) {
+        offenders.push(`${name}: ${value.trim()}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('declares --header-bg from an interpolated variable in both themes', () => {
+    const declarations = [...source.matchAll(CUSTOM_PROPERTY)]
+      .filter(([, name]) => name === '--header-bg')
+      .map(([, , value]) => value.trim());
+
+    expect(declarations).toHaveLength(2);
+    for (const value of declarations) {
+      expect(value).toMatch(/^#\{\$[\w-]+\}$/);
+    }
+  });
+});

--- a/tests/unit/theme-custom-properties.test.ts
+++ b/tests/unit/theme-custom-properties.test.ts
@@ -25,25 +25,36 @@ const UNINTERPOLATED_SASS_VARIABLE = /\$[\w-]+/;
 
 const stripInterpolations = (value: string): string => value.replace(/#\{[^}]*\}/g, '');
 
+interface CustomProperty {
+  name: string;
+  value: string;
+}
+
+/** Capture groups are optional to the type checker, so narrow once here rather than at each use. */
+const parseCustomProperties = (scss: string): CustomProperty[] =>
+  [...scss.matchAll(CUSTOM_PROPERTY)].flatMap(([, name, value]) =>
+    name && value ? [{ name, value: value.trim() }] : [],
+  );
+
 describe('theme custom properties', () => {
-  const source = readFileSync(THEME_FILE, 'utf8');
+  const properties = parseCustomProperties(readFileSync(THEME_FILE, 'utf8'));
+
+  it('parses the theme file', () => {
+    expect(properties.length).toBeGreaterThan(0);
+  });
 
   it('interpolates every Sass variable used in a custom-property value', () => {
-    const offenders: string[] = [];
-
-    for (const [, name, value] of source.matchAll(CUSTOM_PROPERTY)) {
-      if (UNINTERPOLATED_SASS_VARIABLE.test(stripInterpolations(value))) {
-        offenders.push(`${name}: ${value.trim()}`);
-      }
-    }
+    const offenders = properties
+      .filter(({ value }) => UNINTERPOLATED_SASS_VARIABLE.test(stripInterpolations(value)))
+      .map(({ name, value }) => `${name}: ${value}`);
 
     expect(offenders).toEqual([]);
   });
 
   it('declares --header-bg from an interpolated variable in both themes', () => {
-    const declarations = [...source.matchAll(CUSTOM_PROPERTY)]
-      .filter(([, name]) => name === '--header-bg')
-      .map(([, , value]) => value.trim());
+    const declarations = properties
+      .filter(({ name }) => name === '--header-bg')
+      .map(({ value }) => value);
 
     expect(declarations).toHaveLength(2);
     for (const value of declarations) {


### PR DESCRIPTION
Fixes #146.

## The bug

`src/css/quasar.variables.scss` declared the custom property from a Sass variable:

```scss
.body--light { --header-bg: $light-header; }
.body--dark  { --header-bg: $dark-header; }
```

Sass does not evaluate SassScript inside a custom-property value — the value is emitted as plain CSS
text. Both theme blocks therefore shipped the literal strings `$light-header` and `$dark-header`,
which are invalid property values, so every `var(--header-bg)` consumer resolved to nothing.

Confirmed by compiling the file standalone in both directions:

| | compiled output |
|---|---|
| before | `--header-bg: $light-header;` / `--header-bg: $dark-header;` |
| after | `--header-bg: #898989;` / `--header-bg: #353e43;` |

These were the only two custom properties in the file declared from a Sass variable. Every other
declaration in both theme blocks is a literal. I also checked the rest of `src/` for the same shape
and for the related case of a Sass function inside a custom-property value — nothing else.

## What was affected

Wider than the sidebar, which is where it was noticed:

- `src/layouts/SidebarLayout.vue` — panel header
- `src/components/sidebar/SidebarFooterLinks.vue` — panel footer
- `src/components/sidebar/RequestOriginHeader.vue` — request origin badge
- `src/components/sidebar/RequestPreview.vue` — raw and full-event blocks
- `src/layouts/PopupLayout.vue` — popup header
- `src/css/app.scss:424` — `.q-header` and its toolbar, buttons and icons
- `src/css/app.scss:581` — `.dashboard-topbar`, the worst case: the bad value sat inside
  `color-mix(in oklab, var(--header-bg) 86%, transparent)`, and one invalid argument invalidates the
  whole function, so the background declaration was dropped entirely

## Contrast (NFR-6)

Correcting this makes chrome visible in places that have only ever been seen unstyled, so I traced
what text actually sits on each corrected surface. `.q-header` and `.dashboard-topbar` set
`color: var(--on-header)`; everything else inherits `--text-color` from `#q-app`.

| Surface | Light | Dark |
|---|---|---|
| Panel header / footer, origin badge | 5.35:1 | 8.75:1 |
| `.q-header` | 5.35:1 | 10.93:1 |
| `.dashboard-topbar` (86% composite) | 6.55:1 | 11.95:1 |

All above the 4.5:1 body-text bar. `--text-muted` would fail on the light header at 1.36:1, but
nothing renders muted text on a header-bg surface — `.request-origin__label` is a sibling of the
badge, not inside it.

## Second commit: the event preview block

The one place where passing AA was not good enough. `.request-preview__pre` is where the user reads
what they are about to sign, and the correction would have moved it from an effective 17.6:1 to
5.35:1 at 0.75rem. It now takes `--surface-soft` instead of the chrome colour: **16.65:1** light,
**13.25:1** dark.

## Regression guard

`tests/unit/theme-custom-properties.test.ts` asserts that no custom-property value in the theme file
contains an uninterpolated `$var`.

This class of bug is silent — Sass compiles it without a warning and the output is valid CSS, so the
only existing signal was noticing a missing background by eye. Verified the test fails against the
pre-fix file and passes after.

## Checks

`lint`, `typecheck`, and `test:run` (81 files, 662 tests) all pass.

## Note for review

The comment on the light declaration read "deep blue header background", but `$light-header` is
`#898989`, a mid grey. I removed the inaccurate comment rather than changing the value, since the
value is what has been intended-but-invisible all along. If grey is not the design intent, this is
the cheap moment to change it — a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)