### PR TITLE
feat(theme): take slate-200 for the light header and invert the badge

### DIFF
--- a/src/components/sidebar/SidebarFooterLinks.vue
+++ b/src/components/sidebar/SidebarFooterLinks.vue
@@ -43,7 +43,7 @@ const links = [
   flex-wrap: wrap;
   gap: 4px;
   padding: 8px 12px;
-  border-top: 1px solid var(--border-color);
+  border-top: 1px solid var(--header-border);
   background: var(--header-bg);
   flex-shrink: 0;
 }

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -579,7 +579,7 @@ html.extension-popup body {
 
 .dashboard-topbar {
   background: color-mix(in oklab, var(--header-bg) 86%, transparent);
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--header-border);
   backdrop-filter: blur(12px);
   box-shadow: 0 6px 24px rgba(0, 0, 0, 0.06);
 }

--- a/src/css/quasar.variables.scss
+++ b/src/css/quasar.variables.scss
@@ -29,8 +29,19 @@ $negative: #c10015;
 $info: #31ccec;
 $warning: #f2c037;
 
-$light-header: #898989;
+// Chrome. The light value was #898989 until #153: a neutral grey belonging to no family in this
+// palette, described in a comment as "deep blue", and never actually reviewed because an
+// uninterpolated custom property meant it was never rendered (#146). Slate-200 puts it in the same
+// family as $dark-header and restores the usual light-theme relationship of chrome no darker than
+// the page.
+$light-header: #e2e8f0; // slate-200
 $dark-header: #353e43;
+
+// Attention badge. Mid-luminance amber reads well on the dark header and disappears against any
+// light one, so the badge inverts with the theme rather than being one colour that has to survive
+// both (#153).
+$light-badge: #1e293b; // slate-800
+$dark-badge: $warning;
 
 // Surface variables for both themes. These are consumed in app.scss
 .body--light {
@@ -49,6 +60,14 @@ $dark-header: #353e43;
   // Interpolated: Sass does not evaluate variables inside a custom-property value.
   --header-bg: #{$light-header};
   --on-header: #0b1220; // header foreground (icons/text)
+
+  // Attention badge
+  --badge-bg: #{$light-badge};
+  --on-badge: #ffffff;
+
+  // Chrome edge. --border-color is a hairline meant for cards on the page; against chrome that
+  // sits this close to the page background it is invisible, so the band needs its own line.
+  --header-border: rgba(15, 23, 42, 0.36);
 
   // Configuration forms
   --settings-form-bg: #efefef;
@@ -75,6 +94,13 @@ $dark-header: #353e43;
   // App chrome (header/toolbars)
   --header-bg: #{$dark-header};
   --on-header: #ffffff;
+
+  // Attention badge
+  --badge-bg: #{$dark-badge};
+  --on-badge: #0b1220;
+
+  // Chrome edge
+  --header-border: rgba(255, 255, 255, 0.32);
 
   // Configuration forms
   --settings-form-bg: #242424;

--- a/src/layouts/PopupLayout.vue
+++ b/src/layouts/PopupLayout.vue
@@ -47,7 +47,7 @@ html.extension-popup body {
   justify-content: space-between;
   padding: 12px 16px;
   background: var(--header-bg);
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--header-border);
   flex-shrink: 0;
 }
 

--- a/src/layouts/SidebarLayout.vue
+++ b/src/layouts/SidebarLayout.vue
@@ -101,7 +101,7 @@ const pendingLabel = computed(() =>
   gap: 8px;
   padding: 12px 16px;
   background: var(--header-bg);
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--header-border);
   flex-shrink: 0;
 }
 
@@ -127,9 +127,10 @@ const pendingLabel = computed(() =>
   flex-shrink: 0;
 }
 
