### PR TITLE
ci: run the build on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,10 @@ on:
   push:
     branches:
       - develop
+  # No branch filter: a pull request stacked on another feature branch is still code heading
+  # for master, and filtering by base left those PRs with no checks at all until they were
+  # retargeted. Running on every pull request costs one job and closes that gap.
   pull_request:
-    branches:
-      - master
-      - develop
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The `pull_request` trigger filtered on a `master` or `develop` base:

```yaml
pull_request:
  branches:
    - master
    - develop
```

A pull request stacked on another feature branch matches neither, so no workflow runs and
`gh pr checks` reports "no checks reported on the branch". #151 opened green-by-absence rather than
green — nothing had verified it.

That is the wrong case to leave uncovered. Stacked work is still code heading for master, and it is
the one most likely to need checking, since it carries another branch's commits underneath it.

Dropping the base filter runs `build` on every pull request. The `push` trigger is untouched, so this
adds no duplicate runs: `push` still fires only for `develop`, and `master` deliberately has none —
the reasoning already recorded at the top of the file.

Also worth a separate issue, not changed here: CI annotates that `actions/checkout@v4` and
`actions/setup-node@v4` target Node 20 and are being forced onto Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)