### PR TITLE
fix(sidebar): source the active tab origin from the content script

### DIFF
--- a/src-bex/background.ts
+++ b/src-bex/background.ts
@@ -32,6 +32,11 @@ import {
   requeuePresented,
   submitDecision,
 } from './services/request-queue';
+import {
+  getPageOrigin,
+  observePageConnections,
+  restorePageOrigins,
+} from './services/page-origin-registry';
 import type { ApprovalDuration, UnsignedEvent } from './types/background';
 import type {
   BridgeResponsePayload,
@@ -133,6 +138,7 @@ declare module '@quasar/app-vite' {
     'nostr.requests.list': [undefined, BridgeResponsePayload<'nostr.requests.list'>];
     'nostr.requests.current': [undefined, BridgeResponsePayload<'nostr.requests.current'>];
     'nostr.requests.count': [undefined, BridgeResponsePayload<'nostr.requests.count'>];
+    'pages.originForTab': [{ tabId: number }, BridgeResponsePayload<'pages.originForTab'>];
     'nostr.requests.present': [{ requestId: string }, BridgeResponsePayload<'nostr.requests.present'>];
     'nostr.requests.respond': [
       { requestId: string; approved: boolean; duration: ApprovalDuration },
@@ -259,6 +265,12 @@ bridge.on('nostr.requests.count', () => {
   return getPendingCount() as unknown as BridgeResponsePayload<'nostr.requests.count'>;
 });
 
+// The panel can read a tab's id but never its url (NFR-18 rules out the permission that would
+// expose it), so the origin is resolved here from what the content script's port already told us.
+bridge.on('pages.originForTab', ({ payload }) => {
+  return getPageOrigin(payload.tabId) ?? null;
+});
+
 bridge.on('nostr.requests.present', ({ payload }) => {
   return markPresented(payload.requestId) as unknown as BridgeResponsePayload<'nostr.requests.present'>;
 });
@@ -383,6 +395,7 @@ async function initialize(): Promise<void> {
       });
     });
     await initializePanelSurface();
+    await restorePageOrigins();
     // A restarted worker has lost every live callback, so anything still pending is interrupted
     // and can never be approved (ADR D7).
     await reconcileInterruptedRequests();
@@ -395,6 +408,10 @@ async function initialize(): Promise<void> {
 }
 
 void initialize();
+
+// Registered at top level, not inside initialize(): a restarted worker must be watching before the
+// first content script reconnects, or the registry starts empty and stays that way.
+observePageConnections();
 
 // Chromium reveals the panel through `openPanelOnActionClick`, so `action.onClicked` never
 // fires there. Firefox has no equivalent, so the click is the user gesture that toggles the