+/* Theme-aware: a dark pill on light chrome, an amber pill on dark chrome (#153). */
 .sidebar-header__pending {
-  background: var(--q-warning, #f2c037);
-  color: #0b1220;
+  background: var(--badge-bg);
+  color: var(--on-badge);
   font-weight: 700;
   font-size: 0.7rem;
   min-width: 20px;

--- a/tests/unit/theme-custom-properties.test.ts
+++ b/tests/unit/theme-custom-properties.test.ts
@@ -51,14 +51,28 @@ describe('theme custom properties', () => {
     expect(offenders).toEqual([]);
   });
 
-  it('declares --header-bg from an interpolated variable in both themes', () => {
-    const declarations = properties
-      .filter(({ name }) => name === '--header-bg')
-      .map(({ value }) => value);
+  it.each(['--header-bg', '--badge-bg'])(
+    'declares %s from an interpolated variable in both themes',
+    (name) => {
+      const declarations = properties.filter((p) => p.name === name).map(({ value }) => value);
 
-    expect(declarations).toHaveLength(2);
-    for (const value of declarations) {
-      expect(value).toMatch(/^#\{\$[\w-]+\}$/);
+      expect(declarations).toHaveLength(2);
+      for (const value of declarations) {
+        expect(value).toMatch(/^#\{\$[\w-]+\}$/);
+      }
+    },
+  );
+
+  /**
+   * Chrome tokens only mean anything as a set. A theme that defines the background but not the
+   * foreground or the edge renders unreadable text or an invisible band, which is the class of
+   * defect #146 and #153 both came from.
+   */
+  it('defines every chrome token in both themes', () => {
+    const chromeTokens = ['--header-bg', '--on-header', '--header-border', '--badge-bg', '--on-badge'];
+
+    for (const name of chromeTokens) {
+      expect(properties.filter((p) => p.name === name)).toHaveLength(2);
     }
   });
 });


### PR DESCRIPTION
Closes #153, taking the recommendation from that issue.

## The header

`$light-header` was `#898989` — a neutral grey belonging to no family in the palette, commented as
"deep blue", and never reviewed, because until #146 an uninterpolated custom property meant it was
never rendered.

It is now `#e2e8f0` (slate-200), which puts the light half in the same family as `$dark-header` and
restores the usual light-theme relationship of chrome no darker than the page.

## The badge could not follow it

`--q-warning` is mid-luminance: the amber pill reads well on the dark header and disappears against
any light one — **1.38:1** on slate-200, and it was already only 2.06:1 on the old grey. No single
badge colour survives both themes.

So it inverts with the chrome. `--badge-bg` / `--on-badge` give a dark pill with light text in the
light theme, and the existing amber with dark text in the dark theme.

## `--header-border` — the consequence of choosing a light chrome

This is the part #153 did not anticipate, and I would rather name it than let it ship quietly.

At `#e2e8f0` the header sits **1.16:1** against the page, so the band is defined by its edge rather
than its fill — and `--border-color` is a hairline intended for cards on the page, invisible here at
**1.31:1**. The old grey did not need a line because its fill did the work.

Chrome now has its own edge token at **2.21:1**, applied to the panel header and footer, the popup
header, and the dashboard topbar.

## Contrast, both themes

| Surface | Light | Dark |
|---|---|---|
| Panel header / footer text | 15.19 | 8.75 |
| Popup header text | 15.19 | 8.75 |
| `.q-header` text | 15.19 | 10.93 |
| Request origin badge text | 15.19 | 8.75 |
| Dashboard topbar (86% composite) | 15.50 | 11.95 |
| Pending badge text on pill | 14.63 | 11.03 |
| Pending badge pill vs header (needs 3) | 11.87 | 6.44 |

Lowest figure anywhere is 6.44:1. Chrome text was 5.35:1 in the light theme before this.

## Guard

The theme test now covers `--badge-bg` interpolation and asserts that **every** chrome token is
defined in both themes. A theme that sets a background but not its foreground or its edge renders
unreadable text or an invisible band — the class of defect both #146 and #153 came from.

## Verification

Compiled the stylesheet standalone to confirm all four theme values emit real colours, then rendered
the panel at the 320px floor with the new palette to confirm the header reads as a band and the badge
as a pill rather than as bare text.

The rendered check covers the light theme; the dark theme figures above are computed. `lint`,
`typecheck` and `test:run` pass: 85 files, 688 tests.

## Unblocks

diogel-io/workspace#5 — the panel mockups were waiting on this decision, since the chrome colour
appears in all ten panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)