### PR TITLE
feat(sidebar): complete the panel header with lock and pending count

### DIFF
--- a/src/composables/useApprovalQueue.ts
+++ b/src/composables/useApprovalQueue.ts
@@ -15,6 +15,10 @@ import type {
  * The panel observes and submits decisions; the background owns lifecycle (ADR D1). Nothing here
  * caches authoritative state: every decision is followed by a refresh from the background, so a
  * request that expired or was interrupted meanwhile cannot linger on screen as actionable.
+ *
+ * State is module-scoped so every consumer in the panel observes one queue behind one poller. The
+ * header shows the pending count while the page shows the request itself; per-caller state would
+ * mean two pollers racing each other and a count that could disagree with what is on screen.
  */
 
 const POLL_INTERVAL_MS = 1000;
@@ -29,73 +33,102 @@ export interface UseApprovalQueueResult {
   decide: (id: string, approved: boolean, duration: ApprovalDuration) => Promise<DecisionResult>;
 }
 
+const pending = ref<ApprovalRequestRecord[]>([]);
+const current = ref<ApprovalRequestRecord | null>(null);
+const content = ref<ApprovalRequestContent | null>(null);
+const loading = ref(true);
+const pendingCount = computed(() => pending.value.length);
+
+let timer: ReturnType<typeof setInterval> | undefined;
+let consumers = 0;
+
+const loadContent = async (id: string | undefined): Promise<void> => {
+  if (!id) {
+    content.value = null;
+    return;
+  }
+  content.value = (await sendBexMessage('nostr.requests.content', { requestId: id })) ?? null;
+};
+
+const refresh = async (): Promise<void> => {
+  try {
+    const records = (await sendBexMessage('nostr.requests.list')) ?? [];
+    pending.value = records;
+
+    const next = (await sendBexMessage('nostr.requests.current')) ?? null;
+    const changed = next?.id !== current.value?.id;
+    current.value = next;
+
+    if (next && next.state !== 'presented') {
+      await sendBexMessage('nostr.requests.present', { requestId: next.id });
+    }
+    if (changed) {
+      await loadContent(next?.id);
+    }
+  } catch (error: unknown) {
+    logService.log(LogLevel.DEBUG, '[Panel] Failed to refresh request queue', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  } finally {
+    loading.value = false;
+  }
+};
+
+const decide = async (
+  id: string,
+  approved: boolean,
+  duration: ApprovalDuration,
+): Promise<DecisionResult> => {
+  const result = (await sendBexMessage('nostr.requests.respond', {
+    requestId: id,
+    approved,
+    duration,
+  })) ?? { applied: false as const, reason: 'unknown-request' as const };
+
+  // Always re-read: the background is the authority on what happened, including refusals.
+  await refresh();
+  return result;
+};
+
+/**
+ * Discards the shared queue state and stops the poller.
+ *
+ * Module-scoped state outlives a component, which is the point in the panel and a hazard in tests.
+ * Exported so a suite can start from a known queue rather than inheriting the previous test's.
+ */
+export function resetApprovalQueue(): void {
+  if (timer !== undefined) clearInterval(timer);
+  timer = undefined;
+  consumers = 0;
+  pending.value = [];
+  current.value = null;
+  content.value = null;
+  loading.value = true;
+}
+
 export function useApprovalQueue(): UseApprovalQueueResult {
-  const pending = ref<ApprovalRequestRecord[]>([]);
-  const current = ref<ApprovalRequestRecord | null>(null);
-  const content = ref<ApprovalRequestContent | null>(null);
-  const loading = ref(true);
-  const pendingCount = computed(() => pending.value.length) as unknown as Ref<number>;
-
-  let timer: ReturnType<typeof setInterval> | undefined;
-
-  const loadContent = async (id: string | undefined): Promise<void> => {
-    if (!id) {
-      content.value = null;
-      return;
-    }
-    content.value = (await sendBexMessage('nostr.requests.content', { requestId: id })) ?? null;
-  };
-
-  const refresh = async (): Promise<void> => {
-    try {
-      const records = (await sendBexMessage('nostr.requests.list')) ?? [];
-      pending.value = records;
-
-      const next = (await sendBexMessage('nostr.requests.current')) ?? null;
-      const changed = next?.id !== current.value?.id;
-      current.value = next;
-
-      if (next && next.state !== 'presented') {
-        await sendBexMessage('nostr.requests.present', { requestId: next.id });
-      }
-      if (changed) {
-        await loadContent(next?.id);
-      }
-    } catch (error: unknown) {
-      logService.log(LogLevel.DEBUG, '[Panel] Failed to refresh request queue', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-    } finally {
-      loading.value = false;
-    }
-  };
-
-  const decide = async (
-    id: string,
-    approved: boolean,
-    duration: ApprovalDuration,
-  ): Promise<DecisionResult> => {
-    const result = (await sendBexMessage('nostr.requests.respond', {
-      requestId: id,
-      approved,
-      duration,
-    })) ?? { applied: false as const, reason: 'unknown-request' as const };
-
-    // Always re-read: the background is the authority on what happened, including refusals.
-    await refresh();
-    return result;
-  };
-
   onMounted(() => {
+    consumers += 1;
+
+    // The poller belongs to the queue, not to whichever component mounted first.
+    if (timer === undefined) {
+      timer = setInterval(() => {
+        void refresh();
+      }, POLL_INTERVAL_MS);
+    }
+
     void refresh();
-    timer = setInterval(() => {
-      void refresh();
-    }, POLL_INTERVAL_MS);
   });
 
   onUnmounted(() => {
+    consumers -= 1;
+    if (consumers > 0) return;
+
     if (timer !== undefined) clearInterval(timer);
-    // Closing the panel is never a decision: hand the request back to the queue (FR-6).
+    timer = undefined;
+
+    // Closing the panel is never a decision: hand the request back to the queue (FR-6). This runs
+    // only once the last consumer has gone, so navigating within the panel does not requeue.
     void sendBexMessage('nostr.requests.requeuePresented').catch(() => {
       /* the background reconciles on its own if this never lands */
     });

--- a/src/composables/useVault.ts
+++ b/src/composables/useVault.ts
@@ -99,6 +99,14 @@ export function useVault() {
 
   async function handleLock() {
     await vaultStore.lock();
+
+    // The panel renders its own unlock view for a locked vault, the same way it already reacts to a
+    // background auto-lock. Routing to the dashboard login page would pull a full-tab surface into
+    // the 360px panel, which the sidebar surface map forbids.
+    if (route.name === 'sidebar') {
+      return;
+    }
+
     void router.push({
       name: 'login',
       query: {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -572,6 +572,13 @@ export default {
       eventHistory: 'History',
       settings: 'Settings',
     },
+    header: {
+      ariaLabel: 'Porwr panel',
+      pending: {
+        // The badge carries the number; the label is what assistive technology reads instead.
+        ariaLabel: 'No requests waiting | 1 request waiting | {count} requests waiting',
+      },
+    },
   },
   approval: {
     title: 'Approval Request',

--- a/src/layouts/SidebarLayout.vue
+++ b/src/layouts/SidebarLayout.vue
@@ -1,14 +1,73 @@
 <script lang="ts" setup>
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
 import DiogelLogo from 'components/DiogelLogo/Index.vue';
 import SidebarFooterLinks from 'components/sidebar/SidebarFooterLinks.vue';
+import { useApprovalQueue } from 'src/composables/useApprovalQueue';
+import { useVault } from 'src/composables/useVault';
+import useVaultStore from 'src/stores/vault-store';
+
+const { t } = useI18n();
+const vaultStore = useVaultStore();
+const { handleLock } = useVault();
+
+// Shared queue state, so this count and the request the page is showing can never disagree.
+const { pendingCount } = useApprovalQueue();
+
+const hasPending = computed(() => pendingCount.value > 0);
+
+/**
+ * The badge carries the number visually; this is what a screen reader announces instead (NFR-4).
+ */
+const pendingLabel = computed(() =>
+  t('sidebar.header.pending.ariaLabel', { count: pendingCount.value }, pendingCount.value),
+);
 </script>
 
 <template>
   <q-layout class="sidebar-root" view="hHh Lpr lFf">
-    <header class="sidebar-header">
+    <header class="sidebar-header" :aria-label="t('sidebar.header.ariaLabel')">
       <div class="sidebar-brand">
         <DiogelLogo size="md" />
         <span class="sidebar-brand__name">Diogel</span>
+      </div>
+
+      <div class="sidebar-header__actions">
+        <!--
+          The account switcher named in specification §3 belongs here. It is deferred to #116,
+          which owns site-to-account binding and therefore decides what switching means for an
+          origin that is already bound to an account.
+        -->
+
+        <q-badge
+          v-if="hasPending"
+          class="sidebar-header__pending"
+          aria-hidden="true"
+          rounded
+        >
+          {{ pendingCount }}
+        </q-badge>
+
+        <!--
+          Polite, never assertive: a request arriving must not interrupt what the user is reading
+          in the panel body (NFR-4).
+        -->
+        <span class="sidebar-header__sr-only" role="status" aria-live="polite">
+          {{ pendingLabel }}
+        </span>
+
+        <q-btn
+          v-if="vaultStore.isUnlocked"
+          flat
+          dense
+          round
+          icon="lock"
+          class="sidebar-header__lock"
+          :aria-label="t('navigation.lock.caption')"
+          :title="t('navigation.lock.caption')"
+          @click="handleLock"
+        />
       </div>
     </header>
 
@@ -58,6 +117,35 @@ import SidebarFooterLinks from 'components/sidebar/SidebarFooterLinks.vue';
   font-size: 1rem;
   color: var(--text-color);
   letter-spacing: -0.0125em;
+}
+
+/* Actions keep their width so the brand is what gives way when the panel is narrow. */
+.sidebar-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.sidebar-header__pending {
+  background: var(--q-warning, #f2c037);
+  color: #0b1220;
+  font-weight: 700;
+  font-size: 0.7rem;
+  min-width: 20px;
+  justify-content: center;
+}
+
+.sidebar-header__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .sidebar-body {

--- a/src/pages/SidebarHome.vue
+++ b/src/pages/SidebarHome.vue
@@ -9,7 +9,6 @@ import PendingRequestList from '../components/sidebar/PendingRequestList.vue';
 import SidebarUnlock from '../components/sidebar/SidebarUnlock.vue';
 import { useActiveTab } from '../composables/useActiveTab';
 import { useApprovalQueue } from '../composables/useApprovalQueue';
-import { useVault } from '../composables/useVault';
 import useVaultStore from '../stores/vault-store';
 import type { ApprovalDuration } from 'app/src-bex/types/background';
 
@@ -18,7 +17,6 @@ defineOptions({ name: 'SidebarHome' });
 const { t } = useI18n();
 const accountStore = useAccountStore();
 const { activeOrigin } = useActiveTab();
-const { handleLock } = useVault();
 const vaultStore = useVaultStore();
 const { pending, current, content, decide, refresh } = useApprovalQueue();
 
@@ -96,17 +94,9 @@ onMounted(async () => {
       <div class="sidebar-home__context-origin">{{ activeOrigin }}</div>
     </section>
 
+    <!-- The lock action lives in the header, so it stays reachable once a request is presented. -->
     <div v-if="activeStoredKey" class="sidebar-home__account">
       <ProfileView :stored-key="activeStoredKey" />
-      <q-btn
-        flat
-        dense
-        no-caps
-        icon="lock"
-        class="sidebar-home__lock"
-        :label="t('navigation.lock.label')"
-        @click="handleLock"
-      />
     </div>
 
     <div v-else class="sidebar-home__empty">
@@ -158,10 +148,6 @@ onMounted(async () => {
   flex-direction: column;
   gap: 8px;
   min-width: 0;
-}
-
-.sidebar-home__lock {
-  align-self: flex-start;
 }
 
 .sidebar-home__empty {

--- a/tests/unit/composables/useApprovalQueue.test.ts
+++ b/tests/unit/composables/useApprovalQueue.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+
+const { sendBexMessage } = vi.hoisted(() => ({ sendBexMessage: vi.fn() }));
+
+vi.mock('src/services/bridge-client', () => ({ sendBexMessage }));
+vi.mock('src/services/log-service', () => ({
+  LogLevel: { DEBUG: 'debug' },
+  logService: { log: vi.fn() },
+}));
+
+import { resetApprovalQueue, useApprovalQueue } from 'src/composables/useApprovalQueue';
+
+const Consumer = defineComponent({
+  name: 'QueueConsumer',
+  setup() {
+    return useApprovalQueue();
+  },
+  template: '<div />',
+});
+
+/** Lets the mounted `void refresh()` settle before assertions. */
+const flush = async (): Promise<void> => {
+  await vi.waitFor(() => expect(sendBexMessage).toHaveBeenCalled());
+};
+
+describe('useApprovalQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetApprovalQueue();
+    sendBexMessage.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    resetApprovalQueue();
+    vi.useRealTimers();
+  });
+
+  describe('shared state', () => {
+    it('runs one poller however many consumers are mounted', async () => {
+      vi.useFakeTimers();
+      const setInterval = vi.spyOn(globalThis, 'setInterval');
+
+      const header = mount(Consumer);
+      const page = mount(Consumer);
+
+      // The header shows the count while the page shows the request. Two pollers would race and
+      // could disagree about what is waiting.
+      expect(setInterval).toHaveBeenCalledTimes(1);
+
+      header.unmount();
+      page.unmount();
+    });
+
+    it('hands every consumer the same queue object', () => {
+      const header = mount(Consumer);
+      const page = mount(Consumer);
+
+      expect(header.vm.pending).toBe(page.vm.pending);
+      expect(header.vm.current).toBe(page.vm.current);
+
+      header.unmount();
+      page.unmount();
+    });
+  });
+
+  describe('teardown', () => {
+    it('keeps polling while any consumer remains', async () => {
+      vi.useFakeTimers();
+      const clearInterval = vi.spyOn(globalThis, 'clearInterval');
+
+      const header = mount(Consumer);
+      const page = mount(Consumer);
+
+      header.unmount();
+      expect(clearInterval).not.toHaveBeenCalled();
+
+      page.unmount();
+      expect(clearInterval).toHaveBeenCalled();
+    });
+
+    it('requeues the presented request only once the last consumer has gone', () => {
+      const header = mount(Consumer);
+      const page = mount(Consumer);
+
+      header.unmount();
+      expect(sendBexMessage).not.toHaveBeenCalledWith('nostr.requests.requeuePresented');
+
+      page.unmount();
+      // Closing the panel is never a decision (FR-6); navigating within it is not either.
+      expect(sendBexMessage).toHaveBeenCalledWith('nostr.requests.requeuePresented');
+    });
+  });
+
+  describe('refresh', () => {
+    it('reads the queue from the background rather than caching a decision', async () => {
+      const record = { id: 'req-1', state: 'presented' };
+      sendBexMessage.mockImplementation((event: string) => {
+        if (event === 'nostr.requests.list') return Promise.resolve([record]);
+        if (event === 'nostr.requests.current') return Promise.resolve(record);
+        return Promise.resolve(null);
+      });
+
+      const wrapper = mount(Consumer);
+      await flush();
+      await vi.waitFor(() => expect(wrapper.vm.pendingCount).toBe(1));
+
+      expect(wrapper.vm.current).toEqual(record);
+      wrapper.unmount();
+    });
+  });
+});

--- a/tests/unit/composables/useVault.test.ts
+++ b/tests/unit/composables/useVault.test.ts
@@ -186,5 +186,18 @@ describe('useVault', () => {
 
       expect(testState.pushMock).toHaveBeenCalledWith({ name: 'login', query: { loginContext: 'extension' } });
     });
+
+    it('locks without leaving the panel when the sidebar is the active surface', async () => {
+      // The panel renders its own unlock view. Routing would pull the full-tab login page into
+      // the 360px panel, which the sidebar surface map forbids.
+      testState.route.name = 'sidebar';
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+
+      await vm.handleLock();
+
+      expect(testState.vaultStore.lock).toHaveBeenCalledTimes(1);
+      expect(testState.pushMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/unit/layouts/SidebarLayout.test.ts
+++ b/tests/unit/layouts/SidebarLayout.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { computed, nextTick, ref } from 'vue';
+
+const testState = vi.hoisted(() => ({
+  handleLock: vi.fn(async () => undefined),
+  isUnlocked: true,
+  pendingCount: 0,
+}));
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, named?: Record<string, number>, plural?: number) => {
+      if (key !== 'sidebar.header.pending.ariaLabel') return key;
+      const count = named?.count ?? plural ?? 0;
+      if (count === 0) return 'No requests waiting';
+      return count === 1 ? '1 request waiting' : `${count} requests waiting`;
+    },
+  }),
+}));
+
+vi.mock('src/composables/useVault', () => ({
+  useVault: () => ({ handleLock: testState.handleLock }),
+}));
+
+vi.mock('src/stores/vault-store', () => ({
+  default: () => ({
+    get isUnlocked() {
+      return testState.isUnlocked;
+    },
+  }),
+}));
+
+const pendingCount = ref(0);
+
+vi.mock('src/composables/useApprovalQueue', () => ({
+  useApprovalQueue: () => ({ pendingCount: computed(() => pendingCount.value) }),
+}));
+
+const mountLayout = async () => {
+  const SidebarLayout = (await import('src/layouts/SidebarLayout.vue')).default;
+
+  return mount(SidebarLayout, {
+    global: {
+      stubs: {
+        DiogelLogo: true,
+        SidebarFooterLinks: true,
+        'router-view': true,
+        'q-layout': { template: '<div><slot /></div>' },
+        'q-page-container': { template: '<div><slot /></div>' },
+        'q-badge': { template: '<span class="badge"><slot /></span>' },
+        'q-btn': {
+          template: '<button :aria-label="ariaLabel"><slot /></button>',
+          props: ['icon', 'ariaLabel'],
+        },
+      },
+    },
+  });
+};
+
+describe('SidebarLayout header', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    testState.isUnlocked = true;
+    pendingCount.value = 0;
+  });
+
+  describe('lock action', () => {
+    it('is reachable from the header whenever the vault is unlocked', async () => {
+      const wrapper = await mountLayout();
+
+      const lock = wrapper.find('.sidebar-header__lock');
+      expect(lock.exists()).toBe(true);
+
+      await lock.trigger('click');
+      expect(testState.handleLock).toHaveBeenCalledTimes(1);
+    });
+
+    it('stays available once a request is presented', async () => {
+      pendingCount.value = 3;
+      const wrapper = await mountLayout();
+
+      // The regression this guards: the action used to live in the idle view, so presenting a
+      // request took it off screen.
+      expect(wrapper.find('.sidebar-header__lock').exists()).toBe(true);
+    });
+
+    it('is hidden while the vault is locked', async () => {
+      testState.isUnlocked = false;
+      const wrapper = await mountLayout();
+
+      expect(wrapper.find('.sidebar-header__lock').exists()).toBe(false);
+    });
+  });
+
+  describe('pending count', () => {
+    it('is not rendered when nothing is waiting', async () => {
+      const wrapper = await mountLayout();
+
+      expect(wrapper.find('.sidebar-header__pending').exists()).toBe(false);
+    });
+
+    it('shows the queue length', async () => {
+      pendingCount.value = 2;
+      const wrapper = await mountLayout();
+
+      expect(wrapper.find('.sidebar-header__pending').text()).toBe('2');
+    });
+
+    it('follows the queue without a remount', async () => {
+      const wrapper = await mountLayout();
+
+      pendingCount.value = 1;
+      await nextTick();
+      expect(wrapper.find('.sidebar-header__pending').text()).toBe('1');
+
+      pendingCount.value = 0;
+      await nextTick();
+      expect(wrapper.find('.sidebar-header__pending').exists()).toBe(false);
+    });
+  });
+
+  describe('accessibility (NFR-4)', () => {
+    it('exposes the count through a polite live region, never assertively', async () => {
+      pendingCount.value = 2;
+      const wrapper = await mountLayout();
+
+      const region = wrapper.find('[role="status"]');
+      expect(region.attributes('aria-live')).toBe('polite');
+      expect(region.text()).toBe('2 requests waiting');
+    });
+
+    it('keeps the live region present at zero so a return to empty is announced', async () => {
+      const wrapper = await mountLayout();
+
+      expect(wrapper.find('[role="status"]').text()).toBe('No requests waiting');
+    });
+
+    it('hides the visual badge from assistive technology to avoid announcing it twice', async () => {
+      pendingCount.value = 5;
+      const wrapper = await mountLayout();
+
+      expect(wrapper.find('.sidebar-header__pending').attributes('aria-hidden')).toBe('true');
+    });
+  });
+});

--- a/tests/unit/sidebar-surface-boundary.test.ts
+++ b/tests/unit/sidebar-surface-boundary.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import type { RouteRecordRaw } from 'vue-router';
+
+import routes from 'src/router/routes';
+import SidebarFooterLinks from 'src/components/sidebar/SidebarFooterLinks.vue';
+
+/**
+ * Guards the sidebar surface boundary.
+ *
+ * The panel and the management surfaces share one router and one bundle, so nothing structural
+ * stops a dashboard page being rendered inside a 360px panel. The approved surface map says
+ * management stays full-tab and the panel links out to it; this is what holds that line.
+ */
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const SIDEBAR_PATH = '/sidebar';
+
+const findRoute = (path: string): RouteRecordRaw => {
+  const route = routes.find((candidate) => candidate.path === path);
+  if (!route) throw new Error(`No route registered for ${path}`);
+  return route;
+};
+
+/**
+ * Resolves a lazy route component to the name the SFC compiler derives from its filename.
+ *
+ * Undefined rather than throwing for a component that carries no name: not every SFC in the
+ * router does, and an unnamed one is by definition not the layout this file is looking for.
+ */
+const resolveComponentName = async (component: unknown): Promise<string | undefined> => {
+  if (typeof component !== 'function') return undefined;
+  const loaded = (await component()) as { default: Record<string, unknown> };
+  const name = loaded.default.__name ?? loaded.default.name;
+  return typeof name === 'string' ? name : undefined;
+};
+
+describe('sidebar surface boundary', () => {
+  it('renders the sidebar under its own layout, not the dashboard layout', async () => {
+    await expect(resolveComponentName(findRoute(SIDEBAR_PATH).component)).resolves.toBe(
+      'SidebarLayout',
+    );
+  });
+
+  it('nests nothing but the panel itself under the sidebar route', async () => {
+    const children = findRoute(SIDEBAR_PATH).children ?? [];
+
+    expect(children).toHaveLength(1);
+    await expect(resolveComponentName(children[0]?.component)).resolves.toBe('SidebarHome');
+  });
+
+  it('keeps every dashboard-layout route outside the sidebar branch', async () => {
+    const managementPaths: string[] = [];
+
+    for (const route of routes) {
+      if (route.path === SIDEBAR_PATH || typeof route.component !== 'function') continue;
+
+      // Mounting DashboardLayout is what makes a route a management surface.
+      if ((await resolveComponentName(route.component)) === 'DashboardLayout') {
+        managementPaths.push(route.path);
+      }
+    }
+
+    // A guard that found nothing would pass silently forever.
+    expect(managementPaths.length).toBeGreaterThan(0);
+    for (const path of managementPaths) {
+      expect(path.startsWith(SIDEBAR_PATH)).toBe(false);
+    }
+  });
+});
+
+describe('sidebar footer links', () => {
+  const createTab = vi.fn();
+  const getURL = vi.fn((path: string) => `chrome-extension://id/${path}`);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('chrome', { runtime: { getURL }, tabs: { create: createTab } });
+  });
+
+  it('opens every management surface in a full tab rather than routing the panel', async () => {
+    const push = vi.fn();
+    const wrapper = mount(SidebarFooterLinks, {
+      global: {
+        mocks: { $router: { push } },
+        stubs: {
+          // No explicit emit: the parent's @click falls through to the native button, which is
+          // how the real q-btn behaves. Emitting as well would double every click.
+          'q-btn': {
+            template: '<button>{{ label }}</button>',
+            props: ['label', 'icon'],
+          },
+        },
+      },
+    });
+
+    const buttons = wrapper.findAll('button');
+    expect(buttons.length).toBeGreaterThan(0);
+
+    for (const button of buttons) {
+      await button.trigger('click');
+    }
+
+    expect(createTab).toHaveBeenCalledTimes(buttons.length);
+    expect(push).not.toHaveBeenCalled();
+
+    // Every destination is an extension URL, never a page the panel navigates to in place.
+    const calls = createTab.mock.calls as Array<[{ url: string }]>;
+    for (const [{ url }] of calls) {
+      expect(url).toMatch(/^chrome-extension:\/\/id\/www\/index\.html#\//);
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,12 @@ export default defineConfig({
       'src/*': fileURLToPath(new URL('./src/*', import.meta.url)),
       'components': fileURLToPath(new URL('./src/components', import.meta.url)),
       'components/*': fileURLToPath(new URL('./src/components/*', import.meta.url)),
+      // Quasar supplies these at build time. Tests need them to reach the router, which is the
+      // only place the panel and the management surfaces are described together.
+      'layouts': fileURLToPath(new URL('./src/layouts', import.meta.url)),
+      'layouts/*': fileURLToPath(new URL('./src/layouts/*', import.meta.url)),
+      'pages': fileURLToPath(new URL('./src/pages', import.meta.url)),
+      'pages/*': fileURLToPath(new URL('./src/pages/*', import.meta.url)),
       'app': fileURLToPath(new URL('./', import.meta.url)),
       'app/*': fileURLToPath(new URL('./*', import.meta.url)),
       'src-bex': fileURLToPath(new URL('./src-bex', import.meta.url)),


### PR DESCRIPTION
Closes #147.

Specification §3 names a lock action and a pending-request count in the panel header. It carried the
brand alone.

## What changed

**The lock action moves into the header.** It existed only inside the idle view's account block, so
presenting a request took it off screen — the states where a user is most likely to reach for it. It
is now reachable from every unlocked state.

**The pending count is new**, and delivers NFR-4, which had no implementation. The number is visual
and `aria-hidden`; a polite live region carries the sentence a screen reader announces. Never
assertive, so an arriving request does not interrupt what is being read in the panel body.

## Two problems the issue did not anticipate

### The queue could not be shared

`useApprovalQueue` built its own state and its own 1s poller per caller. A count in the layout plus a
request view in the page would have been two pollers racing over one queue, free to disagree about
what is waiting.

State is now module-scoped behind a single refcounted poller. The presented request is requeued only
once the last consumer unmounts, so navigating within the panel is still not a decision (FR-6).
`resetApprovalQueue()` is exported so a suite can start from a known queue rather than inheriting the
previous test's.

### Manual lock left the panel

`handleLock` pushed to the `login` route, which mounts `LoginLayout` and `VaultLogin` — a full-tab
management surface rendered inside a 360px panel, which the approved surface map forbids.

The panel already renders its own unlock view when the vault locks in the background, so locking from
the sidebar now stays put. The new test fails against the old code.

## Surface-boundary regression test

The one #145 asks for. The panel and the management surfaces share one router and one bundle, so
nothing structural held this line before:

- the sidebar mounts `SidebarLayout`, not `DashboardLayout`
- nothing but the panel nests under `/sidebar`
- every dashboard-layout route sits outside that branch
- the footer opens full tabs rather than routing the panel in place

No test had ever imported `routes.ts`, so reaching the router needed the `layouts` and `pages`
aliases Quasar supplies at build time. `vitest.config.ts` gains them.

## Deliberately absent

The account switcher §3 also names. It depends on what an origin's bound account means, which #116
owns — building it first would be rework. The header leaves a slot and the code points at the issue.

## Verification

Checked in Chrome at the 320px floor rather than inferred from the CSS, with counts up to three
digits:

| Case | Overflow | Brand visible | Lock target |
|---|---|---|---|
| 320px, count 0 / 1 / 99 / 999 | none | yes | 32×32 |
| 360px, count 999 | none | yes | 32×32 |

Above the 24×24 AA minimum (NFR-7), no horizontal scrolling (NFR-11, NFR-12).

`lint`, `typecheck` and `test:run` pass: 84 files, 682 tests, up from 663.

## Note for review

The badge is `--q-warning` yellow. Against the light theme's `#898989` header its **boundary**
contrast is 2.06:1. The number inside it is 11:1 and the count is also in a live region, so no
information is lost, but the pill will not read as a pill in the light theme.

I did not compensate with a border, because that ratio is a function of the header colour still under
review in #149 — where `$light-header` turns out to be a mid grey described in the code as "deep
blue". Settle that and this either resolves itself or becomes a one-liner.

Independent of #149; no overlapping files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)