--- a/src-bex/services/page-origin-registry.ts
+++ b/src-bex/services/page-origin-registry.ts
@@ -1,0 +1,147 @@
+/**
+ * Page origin registry.
+ *
+ * Records which origin is loaded in which tab, so the panel can name the active site without the
+ * `tabs` permission. `tab.url` is redacted from `chrome.tabs.query` unless the extension holds
+ * `tabs` or a host permission, and NFR-18 forbids adding either on the Chromium build, so the
+ * origin has to come from somewhere the browser already lets us see it.
+ *
+ * That place is the content script's port. Every content script opens a long-lived connection to
+ * the background, and the browser stamps `port.sender` with the origin, tab id and window id of
+ * the frame that opened it. The sender is set by the browser, not by the page, so a hostile page
+ * cannot claim to be another origin here — the payload is never read and nothing the page controls
+ * is trusted.
+ *
+ * `port.onDisconnect` fires when the frame goes away: navigation, tab close, window close, or
+ * crash. That makes this registry a page-liveness signal as well as an origin lookup, which is
+ * what #113 needs for reconciling requests whose page has gone.
+ */
+
+import { LogLevel, logService } from 'src/services/log-service';
+
+/** Survives a service-worker restart; `storage` is already granted, `session` adds no permission. */
+const SESSION_KEY = 'porwr.pageOrigins';
+
+interface PageOriginRecord {
+  origin: string;
+  windowId: number;
+}
+
+const origins = new Map<number, PageOriginRecord>();
+
+type OriginListener = (tabId: number, record: PageOriginRecord | undefined) => void;
+
+const listeners = new Set<OriginListener>();
+
+const getSessionArea = (): chrome.storage.StorageArea | undefined =>
+  (chrome.storage as { session?: chrome.storage.StorageArea } | undefined)?.session;
+
+const persist = (): void => {
+  const area = getSessionArea();
+  if (!area) return;
+
+  void area.set({ [SESSION_KEY]: Array.from(origins.entries()) }).catch((error: unknown) => {
+    logService.log(LogLevel.DEBUG, '[Pages] Failed to persist page origins', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+};
+
+const notify = (tabId: number, record: PageOriginRecord | undefined): void => {
+  for (const listener of listeners) listener(tabId, record);
+};
+
+/** Only http(s) frames name a site the user can meaningfully be shown. */
+const toDisplayableOrigin = (origin: string | undefined): string | undefined => {
+  if (!origin) return undefined;
+  try {
+    const parsed = new URL(origin);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? parsed.origin : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export const recordPageOrigin = (sender: chrome.runtime.MessageSender): void => {
+  const tabId = sender.tab?.id;
+  const windowId = sender.tab?.windowId;
+  // Only the top frame names the site. A cross-origin iframe has its own content script and must
+  // not be able to relabel the tab it is embedded in.
+  if (tabId === undefined || windowId === undefined || sender.frameId !== 0) return;
+
+  const origin = toDisplayableOrigin(sender.origin ?? undefined);
+  if (!origin) return;
+
+  const record: PageOriginRecord = { origin, windowId };
+  origins.set(tabId, record);
+  persist();
+  notify(tabId, record);
+};
+
+export const forgetPageOrigin = (tabId: number | undefined): void => {
+  if (tabId === undefined || !origins.delete(tabId)) return;
+  persist();
+  notify(tabId, undefined);
+};
+
+export const getPageOrigin = (tabId: number): string | undefined => origins.get(tabId)?.origin;
+
+/** Every tab currently known to hold a page, for callers reconciling against the request queue. */
+export const listPageOrigins = (): ReadonlyMap<number, PageOriginRecord> => new Map(origins);
+
+/** Notified whenever a page arrives or goes away. #113's page-gone reconciliation hangs here. */
+export const onPageOriginChange = (listener: OriginListener): (() => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+export const restorePageOrigins = async (): Promise<void> => {
+  const area = getSessionArea();
+  if (!area) return;
+
+  try {
+    const stored = await area.get(SESSION_KEY);
+    const entries = stored[SESSION_KEY];
+    if (!Array.isArray(entries)) return;
+
+    origins.clear();
+    for (const entry of entries as Array<[number, PageOriginRecord]>) {
+      const [tabId, record] = entry;
+      if (typeof tabId === 'number' && typeof record?.origin === 'string') origins.set(tabId, record);
+    }
+  } catch (error: unknown) {
+    logService.log(LogLevel.DEBUG, '[Pages] Failed to restore page origins', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+};
+
+/**
+ * Watch content-script connections.
+ *
+ * Ports opened by extension surfaces carry no `sender.tab` and are ignored, so this sees page
+ * frames only.
+ */
+export const observePageConnections = (): void => {
+  chrome.runtime.onConnect.addListener((port) => {
+    const sender = port.sender;
+    if (!sender?.tab) return;
+
+    recordPageOrigin(sender);
+
+    const tabId = sender.tab.id;
+    port.onDisconnect.addListener(() => {
+      forgetPageOrigin(tabId);
+    });
+  });
+
+  // A closed tab may never disconnect its port cleanly; this needs no permission.
+  chrome.tabs?.onRemoved?.addListener((tabId) => {
+    forgetPageOrigin(tabId);
+  });
+};
+
+export const __resetPageOriginsForTests = (): void => {
+  origins.clear();
+  listeners.clear();
+};

--- a/src/composables/useActiveTab.ts
+++ b/src/composables/useActiveTab.ts
@@ -1,5 +1,6 @@
 import { onMounted, onUnmounted, ref, type Ref } from 'vue';
 
+import { sendBexMessage } from 'src/services/bridge-client';
 import { LogLevel, logService } from 'src/services/log-service';
 
 export interface UseActiveTabResult {
@@ -7,16 +8,7 @@ export interface UseActiveTabResult {
   activeOrigin: Ref<string>;
 }
 
-const toOrigin = (url: string | undefined): string => {
-  if (!url) return '';
-  try {
-    const parsed = new URL(url);
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return '';
-    return parsed.origin;
-  } catch {
-    return '';
-  }
-};
+
 
 /**
  * Track the active tab's origin for panel context.
@@ -24,6 +16,12 @@ const toOrigin = (url: string | undefined): string => {
  * This is context only. A request always carries its own origin, and the panel must display that
  * rather than this value, because a request may come from a background tab or another window
  * (ADR D2, specification S8).
+ *
+ * The origin cannot be read from the tab here. `chrome.tabs.query` redacts `url` unless the
+ * extension holds `tabs` or a host permission, and NFR-18 forbids adding either on the Chromium
+ * build, so this used to resolve to an empty string in every real build and the panel showed
+ * nothing. The tab id is available, and the background knows which origin is loaded in which tab
+ * from the content script's port, so the id is resolved there instead.
  */
 export function useActiveTab(): UseActiveTabResult {
   const activeOrigin = ref('');
@@ -32,7 +30,13 @@ export function useActiveTab(): UseActiveTabResult {
     try {
       if (typeof chrome === 'undefined' || !chrome.tabs?.query) return;
       const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-      activeOrigin.value = toOrigin(tab?.url);
+      const tabId = tab?.id;
+      if (tabId === undefined) {
+        activeOrigin.value = '';
+        return;
+      }
+
+      activeOrigin.value = (await sendBexMessage('pages.originForTab', { tabId })) ?? '';
     } catch (error: unknown) {
       logService.log(LogLevel.DEBUG, '[Sidebar] Failed to read active tab', {
         error: error instanceof Error ? error.message : String(error),
@@ -45,8 +49,10 @@ export function useActiveTab(): UseActiveTabResult {
     void refresh();
   };
 
+  // `changeInfo.url` is redacted for the same reason `tab.url` is, so status is the only usable
+  // signal that the tab loaded something new.
   const onUpdated = (_tabId: number, changeInfo: chrome.tabs.OnUpdatedInfo): void => {
-    if (changeInfo.url === undefined && changeInfo.status === undefined) return;
+    if (changeInfo.status === undefined) return;
     void refresh();
   };
 

--- a/src/types/bridge-types.d.ts
+++ b/src/types/bridge-types.d.ts
@@ -115,6 +115,7 @@ export type BridgeAction =
   | 'nostr.requests.respond'
   | 'nostr.requests.content'
   | 'nostr.requests.requeuePresented'
+  | 'pages.originForTab'
   | 'relay.browser.list'
   | 'relay.browser.getStatus'
   | 'relay.browser.refresh'
@@ -287,6 +288,11 @@ export interface BridgeRequestMap {
     action: 'nostr.requests.content';
     requestId: string;
   };
+  'pages.originForTab': {
+    id: string;
+    action: 'pages.originForTab';
+    tabId: number;
+  };
   'nostr.requests.requeuePresented': {
     id: string;
     action: 'nostr.requests.requeuePresented';
@@ -395,6 +401,7 @@ export interface BridgeResponseMap {
   'nostr.requests.list': ApprovalRequestRecord[];
   'nostr.requests.current': ApprovalRequestRecord | null;
   'nostr.requests.count': number;
+  'pages.originForTab': string | null;
   'nostr.requests.present': ApprovalRequestRecord | null;
   'nostr.requests.respond': DecisionResult;
   'nostr.requests.content': ApprovalRequestContent | null;

--- a/tests/unit/composables/useActiveTab.test.ts
+++ b/tests/unit/composables/useActiveTab.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { defineComponent, nextTick } from 'vue';
+
+const { sendBexMessage } = vi.hoisted(() => ({ sendBexMessage: vi.fn() }));
+
+vi.mock('src/services/bridge-client', () => ({ sendBexMessage }));
+vi.mock('src/services/log-service', () => ({
+  LogLevel: { DEBUG: 'debug' },
+  logService: { log: vi.fn() },
+}));
+
+import { useActiveTab } from 'src/composables/useActiveTab';
+
+const Harness = defineComponent({
+  name: 'ActiveTabHarness',
+  setup() {
+    return useActiveTab();
+  },
+  template: '<div />',
+});
+
+const query = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal('chrome', {
+    tabs: {
+      query,
+      onActivated: { addListener: vi.fn(), removeListener: vi.fn() },
+      onUpdated: { addListener: vi.fn(), removeListener: vi.fn() },
+    },
+  });
+});
+
+const settle = async (): Promise<void> => {
+  await vi.waitFor(() => expect(query).toHaveBeenCalled());
+  await nextTick();
+  await nextTick();
+};
+
+describe('useActiveTab', () => {
+  it('resolves the origin through the background rather than from the tab', async () => {
+    // The regression this guards: `tab.url` is redacted without the `tabs` permission, which
+    // NFR-18 forbids adding, so reading it here always produced an empty origin.
+    query.mockResolvedValue([{ id: 42 }]);
+    sendBexMessage.mockResolvedValue('https://example.com');
+
+    const wrapper = mount(Harness);
+    await settle();
+
+    expect(sendBexMessage).toHaveBeenCalledWith('pages.originForTab', { tabId: 42 });
+    await vi.waitFor(() => expect(wrapper.vm.activeOrigin).toBe('https://example.com'));
+    wrapper.unmount();
+  });
+
+  it('reports no origin when the background has never seen the tab', async () => {
+    query.mockResolvedValue([{ id: 42 }]);
+    sendBexMessage.mockResolvedValue(null);
+
+    const wrapper = mount(Harness);
+    await settle();
+
+    expect(wrapper.vm.activeOrigin).toBe('');
+    wrapper.unmount();
+  });
+
+  it('does not ask the background when there is no active tab', async () => {
+    query.mockResolvedValue([]);
+
+    const wrapper = mount(Harness);
+    await settle();
+
+    expect(sendBexMessage).not.toHaveBeenCalled();
+    expect(wrapper.vm.activeOrigin).toBe('');
+    wrapper.unmount();
+  });
+
+  it('falls back to no origin when the background call fails', async () => {
+    query.mockResolvedValue([{ id: 42 }]);
+    sendBexMessage.mockRejectedValue(new Error('bridge down'));
+
+    const wrapper = mount(Harness);
+    await settle();
+
+    expect(wrapper.vm.activeOrigin).toBe('');
+    wrapper.unmount();
+  });
+
+  it('refreshes on a tab status change, since url changes are never delivered', async () => {
+    query.mockResolvedValue([{ id: 42 }]);
+    sendBexMessage.mockResolvedValue('https://example.com');
+
+    const wrapper = mount(Harness);
+    await settle();
+
+    const chromeMock = globalThis.chrome as unknown as {
+      tabs: { onUpdated: { addListener: ReturnType<typeof vi.fn> } };
+    };
+    const onUpdated = chromeMock.tabs.onUpdated.addListener.mock.calls[0]?.[0] as (
+      tabId: number,
+      info: { status?: string; url?: string },
+    ) => void;
+
+    query.mockClear();
+    onUpdated(42, { status: 'complete' });
+    await vi.waitFor(() => expect(query).toHaveBeenCalled());
+
+    query.mockClear();
+    onUpdated(42, {});
+    await nextTick();
+    expect(query).not.toHaveBeenCalled();
+
+    wrapper.unmount();
+  });
+});

--- a/tests/unit/services/page-origin-registry.test.ts
+++ b/tests/unit/services/page-origin-registry.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('src/services/log-service', () => ({
+  LogLevel: { DEBUG: 'debug' },
+  logService: { log: vi.fn() },
+}));
+
+import {
+  __resetPageOriginsForTests,
+  forgetPageOrigin,
+  getPageOrigin,
+  listPageOrigins,
+  observePageConnections,
+  onPageOriginChange,
+  recordPageOrigin,
+  restorePageOrigins,
+} from 'app/src-bex/services/page-origin-registry';
+
+type Sender = chrome.runtime.MessageSender;
+
+const sender = (over: Partial<Sender> & { tabId?: number } = {}): Sender =>
+  ({
+    origin: 'https://example.com',
+    frameId: 0,
+    tab: { id: over.tabId ?? 1, windowId: 10 },
+    ...over,
+  }) as Sender;
+
+const sessionStore: Record<string, unknown> = {};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetPageOriginsForTests();
+  for (const key of Object.keys(sessionStore)) delete sessionStore[key];
+  vi.stubGlobal('chrome', {
+    storage: {
+      session: {
+        set: vi.fn(async (items: Record<string, unknown>) => Object.assign(sessionStore, items)),
+        get: vi.fn(async (key: string) => ({ [key]: sessionStore[key] })),
+      },
+    },
+    runtime: { onConnect: { addListener: vi.fn() } },
+    tabs: { onRemoved: { addListener: vi.fn() } },
+  });
+});
+
+describe('page origin registry', () => {
+  describe('what it trusts', () => {
+    it('records the origin the browser stamped on the sender', () => {
+      recordPageOrigin(sender());
+
+      expect(getPageOrigin(1)).toBe('https://example.com');
+    });
+
+    it('ignores subframes so an iframe cannot relabel the tab it sits in', () => {
+      recordPageOrigin(sender());
+      recordPageOrigin(sender({ origin: 'https://evil.example', frameId: 3 }));
+
+      expect(getPageOrigin(1)).toBe('https://example.com');
+    });
+
+    it('ignores senders with no tab, which is every extension surface', () => {
+      recordPageOrigin({ origin: 'https://example.com', frameId: 0 } as Sender);
+
+      expect(listPageOrigins().size).toBe(0);
+    });
+
+    it('ignores schemes that name no site a user can act on', () => {
+      recordPageOrigin(sender({ origin: 'chrome-extension://abc' }));
+      recordPageOrigin(sender({ tabId: 2, origin: 'file://' }));
+      recordPageOrigin(sender({ tabId: 3, origin: 'null' }));
+
+      expect(listPageOrigins().size).toBe(0);
+    });
+  });
+
+  describe('liveness', () => {
+    it('forgets a tab and reports the change', () => {
+      const seen: Array<[number, string | undefined]> = [];
+      onPageOriginChange((tabId: number, record) => seen.push([tabId, record?.origin]));
+
+      recordPageOrigin(sender());
+      forgetPageOrigin(1);
+
+      expect(getPageOrigin(1)).toBeUndefined();
+      expect(seen).toEqual([
+        [1, 'https://example.com'],
+        [1, undefined],
+      ]);
+    });
+
+    it('does not report a change for a tab it never knew', () => {
+      const listener = vi.fn();
+      onPageOriginChange(listener);
+
+      forgetPageOrigin(99);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('drops the record when the content script port disconnects', () => {
+      observePageConnections();
+
+      const chromeMock = globalThis.chrome as unknown as {
+        runtime: { onConnect: { addListener: ReturnType<typeof vi.fn> } };
+      };
+      const onConnect = chromeMock.runtime.onConnect.addListener.mock.calls[0]?.[0] as (
+        port: chrome.runtime.Port,
+      ) => void;
+
+      const disconnectHandlers: Array<() => void> = [];
+      onConnect({
+        sender: sender(),
+        onDisconnect: { addListener: (fn: () => void) => disconnectHandlers.push(fn) },
+      } as unknown as chrome.runtime.Port);
+
+      expect(getPageOrigin(1)).toBe('https://example.com');
+
+      // Navigation, tab close, window close and crash all surface here.
+      disconnectHandlers.forEach((fn) => fn());
+      expect(getPageOrigin(1)).toBeUndefined();
+    });
+  });
+
+  describe('surviving a worker restart', () => {
+    it('restores what it had persisted', async () => {
+      recordPageOrigin(sender());
+      await Promise.resolve();
+
+      __resetPageOriginsForTests();
+      expect(getPageOrigin(1)).toBeUndefined();
+
+      await restorePageOrigins();
+      expect(getPageOrigin(1)).toBe('https://example.com');
+    });
+
+    it('survives session storage holding nothing usable', async () => {
+      sessionStore['porwr.pageOrigins'] = 'not an array';
+
+      await expect(restorePageOrigins()).resolves.toBeUndefined();
+      expect(listPageOrigins().size).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #154, taking option 2 from that issue.

## The bug

`useActiveTab` read `tab.url` from `chrome.tabs.query`. MV3 redacts that property unless the
extension holds `tabs` or a host permission; the manifest grants neither, and a `content_scripts`
match of `<all_urls>` is **not** a host permission grant. So `activeOrigin` was always `''` and the
`v-if` in `SidebarHome.vue` dropped the "Current tab" block entirely. It has never rendered.

NFR-18 forbids adding the permission that would fix it on the Chromium build.

## What changed, and why it is smaller than expected

Before writing anything I probed a real build to see what the background can actually observe. A
long-lived content-script port **already exists** — the Quasar BEX bridge opens one per page — and
the browser stamps `port.sender` with everything needed:

```
portName:     "content@content-script-6641"
senderOrigin: "https://example.com"
senderTab:    { id, windowId, active: true }
```

So no content-script change was needed. `src-bex/services/page-origin-registry.ts` observes
`runtime.onConnect`, records `sender.origin` keyed by tab id, and drops it on `onDisconnect`. The
panel resolves its active tab's id — which is available without any permission — through a new
`pages.originForTab` bridge action.

## Trust boundary

The payload is never read. `sender.origin` is set by the browser, not the page, so a hostile page
cannot claim another origin. Subframes are ignored (`frameId !== 0`), so an embedded cross-origin
iframe cannot relabel the tab it sits in. Non-http(s) schemes are dropped.

**Request origins are untouched and were never affected.** They come from the content script's own
`window.location.origin` via `getCurrentWindowOrigin`, and the panel displays the request's own
origin as D2 and S8 require. This is a presentation fix only.

## This also gives #113 half of what it needs

`port.onDisconnect` fires on navigation, tab close, window close and crash — exactly the page-gone
signal #113 needs for reconciling requests whose page has gone. `onPageOriginChange` is the hook.
None of #113's own work is done here.

**One correction to #113's plan:** it says "there is no connect port". That is true of the *panel*,
but wrong about content scripts — the bridge already opens those, and `grep runtime.connect` missed
them because the connection is made inside the Quasar dependency rather than in this repository's
source. I will amend that line on the issue.

## Verification

Against the built extension in Chromium, not only in unit tests:

| Check | Result |
|---|---|
| Registry records the live tab | `https://example.com` |
| Follows a cross-origin navigation | updates to `https://example.org`, no stale record |
| Drops a closed tab | removed, other tab retained |
| Survives a worker restart | restored from `storage.session` |
| `tab.url` still redacted | `true` — NFR-18 holds |

`lint`, `typecheck` and `test:run` pass: 87 files, 700 tests, up from 686. The new tests cover what
the registry trusts, its liveness transitions, restart recovery, and the composable's fallbacks —
including a regression test naming the redaction that caused this.

## Note

`onUpdated` now refreshes on `changeInfo.status` only. `changeInfo.url` is redacted for the same
reason `tab.url` is, so the old condition could never have fired on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)