### PR TITLE
feat(sidebar): add panel presence, the toolbar badge, and page-gone handling

### DIFF
--- a/src-bex/background.ts
+++ b/src-bex/background.ts
@@ -28,13 +28,19 @@ import {
   listPendingRequests,
   markPresented,
   pruneResolvedRequests,
+  interruptRequestsForOrigin,
+  onQueueChange,
   reconcileInterruptedRequests,
   requeuePresented,
   submitDecision,
 } from './services/request-queue';
+import { observePanelConnections } from './services/panel-presence';
+import { refreshAttention } from './services/attention-badge';
 import {
   getPageOrigin,
+  listPageOrigins,
   observePageConnections,
+  onPageOriginChange,
   restorePageOrigins,
 } from './services/page-origin-registry';
 import type { ApprovalDuration, UnsignedEvent } from './types/background';
@@ -400,6 +406,9 @@ async function initialize(): Promise<void> {
     // and can never be approved (ADR D7).
     await reconcileInterruptedRequests();
     await pruneResolvedRequests();
+    // The toolbar is the only signal while the panel is closed, so it must be right from the
+    // first moment a restarted worker is running (D4).
+    await refreshAttention();
   } catch (error: unknown) {
     logService.log(LogLevel.ERROR, '[BEX] Initialization error:', {
       error: error instanceof Error ? error.message : String(error),
@@ -410,8 +419,48 @@ async function initialize(): Promise<void> {
 void initialize();
 
 // Registered at top level, not inside initialize(): a restarted worker must be watching before the
-// first content script reconnects, or the registry starts empty and stays that way.
+// first content script or panel reconnects, or it misses them and never learns they are there.
 observePageConnections();
+observePanelConnections();
+
+// Every queue write mirrors onto the toolbar. Expiry is evaluated lazily on read, so a request can
+// leave the queue with no caller involved; watching the write is the only way to catch that.
+onQueueChange(() => {
+  void refreshAttention();
+});
+
+/**
+ * A page that has gone cannot be signed for.
+ *
+ * The content script's port dies on navigation, tab close, window close and crash, which is what
+ * the page origin registry reports here. Requests name an origin and not a tab, so this waits
+ * until no tab holds the origin at all before interrupting anything (D7).
+ */
+onPageOriginChange((_tabId, record) => {
+  if (record) return;
+
+  const goneOrigins = new Set<string>();
+  for (const [, remaining] of listPageOrigins()) goneOrigins.add(remaining.origin);
+
+  void (async () => {
+    const origins = new Set<string>();
+    for (const request of (await listPendingRequests()) ?? []) origins.add(request.origin);
+
+    for (const origin of origins) {
+      if (goneOrigins.has(origin)) continue;
+      await interruptRequestsForOrigin(origin);
+    }
+  })().catch((error: unknown) => {
+    logService.log(LogLevel.ERROR, '[Pages] Failed to reconcile requests for a closed page', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+});
+
+// A closed window takes its tabs with it; ports usually report that first, but not always.
+chrome.windows?.onRemoved?.addListener(() => {
+  void refreshAttention();
+});
 
 // Chromium reveals the panel through `openPanelOnActionClick`, so `action.onClicked` never
 // fires there. Firefox has no equivalent, so the click is the user gesture that toggles the

--- a/src-bex/services/attention-badge.ts
+++ b/src-bex/services/attention-badge.ts
@@ -1,0 +1,68 @@
+/**
+ * Toolbar attention policy (ADR D4).
+ *
+ * Porwr never opens the panel by itself — both browsers require a user gesture — so the toolbar is
+ * the only way to say that something is waiting while the panel is closed. `action.setBadgeText`
+ * and `action.setTitle` need no permission, which keeps NFR-18 intact.
+ *
+ * The badge is not announced to assistive technology. While the panel is open, NFR-4 is carried by
+ * the in-panel live region; while it is closed, the title is the accessible carrier, which is why
+ * it names the count in words rather than relying on the badge alone.
+ */
+
+import { LogLevel, logService } from 'src/services/log-service';
+import { getPendingCount } from './request-queue';
+
+const BADGE_BACKGROUND = '#f2c037';
+const BADGE_TEXT_COLOR = '#0b1220';
+
+/** Two digits is all the toolbar reliably shows; beyond that the title carries the real number. */
+const MAX_BADGE_COUNT = 99;
+
+const DEFAULT_TITLE = 'Diogel';
+
+const formatBadge = (count: number): string => {
+  if (count <= 0) return '';
+  return count > MAX_BADGE_COUNT ? `${MAX_BADGE_COUNT}+` : String(count);
+};
+
+const formatTitle = (count: number): string => {
+  if (count <= 0) return DEFAULT_TITLE;
+  return count === 1
+    ? `${DEFAULT_TITLE} - 1 request waiting for your decision`
+    : `${DEFAULT_TITLE} - ${count} requests waiting for your decision`;
+};
+
+export const renderAttention = async (count: number): Promise<void> => {
+  const action = chrome.action;
+  if (!action) return;
+
+  try {
+    await action.setBadgeText({ text: formatBadge(count) });
+    await action.setTitle({ title: formatTitle(count) });
+
+    // Only meaningful when a badge is showing, and harmless to set when one is not.
+    await action.setBadgeBackgroundColor?.({ color: BADGE_BACKGROUND });
+    await action.setBadgeTextColor?.({ color: BADGE_TEXT_COLOR });
+  } catch (error: unknown) {
+    logService.log(LogLevel.DEBUG, '[Attention] Failed to render toolbar state', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+};
+
+/**
+ * Re-read the queue and mirror it onto the toolbar.
+ *
+ * Sourced from the queue's own accessor rather than a separate count, so the toolbar and the
+ * panel header can never disagree about what is waiting.
+ */
+export const refreshAttention = async (): Promise<void> => {
+  try {
+    await renderAttention(await getPendingCount());
+  } catch (error: unknown) {
+    logService.log(LogLevel.DEBUG, '[Attention] Failed to read the queue', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+};

--- a/src-bex/services/panel-presence.ts
+++ b/src-bex/services/panel-presence.ts
@@ -1,0 +1,74 @@
+/**
+ * Panel presence.
+ *
+ * Chromium offers no way to ask whether the side panel is open, and Firefox's
+ * `sidebarAction.isOpen` answers only for Firefox. Rather than branch on the browser, presence is
+ * taken from a long-lived port the panel opens on mount and the browser tears down when the panel
+ * closes. One mechanism, both browsers (ADR D17).
+ *
+ * Presence is a presentation fact, never a lifecycle one. When the last panel goes away the
+ * presented request returns to the queue; nothing is decided, rejected or duplicated, because
+ * closing the panel is not a decision (FR-6, S11).
+ */
+
+import { LogLevel, logService } from 'src/services/log-service';
+import { requeuePresented } from './request-queue';
+
+export const PANEL_PORT_NAME = 'porwr-panel';
+
+type PresenceListener = (present: boolean) => void;
+
+const panels = new Set<chrome.runtime.Port>();
+const listeners = new Set<PresenceListener>();
+
+export const isPanelPresent = (): boolean => panels.size > 0;
+
+export const getPanelCount = (): number => panels.size;
+
+export const onPanelPresenceChange = (listener: PresenceListener): (() => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+const notify = (): void => {
+  const present = isPanelPresent();
+  for (const listener of listeners) listener(present);
+};
+
+const handleDisconnect = (port: chrome.runtime.Port): void => {
+  if (!panels.delete(port)) return;
+
+  notify();
+  if (panels.size > 0) return;
+
+  // The last panel has gone. A request left in `presented` would otherwise stay that way until
+  // something else touched the queue, and would be re-presented to nobody.
+  void requeuePresented().catch((error: unknown) => {
+    logService.log(LogLevel.ERROR, '[Panel] Failed to requeue after the last panel closed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+};
+
+/**
+ * Watch for panels connecting.
+ *
+ * Filtered on the port name alone. Content scripts connect too, but under the bridge's own name,
+ * so the name is already decisive. Rejecting ports that carry a `sender.tab` would additionally
+ * reject the panel opened as a tab, which is how it is run during development (#142) — the panel
+ * is the same page either way and should count as present either way.
+ */
+export const observePanelConnections = (): void => {
+  chrome.runtime.onConnect.addListener((port) => {
+    if (port.name !== PANEL_PORT_NAME) return;
+
+    panels.add(port);
+    notify();
+    port.onDisconnect.addListener(() => handleDisconnect(port));
+  });
+};
+
+export const __resetPanelPresenceForTests = (): void => {
+  panels.clear();
+  listeners.clear();
+};

--- a/src-bex/services/request-queue.ts
+++ b/src-bex/services/request-queue.ts
@@ -70,8 +70,25 @@ const readRecords = async (): Promise<ApprovalRequestRecord[]> => {
   return Array.isArray(stored) ? stored : [];
 };
 
+type QueueChangeListener = () => void;
+
+const queueChangeListeners = new Set<QueueChangeListener>();
+
+/**
+ * Notified after every write to the queue.
+ *
+ * Expiry is evaluated lazily on read rather than timed, so a request can leave the queue without
+ * any caller having asked for it. Anything mirroring the queue outward — the toolbar badge (D4) —
+ * has to learn about that from the write itself, not from a poll.
+ */
+export const onQueueChange = (listener: QueueChangeListener): (() => void) => {
+  queueChangeListeners.add(listener);
+  return () => queueChangeListeners.delete(listener);
+};
+
 const writeRecords = async (records: ApprovalRequestRecord[]): Promise<void> => {
   await storageService.set(REQUEST_QUEUE_KEY, records, 'session');
+  for (const listener of queueChangeListeners) listener();
 };
 
 /**
@@ -310,8 +327,54 @@ export const pruneResolvedRequests = async (now: number = Date.now()): Promise<v
   }
 };
 
+/**
+ * Interrupt every live request for an origin whose page has gone.
+ *
+ * Called when the last tab holding an origin disappears, which the browser reports through the
+ * content script's port. The provider promise those requests would resolve no longer has a page
+ * listening to it, so they must become non-signable rather than sit in the queue looking
+ * actionable (D7).
+ *
+ * Scoped to the origin, not to a tab: a request record carries the requesting origin and no tab
+ * id, so two tabs on the same origin are indistinguishable here. Interrupting only once *no* tab
+ * holds the origin is the conservative reading — it never interrupts a request another live tab
+ * might still be waiting on.
+ */
+export const interruptRequestsForOrigin = async (
+  origin: string,
+  now: number = Date.now(),
+): Promise<ApprovalRequestRecord[]> => {
+  const records = await loadQueue(now);
+  const interrupted: ApprovalRequestRecord[] = [];
+
+  const next = records.map((record) => {
+    if (record.origin !== origin || isTerminal(record.state)) return record;
+    const updated: ApprovalRequestRecord = { ...record, state: 'interrupted' };
+    interrupted.push(updated);
+    return updated;
+  });
+
+  if (interrupted.length === 0) return [];
+
+  await writeRecords(next.map(toDurableRecord));
+  for (const record of interrupted) {
+    const callback = liveCallbacks.get(record.id);
+    forgetRequest(record.id);
+    // Fail closed: the page is gone, so the request is refused rather than left hanging.
+    callback?.settle({ approved: false, duration: 'once' });
+  }
+
+  logService.log(LogLevel.WARN, '[Queue] Marked requests interrupted after the page went away', {
+    origin,
+    count: interrupted.length,
+  });
+
+  return interrupted;
+};
+
 /** Test seam: clear in-memory callbacks. Not used by production code. */
 export const __resetLiveCallbacksForTests = (): void => {
   liveCallbacks.clear();
   requestContent.clear();
+  queueChangeListeners.clear();
 };

--- a/src/composables/useApprovalQueue.ts
+++ b/src/composables/useApprovalQueue.ts
@@ -1,5 +1,6 @@
 import { computed, onMounted, onUnmounted, ref, type Ref } from 'vue';
 
+import { connectPanelPort, type PanelPortHandle } from 'src/services/panel-port';
 import { sendBexMessage } from 'src/services/bridge-client';
 import { LogLevel, logService } from 'src/services/log-service';
 import type {
@@ -41,6 +42,7 @@ const pendingCount = computed(() => pending.value.length);
 
 let timer: ReturnType<typeof setInterval> | undefined;
 let consumers = 0;
+let panelPort: PanelPortHandle | undefined;
 
 const loadContent = async (id: string | undefined): Promise<void> => {
   if (!id) {
@@ -99,6 +101,8 @@ const decide = async (
 export function resetApprovalQueue(): void {
   if (timer !== undefined) clearInterval(timer);
   timer = undefined;
+  panelPort?.disconnect();
+  panelPort = undefined;
   consumers = 0;
   pending.value = [];
   current.value = null;
@@ -117,6 +121,16 @@ export function useApprovalQueue(): UseApprovalQueueResult {
       }, POLL_INTERVAL_MS);
     }
 
+    // One presence port per panel, not per consumer: the background counts connections, so a
+    // second port would make a single panel look like two.
+    panelPort ??= connectPanelPort({
+      // A reconnect means the worker restarted and may have reconciled the queue while it was
+      // gone, so nothing on screen can be trusted until it has been re-read.
+      onReconnect: () => {
+        void refresh();
+      },
+    });
+
     void refresh();
   });
 
@@ -127,8 +141,12 @@ export function useApprovalQueue(): UseApprovalQueueResult {
     if (timer !== undefined) clearInterval(timer);
     timer = undefined;
 
+    panelPort?.disconnect();
+    panelPort = undefined;
+
     // Closing the panel is never a decision: hand the request back to the queue (FR-6). This runs
-    // only once the last consumer has gone, so navigating within the panel does not requeue.
+    // only once the last consumer has gone, so navigating within the panel does not requeue. The
+    // presence port covers the cases this cannot reach, such as the window being closed outright.
     void sendBexMessage('nostr.requests.requeuePresented').catch(() => {
       /* the background reconciles on its own if this never lands */
     });

--- a/src/services/panel-port.ts
+++ b/src/services/panel-port.ts
@@ -1,0 +1,89 @@
+/**
+ * Panel-side presence port.
+ *
+ * The panel holds one long-lived connection for as long as it is open. The background treats the
+ * connection as "a panel is present" and its teardown as "the panel has gone", which is the only
+ * signal that works on both browsers (#113).
+ *
+ * The port carries no requests and no decisions. Those stay on the existing request/response
+ * bridge, where the background remains the authority. #140 adds pushes over this same connection.
+ *
+ * A Chromium service worker can be suspended while the panel stays open, which disconnects the
+ * port without the panel having gone anywhere. Reconnecting is therefore normal operation rather
+ * than error recovery, and the caller is told so it can re-read state the worker may have
+ * reconciled while it was away.
+ */
+
+import { LogLevel, logService } from './log-service';
+
+export const PANEL_PORT_NAME = 'porwr-panel';
+
+/** Long enough that a suspended worker has restarted, short enough to feel immediate. */
+const RECONNECT_DELAY_MS = 250;
+
+export interface PanelPortHandle {
+  disconnect: () => void;
+}
+
+export interface PanelPortOptions {
+  /** Called after every reconnect, never on the first connect. */
+  onReconnect?: () => void;
+}
+
+export function connectPanelPort(options: PanelPortOptions = {}): PanelPortHandle {
+  let port: chrome.runtime.Port | undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let closed = false;
+  let hasConnected = false;
+
+  const open = (): void => {
+    if (closed) return;
+
+    // No extension API at all means there is nothing to be present in — a plain page or a test
+    // environment. Retrying forever would only burn timers.
+    if (typeof chrome === 'undefined' || !chrome.runtime?.connect) {
+      closed = true;
+      return;
+    }
+
+    try {
+      port = chrome.runtime.connect({ name: PANEL_PORT_NAME });
+    } catch (error: unknown) {
+      logService.log(LogLevel.DEBUG, '[Panel] Presence port failed to open', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      schedule();
+      return;
+    }
+
+    if (hasConnected) options.onReconnect?.();
+    hasConnected = true;
+
+    port.onDisconnect.addListener(() => {
+      port = undefined;
+      schedule();
+    });
+  };
+
+  const schedule = (): void => {
+    if (closed || timer !== undefined) return;
+    timer = setTimeout(() => {
+      timer = undefined;
+      open();
+    }, RECONNECT_DELAY_MS);
+  };
+
+  open();
+
+  return {
+    disconnect: (): void => {
+      closed = true;
+      if (timer !== undefined) clearTimeout(timer);
+      timer = undefined;
+      // Explicit: the browser would tear this down on unload anyway, but an unmounted panel that
+      // is still counted as present would hold a request in `presented` for nobody.
+      port?.disconnect();
+      port = undefined;
+    },
+  };
+}

--- a/tests/unit/services/attention-badge.test.ts
+++ b/tests/unit/services/attention-badge.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { getPendingCount } = vi.hoisted(() => ({ getPendingCount: vi.fn() }));
+
+vi.mock('app/src-bex/services/request-queue', () => ({ getPendingCount }));
+vi.mock('src/services/log-service', () => ({
+  LogLevel: { DEBUG: 'debug' },
+  logService: { log: vi.fn() },
+}));
+
+import { refreshAttention, renderAttention } from 'app/src-bex/services/attention-badge';
+
+const setBadgeText = vi.fn(async (_details: { text: string }) => undefined);
+const setTitle = vi.fn(async (_details: { title: string }) => undefined);
+const setBadgeBackgroundColor = vi.fn(async () => undefined);
+const setBadgeTextColor = vi.fn(async () => undefined);
+
+const lastText = (): string | undefined => setBadgeText.mock.calls.at(-1)?.[0].text;
+const lastTitle = (): string | undefined => setTitle.mock.calls.at(-1)?.[0].title;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal('chrome', {
+    action: { setBadgeText, setTitle, setBadgeBackgroundColor, setBadgeTextColor },
+  });
+});
+
+describe('toolbar attention (D4)', () => {
+  describe('the badge', () => {
+    it('shows nothing when the queue is empty', async () => {
+      await renderAttention(0);
+
+      expect(lastText()).toBe('');
+    });
+
+    it('shows the count', async () => {
+      await renderAttention(3);
+
+      expect(lastText()).toBe('3');
+    });
+
+    it('caps at what the toolbar can actually show', async () => {
+      await renderAttention(1234);
+
+      expect(lastText()).toBe('99+');
+    });
+
+    it('treats a negative count as empty rather than rendering it', async () => {
+      await renderAttention(-1);
+
+      expect(lastText()).toBe('');
+    });
+  });
+
+  describe('the title', () => {
+    it('is the accessible carrier while the panel is closed, so it names the count in words', async () => {
+      await renderAttention(1);
+      expect(lastTitle()).toBe('Diogel - 1 request waiting for your decision');
+
+      await renderAttention(4);
+      expect(lastTitle()).toBe('Diogel - 4 requests waiting for your decision');
+    });
+
+    it('carries the real number even when the badge is capped', async () => {
+      await renderAttention(1234);
+
+      expect(lastTitle()).toContain('1234');
+    });
+
+    it('returns to the plain name when nothing is waiting', async () => {
+      await renderAttention(0);
+
+      expect(lastTitle()).toBe('Diogel');
+    });
+  });
+
+  describe('sourcing', () => {
+    it('reads the queue rather than being told a count', async () => {
+      getPendingCount.mockResolvedValue(2);
+
+      await refreshAttention();
+
+      // The toolbar and the panel header must never disagree about what is waiting.
+      expect(getPendingCount).toHaveBeenCalled();
+      expect(lastText()).toBe('2');
+    });
+
+    it('survives the queue read failing', async () => {
+      getPendingCount.mockRejectedValue(new Error('storage gone'));
+
+      await expect(refreshAttention()).resolves.toBeUndefined();
+    });
+
+    it('survives a browser with no action API', async () => {
+      vi.stubGlobal('chrome', {});
+
+      await expect(renderAttention(1)).resolves.toBeUndefined();
+    });
+
+    it('survives setBadgeTextColor being unavailable, as it is on Firefox', async () => {
+      vi.stubGlobal('chrome', { action: { setBadgeText, setTitle } });
+
+      await expect(renderAttention(1)).resolves.toBeUndefined();
+      expect(lastText()).toBe('1');
+    });
+  });
+});

--- a/tests/unit/services/panel-port.test.ts
+++ b/tests/unit/services/panel-port.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('src/services/log-service', () => ({
+  LogLevel: { DEBUG: 'debug' },
+  logService: { log: vi.fn() },
+}));
+
+import { PANEL_PORT_NAME, connectPanelPort } from 'src/services/panel-port';
+
+const connect = vi.fn();
+const disconnect = vi.fn();
+
+const makePort = () => {
+  const handlers: Array<() => void> = [];
+  return {
+    port: {
+      name: PANEL_PORT_NAME,
+      disconnect,
+      onDisconnect: { addListener: (fn: () => void) => handlers.push(fn) },
+    },
+    drop: () => handlers.forEach((fn) => fn()),
+  };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.stubGlobal('chrome', { runtime: { connect } });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('panel presence port', () => {
+  it('opens one named connection', () => {
+    connect.mockReturnValue(makePort().port);
+
+    connectPanelPort();
+
+    expect(connect).toHaveBeenCalledWith({ name: PANEL_PORT_NAME });
+  });
+
+  it('reconnects when the worker suspends underneath it', () => {
+    const first = makePort();
+    connect.mockReturnValueOnce(first.port).mockReturnValue(makePort().port);
+    const onReconnect = vi.fn();
+
+    connectPanelPort({ onReconnect });
+    expect(onReconnect).not.toHaveBeenCalled();
+
+    // A suspended service worker drops the port without the panel having gone anywhere.
+    first.drop();
+    vi.advanceTimersByTime(500);
+
+    expect(connect).toHaveBeenCalledTimes(2);
+    // The worker may have reconciled the queue while it was away, so the caller must re-read.
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops reconnecting once the panel disconnects deliberately', () => {
+    const first = makePort();
+    connect.mockReturnValue(first.port);
+
+    const handle = connectPanelPort();
+    handle.disconnect();
+
+    expect(disconnect).toHaveBeenCalledTimes(1);
+
+    first.drop();
+    vi.advanceTimersByTime(2000);
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries when the connection cannot be opened at all', () => {
+    connect.mockImplementationOnce(() => {
+      throw new Error('receiving end does not exist');
+    });
+    connect.mockReturnValue(makePort().port);
+
+    connectPanelPort();
+    expect(connect).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(500);
+    expect(connect).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives up quietly where there is no extension API to connect to', () => {
+    vi.stubGlobal('chrome', undefined);
+
+    expect(() => connectPanelPort()).not.toThrow();
+
+    vi.advanceTimersByTime(5000);
+    expect(connect).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/panel-presence.test.ts
+++ b/tests/unit/services/panel-presence.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { requeuePresented } = vi.hoisted(() => ({ requeuePresented: vi.fn(async () => undefined) }));
+
+vi.mock('app/src-bex/services/request-queue', () => ({ requeuePresented }));
+vi.mock('src/services/log-service', () => ({
+  LogLevel: { ERROR: 'error' },
+  logService: { log: vi.fn() },
+}));
+
+import {
+  PANEL_PORT_NAME,
+  __resetPanelPresenceForTests,
+  getPanelCount,
+  isPanelPresent,
+  observePanelConnections,
+  onPanelPresenceChange,
+} from 'app/src-bex/services/panel-presence';
+
+type Connect = (port: chrome.runtime.Port) => void;
+
+const addListener = vi.fn();
+
+const openPort = (
+  connect: Connect,
+  over: Partial<chrome.runtime.Port> = {},
+): { port: chrome.runtime.Port; disconnect: () => void } => {
+  const handlers: Array<() => void> = [];
+  const port = {
+    name: PANEL_PORT_NAME,
+    onDisconnect: { addListener: (fn: () => void) => handlers.push(fn) },
+    ...over,
+  } as unknown as chrome.runtime.Port;
+
+  connect(port);
+  return { port, disconnect: () => handlers.forEach((fn) => fn()) };
+};
+
+const startObserving = (): Connect => {
+  observePanelConnections();
+  return addListener.mock.calls.at(-1)?.[0] as Connect;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetPanelPresenceForTests();
+  vi.stubGlobal('chrome', { runtime: { onConnect: { addListener } } });
+});
+
+describe('panel presence', () => {
+  it('counts a connected panel as present', () => {
+    const connect = startObserving();
+
+    expect(isPanelPresent()).toBe(false);
+    openPort(connect);
+    expect(isPanelPresent()).toBe(true);
+  });
+
+  it('ignores ports that are not the panel', () => {
+    const connect = startObserving();
+
+    openPort(connect, { name: 'something-else' });
+
+    expect(isPanelPresent()).toBe(false);
+  });
+
+  it('counts the panel even when it is running in a tab, as it does in development (#142)', () => {
+    const connect = startObserving();
+
+    openPort(connect, { sender: { tab: { id: 1 } } as chrome.runtime.MessageSender });
+
+    expect(isPanelPresent()).toBe(true);
+  });
+
+  it('counts each window separately, since every window has its own panel (D2)', () => {
+    const connect = startObserving();
+
+    openPort(connect);
+    openPort(connect);
+
+    expect(getPanelCount()).toBe(2);
+  });
+
+  describe('when a panel goes away', () => {
+    it('requeues the presented request only once the last one has gone', () => {
+      const connect = startObserving();
+      const first = openPort(connect);
+      const second = openPort(connect);
+
+      first.disconnect();
+      expect(requeuePresented).not.toHaveBeenCalled();
+      expect(isPanelPresent()).toBe(true);
+
+      second.disconnect();
+      // Closing the panel is never a decision (FR-6): the request goes back to the queue.
+      expect(requeuePresented).toHaveBeenCalledTimes(1);
+      expect(isPanelPresent()).toBe(false);
+    });
+
+    it('ignores a repeated disconnect for the same port', () => {
+      const connect = startObserving();
+      const panel = openPort(connect);
+
+      panel.disconnect();
+      panel.disconnect();
+
+      expect(requeuePresented).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('reports presence changes to listeners', () => {
+    const seen: boolean[] = [];
+    onPanelPresenceChange((present) => seen.push(present));
+
+    const connect = startObserving();
+    const panel = openPort(connect);
+    panel.disconnect();
+
+    expect(seen).toEqual([true, false]);
+  });
+});

--- a/tests/unit/services/request-queue.test.ts
+++ b/tests/unit/services/request-queue.test.ts
@@ -10,6 +10,8 @@ import {
   reconcileInterruptedRequests,
   requeuePresented,
   submitDecision,
+  interruptRequestsForOrigin,
+  onQueueChange,
   __resetLiveCallbacksForTests,
 } from 'app/src-bex/services/request-queue';
 import { REQUEST_EXPIRY_MINUTES, REQUEST_QUEUE_KEY } from 'src/services/storage-service';
@@ -198,6 +200,79 @@ describe('request queue', () => {
 
       const stored = readStored().find((item) => item.id === record.id);
       expect(stored?.expiresAt).toBe(record.expiresAt);
+    });
+  });
+
+  describe('page gone (#113)', () => {
+    it('interrupts every live request for the origin', async () => {
+      const { record } = await enqueueRequest(baseInput);
+
+      const interrupted = await interruptRequestsForOrigin('https://example.com');
+
+      expect(interrupted).toHaveLength(1);
+      expect(readStored().find((item) => item.id === record.id)?.state).toBe('interrupted');
+    });
+
+    it('settles the waiting provider promise rather than leaving the page hanging', async () => {
+      const { decision } = await enqueueRequest(baseInput);
+
+      await interruptRequestsForOrigin('https://example.com');
+
+      // Fail closed: the page is gone, so the request is refused, not approved.
+      await expect(decision).resolves.toEqual({ approved: false, duration: 'once' });
+    });
+
+    it('cannot approve a request whose page has gone', async () => {
+      const { record } = await enqueueRequest(baseInput);
+      await interruptRequestsForOrigin('https://example.com');
+
+      const result = await submitDecision(record.id, { approved: true, duration: 'once' });
+      expect(result).toEqual({ applied: false, reason: 'already-resolved' });
+    });
+
+    it('leaves other origins alone', async () => {
+      const { record } = await enqueueRequest(baseInput);
+
+      const interrupted = await interruptRequestsForOrigin('https://other.example');
+
+      expect(interrupted).toHaveLength(0);
+      expect(readStored().find((item) => item.id === record.id)?.state).not.toBe('interrupted');
+    });
+
+    it('does not disturb a request that already reached a terminal state', async () => {
+      const { record } = await enqueueRequest(baseInput);
+      await submitDecision(record.id, { approved: true, duration: 'once' });
+
+      const interrupted = await interruptRequestsForOrigin('https://example.com');
+
+      expect(interrupted).toHaveLength(0);
+      expect(readStored().find((item) => item.id === record.id)?.state).toBe('approved');
+    });
+  });
+
+  describe('change notification', () => {
+    it('reports a write so the toolbar can mirror the queue', async () => {
+      const listener = vi.fn();
+      onQueueChange(listener);
+
+      await enqueueRequest(baseInput);
+
+      expect(listener).toHaveBeenCalled();
+    });
+
+    it('reports an expiry, which no caller asked for', async () => {
+      const now = 1_000_000;
+      const { record } = await enqueueRequest(baseInput, { allowRemember: true }, now);
+
+      const listener = vi.fn();
+      onQueueChange(listener);
+
+      // Expiry is evaluated on read, so this write happens with no decision and no caller.
+      await listPendingRequests(record.expiresAt + 1);
+
+      // Assert the expiry actually happened, so the notification is not credited to some other write.
+      expect(readStored().find((item) => item.id === record.id)?.state).toBe('expired');
+      expect(listener).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Part of #113 — **three of its outcomes, not all of them.** What is missing and why is at the bottom.

## Panel presence

Chromium cannot be asked whether the side panel is open; Firefox can. Rather than branch on the
browser, presence comes from a long-lived port the panel holds for as long as it is open — one
mechanism for both (D17).

When the last panel disconnects, the presented request returns to the queue. Closing the panel is
never a decision (FR-6, S11), so nothing is decided, rejected or duplicated.

The port is matched on **its name alone**. My first version also rejected ports carrying a
`sender.tab`, which would have rejected the panel when it is run in a tab — exactly how the dev
workflow (#142) runs it. Content scripts never use our port name, so the name is already decisive.

## The toolbar badge (D4)

`action.setBadgeText` and `action.setTitle` need no permission, so NFR-18 holds.

The count comes from the queue's own accessor, never a second count, so the toolbar and the panel
header from #147 cannot disagree. The badge is not announced to assistive technology, so the title
names the count in words: while the panel is open NFR-4 is carried by its live region, and while it
is closed the title is the only accessible carrier.

## Queue writes now notify

Expiry is evaluated lazily on read rather than timed, so a request can leave the queue with no caller
involved. Watching the write is the only way for the toolbar to catch that — a poll would be the
thing #140 is removing.

## Page-gone reconciliation

Built on the content-script ports #155 already observes. When the last tab holding an origin
disappears, live requests for that origin become `interrupted` and their provider promises settle
closed (D7).

**Scoped to the origin, not the tab.** A request record carries an origin and no tab id, so two tabs
on the same origin are indistinguishable here. Interrupting only once *no* tab holds the origin is
the conservative reading — it never takes down a request another live tab is still waiting on.
Per-tab precision would need a tab id on the record, which is a D6 persistence question and not mine
to decide quietly.

## Verification, and its limits

`lint`, `typecheck` and `test:run` pass: 90 files, 732 tests, up from 702. New tests cover presence
counting and the last-disconnect requeue, badge and title formatting including the cap and the
Firefox-missing-API case, port reconnect after a worker suspend, origin-scoped interruption, and
change notification on both a decision and a lazily-evaluated expiry.

In a real Chromium build I confirmed the toolbar starts correctly at `""` / `"Diogel"` with an empty
queue.

**I could not exercise a request end to end.** Doing so needs a created and unlocked vault, which
means driving the extension UI — #141's territory. So the presence port's browser behaviour is
covered by unit tests but is **unproven in a browser**, and reviewers should treat it that way.

## An unresolved observation, deliberately not fixed here

Loading the panel at `#/sidebar` with **no vault at all** redirects to `#/login` and shows "Create
Vault". I initially read that as `App.vue`'s locked-vault redirect pulling a full-tab surface into
the panel, wrote a fix, and rebuilt — and it still redirected, with the change confirmed present in
the bundle. The fix was not sufficient and I did not find the real cause, so I reverted it rather
than ship a comment claiming behaviour it does not produce.

It may also not be a bug: creating a vault is genuine full-tab onboarding, and "no vault at all" is a
different state from S2/S5/S15, which are *vault exists, locked*. **That case is untested**, for the
same reason as above.

Worth its own investigation once #141 exists. I have not filed an issue, because I cannot yet say
whether there is one.

## Not in this PR

- The fallback-surface decision. `/approve` and `SignerApproval.vue` are untouched; removing them
  deletes a surface and is a call for the maintainer, not a side effect of this work.
- Firefox's `sidebarAction.isOpen` cross-check.
- #140's push channel, which shares this port and is explicitly sequenced after presence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)