### PR TITLE
fix(sidebar): settle the panel boot and stop offering to unlock nothing

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -59,6 +59,18 @@ const addLog = (msg: string) => {
 
 type LoginContext = 'dashboard' | 'extension';
 
+/**
+ * The panel owns every vault state it can be in and must never be routed to the full-tab login
+ * page, which the approved surface map keeps out of a 360px column.
+ *
+ * Without this the boot raced: whether `#/sidebar` survived depended on whether
+ * `checkVaultStatus()` had answered before the redirect check ran, so the same first run landed on
+ * either the panel or the create-vault card (#158).
+ */
+function isPanelRoute(): boolean {
+  return route.path === '/sidebar' || route.name === 'sidebar';
+}
+
 function resolveLoginContextFromRoute(): LoginContext {
   const routeName = route.name;
   if (
@@ -144,9 +156,15 @@ onMounted(async () => {
       `Vault status check complete. exists: ${String(vaultStore.vaultExists)}, unlocked: ${String(vaultStore.isUnlocked)}`,
     );
 
+    // The router may still be resolving the initial URL. Until it has, `route` reports the blank
+    // path the router starts on rather than where the user actually is, so every check below —
+    // including the panel exemption — reads the wrong route. Whether that resolved first was the
+    // race in #158.
+    await router.isReady();
+
     // Only redirect if we ARE on home but SHOULD be on login, or vice versa
     const isAtLogin = route.path === '/login' || route.name === 'login';
-    if (!vaultStore.isUnlocked && !isAtLogin) {
+    if (!vaultStore.isUnlocked && !isAtLogin && !isPanelRoute()) {
       const isAtApprove = route.path === '/approve' || route.name === 'approve';
       addLog(
         `Redirecting to login (current path: ${String(route.path)}, name: ${String(route.name)})`,
@@ -250,7 +268,7 @@ watch(
     if (vaultStore.isLoading) return;
 
     const isAtApprove = route.path === '/approve' || route.name === 'approve';
-    if (isAtApprove) return;
+    if (isAtApprove || isPanelRoute()) return;
 
     if (!isUnlocked && route.path !== '/login' && route.name !== 'login') {
       addLog('Redirecting to login via watcher');

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -572,6 +572,11 @@ export default {
       eventHistory: 'History',
       settings: 'Settings',
     },
+    setup: {
+      title: 'Set up Porwr',
+      body: 'Create your encrypted vault to start signing Nostr events from this panel.',
+      action: 'Create vault',
+    },
     header: {
       ariaLabel: 'Porwr panel',
       pending: {

--- a/src/pages/SidebarHome.vue
+++ b/src/pages/SidebarHome.vue
@@ -26,7 +26,16 @@ const busy = ref(false);
  * Body precedence from the interaction specification §3: unlock, then the current request, then
  * the pending list, then the idle view.
  */
-const showUnlock = computed(() => !vaultStore.isUnlocked);
+/**
+ * A vault that does not exist cannot be unlocked.
+ *
+ * The contract names S16 for "no account configured", meaning an unlocked vault with no keys, and
+ * says nothing about there being no vault at all. Without this distinction the panel fell through
+ * to its unlock view and offered to unlock nothing (#158).
+ */
+const showSetup = computed(() => !vaultStore.vaultExists);
+
+const showUnlock = computed(() => vaultStore.vaultExists && !vaultStore.isUnlocked);
 
 async function onDecide(id: string, approved: boolean, duration: ApprovalDuration): Promise<void> {
   busy.value = true;
@@ -66,9 +75,22 @@ onMounted(async () => {
 
 <template>
   <q-page class="sidebar-home">
-    <!-- Unlock takes precedence over everything, and names any waiting request (S5, S15). -->
+    <!-- Nothing else is reachable without a vault, so this precedes even the unlock view (#158). -->
+    <section v-if="showSetup" class="sidebar-setup">
+      <q-icon color="grey-5" name="lock_open" size="3em" />
+      <h2 class="sidebar-setup__title">{{ t('sidebar.setup.title') }}</h2>
+      <p class="sidebar-setup__body">{{ t('sidebar.setup.body') }}</p>
+      <q-btn
+        no-caps
+        class="diogel-btn-primary"
+        :label="t('sidebar.setup.action')"
+        @click="openInTab('/login')"
+      />
+    </section>
+
+    <!-- Unlock takes precedence over everything else, and names any waiting request (S5, S15). -->
     <SidebarUnlock
-      v-if="showUnlock"
+      v-else-if="showUnlock"
       :waiting-request="current"
       @reject="(id) => onDecide(id, false, 'once')"
     />
@@ -158,5 +180,23 @@ onMounted(async () => {
 .sidebar-home__empty {
   text-align: center;
   padding: 24px 8px;
+}
+
+.sidebar-setup {
+  text-align: center;
+  padding: 24px 8px;
+  min-width: 0;
+}
+
+.sidebar-setup__title {
+  margin: 8px 0 4px;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.sidebar-setup__body {
+  color: var(--text-muted, #888);
+  font-size: 0.85rem;
+  overflow-wrap: anywhere;
 }
 </style>

--- a/tests/e2e/vault-and-panel.spec.ts
+++ b/tests/e2e/vault-and-panel.spec.ts
@@ -9,21 +9,6 @@ import { createVault, lockVault } from './fixtures/vault';
  * no way to tell an intended onboarding redirect from a surface-boundary bug.
  */
 test.describe('the panel across vault states', () => {
-  /**
-   * Marked `fixme` because it fails by design, not by flakiness on our side: with no vault, the
-   * boot races and settles on either the full-tab create-vault card or the panel itself (#158).
-   * Removing the `fixme` reproduces the race. It is left here rather than deleted so the gap in
-   * coverage is visible in the suite rather than only in an issue.
-   */
-  test.fixme('sends a first-run user to vault creation rather than an empty panel', async ({
-    openPage,
-  }) => {
-    const page = await openPage('/sidebar');
-
-    await expect(page.getByText('Create Vault')).toBeVisible();
-    expect(page.url()).toContain('#/login');
-  });
-
   test('shows the panel once a vault exists and is unlocked', async ({ openPage }) => {
     const page = await openPage('/login');
     await createVault(page);
@@ -48,5 +33,36 @@ test.describe('the panel across vault states', () => {
     // violation #113 suspected.
     await expect(page.locator('.sidebar-unlock')).toBeVisible();
     expect(page.url()).toContain('#/sidebar');
+  });
+});
+
+/**
+ * The no-vault state (#158).
+ *
+ * The approval contract names S16 as "no account configured" — a vault that exists and is unlocked
+ * but holds no keys. It says nothing about there being no vault at all, which is why this went
+ * unnoticed: the panel fell through to its unlock view and offered to unlock nothing.
+ */
+test.describe('the panel with no vault', () => {
+  test('settles on the panel deterministically rather than racing a redirect', async ({
+    openPage,
+  }) => {
+    const page = await openPage('/sidebar');
+
+    expect(page.url()).toContain('#/sidebar');
+    await expect(page.locator('.sidebar-root')).toBeVisible();
+  });
+
+  test('never offers to unlock a vault that does not exist', async ({ openPage }) => {
+    const page = await openPage('/sidebar');
+
+    await expect(page.locator('.sidebar-unlock')).toHaveCount(0);
+    await expect(page.getByText('Unlock Vault')).toHaveCount(0);
+  });
+
+  test('prompts to set Porwr up instead', async ({ openPage }) => {
+    const page = await openPage('/sidebar');
+
+    await expect(page.locator('.sidebar-setup')).toBeVisible();
   });
 });

--- a/tests/unit/pages/SidebarHome.test.ts
+++ b/tests/unit/pages/SidebarHome.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
+
+const state = vi.hoisted(() => ({ vaultExists: true, isUnlocked: true }));
+
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }));
+
+vi.mock('src/stores/vault-store', () => ({
+  default: () => ({
+    get vaultExists() {
+      return state.vaultExists;
+    },
+    get isUnlocked() {
+      return state.isUnlocked;
+    },
+  }),
+}));
+
+vi.mock('src/stores/account-store', () => ({
+  default: () => ({ activeKey: undefined, storedKeys: new Set(), getKeys: vi.fn() }),
+}));
+
+vi.mock('src/composables/useActiveTab', () => ({ useActiveTab: () => ({ activeOrigin: ref('') }) }));
+
+vi.mock('src/composables/useApprovalQueue', () => ({
+  useApprovalQueue: () => ({
+    pending: ref([]),
+    current: ref(null),
+    content: ref(null),
+    decide: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+const mountPage = async () => {
+  const SidebarHome = (await import('src/pages/SidebarHome.vue')).default;
+  return mount(SidebarHome, {
+    global: {
+      stubs: {
+        'q-page': { template: '<div><slot /></div>' },
+        'q-icon': true,
+        'q-btn': { template: '<button>{{ label }}</button>', props: ['label'] },
+        ProfileView: true,
+        CurrentRequest: true,
+        PendingRequestList: true,
+        SidebarUnlock: { template: '<div class="sidebar-unlock" />' },
+      },
+    },
+  });
+};
+
+describe('SidebarHome body precedence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.vaultExists = true;
+    state.isUnlocked = true;
+  });
+
+  describe('when no vault exists', () => {
+    beforeEach(() => {
+      state.vaultExists = false;
+      state.isUnlocked = false;
+    });
+
+    it('offers to set Porwr up', async () => {
+      const wrapper = await mountPage();
+
+      expect(wrapper.find('.sidebar-setup').exists()).toBe(true);
+    });
+
+    it('never offers to unlock a vault that does not exist', async () => {
+      // The bug this guards (#158): `!isUnlocked` alone put the unlock view in front of a user who
+      // had no vault to unlock.
+      const wrapper = await mountPage();
+
+      expect(wrapper.find('.sidebar-unlock').exists()).toBe(false);
+    });
+  });
+
+  describe('when the vault exists but is locked', () => {
+    beforeEach(() => {
+      state.vaultExists = true;
+      state.isUnlocked = false;
+    });
+
+    it('shows the unlock view (S2)', async () => {
+      const wrapper = await mountPage();
+
+      expect(wrapper.find('.sidebar-unlock').exists()).toBe(true);
+      expect(wrapper.find('.sidebar-setup').exists()).toBe(false);
+    });
+  });
+
+  describe('when the vault is unlocked', () => {
+    it('shows neither setup nor unlock', async () => {
+      const wrapper = await mountPage();
+
+      expect(wrapper.find('.sidebar-setup').exists()).toBe(false);
+      expect(wrapper.find('.sidebar-unlock').exists()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #158.

> Depends on #159 for the end-to-end tests it adds. The source fix and the unit guard stand alone;
> the e2e additions in `vault-and-panel.spec.ts` need that harness merged first.

## The race, and why the earlier attempt failed

`App.vue` decided whether to redirect to the full-tab login page by reading `route`. But the router
may still have been resolving the initial URL at that point, and until it has, `route.path` is the
blank path the router starts on — not where the user actually is.

So every check against it read the wrong route, **including the panel exemption**. Whether
`#/sidebar` survived came down to whether the router happened to resolve before that code ran.

This is why the same exemption appeared not to work in #113 and was reverted. It was correct; it was
reading a route that did not exist yet. `await router.isReady()` before deciding makes the route
authoritative and removes the race.

## Offering to unlock a vault that does not exist

`showUnlock` was `!vaultStore.isUnlocked`, which is true both when a vault is locked *and* when there
is no vault at all.

The contract names S16 for "no account configured" — an unlocked vault holding no keys — and says
nothing about having no vault, so the panel fell through to its unlock view and offered to unlock
nothing.

**Decision taken, and worth confirming:** the panel keeps the no-vault case and prompts to create a
vault, rather than handing it to a full-tab redirect. That matches how it already treats "no keys" —
prompt and link out, rather than replacing itself with a management surface — and it is what the
approved surface map implies. If you would rather first-run onboarding be a full-tab redirect, this
is the moment to say so; it is a small change either way.

## Verification

Traced against the built extension in Chromium, three cold profiles each time.

**Before** — settled route and rendered surface:

| Run | Route | Rendered |
|---|---|---|
| 1 | `#/login` | Create Vault card |
| 2 | `#/sidebar` | panel, **Unlock Vault** |
| 3 | `#/login` | Create Vault card |

**After:**

| Run | Route | Rendered |
|---|---|---|
| 1 | `#/sidebar` | panel, setup prompt |
| 2 | `#/sidebar` | panel, setup prompt |
| 3 | `#/sidebar` | panel, setup prompt |

The full e2e suite passes three times consecutively — 8 passed, ~4.7s each. `lint`, `typecheck` and
`test:run` pass: 736 unit tests, up from 732.

## Guarded at both levels

The e2e suite runs nightly rather than per pull request, so `tests/unit/pages/SidebarHome.test.ts`
covers the branching directly: no vault offers setup and never the unlock view, a locked vault shows
the unlock view (S2), and an unlocked vault shows neither.

## Note

The `test.fixme` that #159 added for this is removed rather than un-skipped: it asserted the redirect
behaviour, which this deliberately changes. The new `the panel with no vault` block asserts the
behaviour that replaces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)