### PR TITLE
test(e2e): cover Firefox through WebDriver

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,8 +31,13 @@ jobs:
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
 
-      - name: Run end-to-end tests
+      - name: Run Chromium end-to-end tests
         run: npm run test:e2e
+
+      # Firefox is driven through WebDriver, not Playwright, so it needs a real Firefox on the
+      # runner rather than a Playwright download. ubuntu-latest ships one.
+      - name: Run Firefox end-to-end tests
+        run: npm run test:e2e:firefox
 
       - name: Upload traces
         if: failure()

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@types/crypto-js": "^4.2.2",
         "@types/file-saver": "^2.0.7",
         "@types/node": "^25.3.0",
+        "@types/selenium-webdriver": "^4.35.6",
         "@vitejs/plugin-vue": "^6.0.1",
         "@vitest/coverage-v8": "^4.1.10",
         "@vue/eslint-config-prettier": "^10.1.0",
@@ -48,9 +49,11 @@
         "autoprefixer": "^10.4.2",
         "eslint": "^9.0.0",
         "eslint-plugin-vue": "^10.8.0",
+        "geckodriver": "^6.1.1",
         "globals": "^16.4.0",
         "jsdom": "^25.0.1",
         "prettier": "^3.3.3",
+        "selenium-webdriver": "^4.47.0",
         "typescript": "^5.9.2",
         "vite-plugin-checker": "^0.12.0",
         "vitest": "^4.0.15",
@@ -145,6 +148,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bazel/runfiles": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@bazel/runfiles/-/runfiles-6.5.0.tgz",
+      "integrity": "sha512-RzahvqTkfpY2jsDxo8YItPX+/iZ6hbiikw1YhE0bA9EKBR5Og8Pa6FHn9PO9M0zaXRVsr0GFQLKbB/0rzy9SzA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "1.0.2",
@@ -3640,6 +3650,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/selenium-webdriver": {
+      "version": "4.35.6",
+      "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-4.35.6.tgz",
+      "integrity": "sha512-8nfyMRi4VvkY9QrQGyY/zkleAhnjnmE8YtdEeoCrWe3izp1P9vo9f5VTNRYF0up+l+kn+VuZah+je+bLddNV+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ws": "*"
+      }
+    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -3658,6 +3679,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "@types/node": "*"
       }
     },
@@ -4333,6 +4364,36 @@
         "@vue/server-renderer": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@wdio/logger": {
+      "version": "9.29.1",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.29.1.tgz",
+      "integrity": "sha512-0ZAEIo6PNyMIJPlOGkIgyOJUjcd0pC8/QHlVAAe1c91/IcjZ1X+k0yidXHaboJdN7dq1XPUacmhRdtua0U5EZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "safe-regex2": "^5.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/logger/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@zip.js/zip.js": {
@@ -6806,6 +6867,19 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
+      "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -8775,6 +8849,52 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/geckodriver": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-6.1.1.tgz",
+      "integrity": "sha512-/AcCyc9o9o6hUbudaSJM2iOtXbxSLqQPOb4GrPvEN40cjraUeaX/j5kH3mSgwiroyMn7qzx2wM61AQ2XY8j3sA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/logger": "^9.18.0",
+        "@zip.js/zip.js": "^2.8.11",
+        "decamelize": "^6.0.1",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "modern-tar": "^0.7.3"
+      },
+      "bin": {
+        "geckodriver": "bin/geckodriver.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/geckodriver/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/geckodriver/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -10739,6 +10859,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/loglevel-plugin-prefix": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
+      "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -11074,6 +11215,16 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/modern-tar": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.7.tgz",
+      "integrity": "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/ms": {
@@ -12833,6 +12984,16 @@
         "lowercase-keys": "^1.0.0"
       }
     },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -13008,6 +13169,29 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-regex2": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -13442,6 +13626,32 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/selenium-webdriver": {
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.47.0.tgz",
+      "integrity": "sha512-nxxJnH25tsJxz+pdMxtvH89tbrMnfff6W//uBIVlOWz1KZlADiQ7dyRPehknKdYiC3HwEypTy1l+tozxO0I2Qw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/SeleniumHQ"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/selenium"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bazel/runfiles": "^6.5.0",
+        "jszip": "^3.10.1",
+        "tmp": "^0.2.7",
+        "ws": "^8.21.3"
+      },
+      "engines": {
+        "node": ">= 22.0.0"
+      }
     },
     "node_modules/selfsigned": {
       "version": "5.5.0",
@@ -14569,6 +14779,16 @@
       "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
     },
     "node_modules/to-buffer": {
       "version": "1.2.2",
@@ -15895,9 +16115,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
     "build:chrome": "quasar build -m bex -T chrome",
     "build:firefox": "quasar build -m bex -T firefox",
     "icons:bex": "icongenie generate -m bex -i public/images/light/diogel.png",
-    "test:e2e": "npm run build:chrome && playwright test",
-    "test:e2e:only": "playwright test"
+    "test:e2e": "npm run build:chrome && playwright test --project=chromium",
+    "test:e2e:only": "playwright test",
+    "test:e2e:firefox": "npm run build:firefox && playwright test --project=firefox",
+    "test:e2e:all": "npm run build:chrome && npm run build:firefox && playwright test"
   },
   "dependencies": {
     "@noble/ciphers": "^0.5.3",
@@ -53,6 +55,7 @@
     "@types/crypto-js": "^4.2.2",
     "@types/file-saver": "^2.0.7",
     "@types/node": "^25.3.0",
+    "@types/selenium-webdriver": "^4.35.6",
     "@vitejs/plugin-vue": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.10",
     "@vue/eslint-config-prettier": "^10.1.0",
@@ -62,9 +65,11 @@
     "autoprefixer": "^10.4.2",
     "eslint": "^9.0.0",
     "eslint-plugin-vue": "^10.8.0",
+    "geckodriver": "^6.1.1",
     "globals": "^16.4.0",
     "jsdom": "^25.0.1",
     "prettier": "^3.3.3",
+    "selenium-webdriver": "^4.47.0",
     "typescript": "^5.9.2",
     "vite-plugin-checker": "^0.12.0",
     "vitest": "^4.0.15",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,8 +30,15 @@ export default defineConfig({
     {
       name: 'chromium',
       // Chromium is where `side_panel` and the MV3 service worker live, so it is the reference
-      // target. Firefox is tracked separately; see tests/e2e/README.md.
+      // target and carries the deeper coverage.
+      testIgnore: '**/firefox/**',
       use: { browserName: 'chromium' },
+    },
+    {
+      // Driven through WebDriver, not Playwright: Playwright cannot install extensions in Firefox.
+      // The runner here is only providing structure and reporting — see tests/e2e/fixtures/firefox.ts.
+      name: 'firefox',
+      testMatch: '**/firefox/**/*.spec.ts',
     },
   ],
 });

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -55,16 +55,35 @@ Two consequences, both learned the hard way:
 
 ## Firefox
 
-Not covered yet, and not for want of trying. Playwright cannot install extensions in Firefox — the
-capability exists for Chromium only. Adding Firefox means a second driver, realistically
-`geckodriver` with WebDriver's temporary-addon install, which works on release Firefox.
+```bash
+npm run test:e2e:firefox   # builds the Firefox extension, then runs the Firefox project
+npm run test:e2e:all       # both browsers
+```
 
-That is a separate piece of work rather than a config flag, so it is tracked on #141 rather than
-half-done here. NFR-17 wants both browsers shipping from the same source with equivalent behaviour,
-so it should not be dropped.
+Playwright runs the suite but does not drive the browser here — it cannot install extensions in
+Firefox at all, that capability is Chromium-only. Firefox goes through WebDriver instead, which does
+support installing a temporary add-on on release builds. The runner is providing structure and
+reporting; the driver is selenium.
 
-## Known gap
+Three Firefox obstacles are worked around in `fixtures/firefox.ts`, each of which fails in a way that
+does not name its own cause:
 
-`vault-and-panel.spec.ts` has one `test.fixme`. It is not flakiness in the harness: with no vault the
-app boot races and settles on either surface (#158). It is left visible in the suite rather than
-deleted so the gap shows up when the suite runs.
+1. **The `moz-extension://` origin is a fresh UUID per profile**, so the panel's URL is unknowable up
+   front. The `extensions.webextensions.uuids` preference pins it, keyed by the add-on id.
+2. **WebDriver refuses to navigate content to `moz-extension://`** — "Navigation is not allowed in
+   this context". The tab is opened from the browser's own chrome context instead.
+3. **Chrome-context scripting needs `--allow-system-access`** from Firefox 137, and Firefox rejects
+   that flag when it arrives through WebDriver capabilities. It has to be on geckodriver's command
+   line, so the fixture starts geckodriver itself rather than letting selenium start one.
+
+Firefox coverage is deliberately thinner than Chromium's. Chromium is where `side_panel` and the MV3
+service worker live, so it carries the deeper suite; Firefox asserts parity on the panel facts that
+NFR-17 says must be equivalent.
+
+## Known gaps
+
+- The real side panel is never opened, in either browser — see above. The manifest keys are asserted
+  instead (`side_panel` on Chromium, `sidebar_action` on Firefox); that the toolbar reveals the panel
+  is manual.
+- Firefox has no vault-lifecycle coverage yet. The Chromium suite creates, locks and unlocks a vault;
+  the Firefox project asserts panel parity only.

--- a/tests/e2e/firefox/panel.spec.ts
+++ b/tests/e2e/firefox/panel.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '../fixtures/firefox';
+
+/**
+ * Firefox parity (#141, NFR-17).
+ *
+ * Both browsers ship from the same tagged source and must behave equivalently on the core approval
+ * path. These assert the same panel facts the Chromium suite does, so a divergence shows up as a
+ * failure here rather than as a support report.
+ */
+test.describe('the panel in Firefox', () => {
+  test('loads the extension and renders the panel shell', async ({ driver, openExtensionPage }) => {
+    await openExtensionPage('/sidebar');
+
+    expect(await driver.findElements({ css: '.sidebar-root' })).toHaveLength(1);
+    expect(await driver.findElements({ css: '.sidebar-header' })).toHaveLength(1);
+  });
+
+  test('settles on the panel with no vault, rather than racing a redirect (#158)', async ({
+    driver,
+    openExtensionPage,
+  }) => {
+    await openExtensionPage('/sidebar');
+
+    expect(await driver.getCurrentUrl()).toContain('#/sidebar');
+    expect(await driver.findElements({ css: '.sidebar-setup' })).toHaveLength(1);
+  });
+
+  test('never offers to unlock a vault that does not exist (#158)', async ({
+    driver,
+    openExtensionPage,
+  }) => {
+    await openExtensionPage('/sidebar');
+
+    expect(await driver.findElements({ css: '.sidebar-unlock' })).toHaveLength(0);
+  });
+
+  test('ships the sidebar_action manifest key, which is how Firefox reveals the panel', async ({
+    driver,
+    openExtensionPage,
+  }) => {
+    await openExtensionPage('/sidebar');
+
+    // The panel is reached here as an extension page, so the browser-owned surface itself is not
+    // exercised. Asserting the manifest key is what keeps that half honest.
+    const manifest = await driver.executeScript<{ sidebar_action?: unknown; permissions?: string[] }>(
+      'return chrome.runtime.getManifest()',
+    );
+
+    expect(manifest.sidebar_action).toBeTruthy();
+    // Firefox gets no sidePanel permission; that key is Chromium's (NFR-18).
+    expect(manifest.permissions ?? []).toEqual(['storage']);
+  });
+});

--- a/tests/e2e/fixtures/firefox.ts
+++ b/tests/e2e/fixtures/firefox.ts
@@ -1,0 +1,141 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { createServer } from 'node:net';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { test as base } from '@playwright/test';
+import { Builder, until } from 'selenium-webdriver';
+import firefox from 'selenium-webdriver/firefox.js';
+
+/**
+ * Firefox end-to-end fixture (#141).
+ *
+ * Playwright drives the suite but not the browser here: it cannot install extensions in Firefox at
+ * all — that capability is Chromium-only. Firefox is driven through WebDriver instead, which does
+ * support installing a temporary add-on on release builds.
+ *
+ * Three Firefox-specific obstacles are worked around below, each of which fails in a way that does
+ * not name its own cause:
+ *
+ * 1. The internal `moz-extension://` origin is a fresh UUID per profile, so the panel's URL is
+ *    unknowable up front. Pinning it through the `extensions.webextensions.uuids` preference makes
+ *    it deterministic, keyed by the add-on id in the manifest.
+ * 2. WebDriver refuses to navigate content to a `moz-extension://` URL — "Navigation is not allowed
+ *    in this context". Opening the tab from the browser's own chrome context is the way round it.
+ * 3. Chrome-context scripting is privileged, and from Firefox 137 it needs
+ *    `--allow-system-access`, which Firefox rejects if passed through WebDriver capabilities. It has
+ *    to be a geckodriver command-line flag, so this fixture runs geckodriver itself rather than
+ *    letting selenium start one.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DIST = resolve(HERE, '../../../dist/bex-firefox');
+
+/** Any fixed UUID works; it only has to match the preference below. */
+const EXTENSION_UUID = '3a4b5c6d-7e8f-4a0b-9c1d-2e3f4a5b6c7d';
+
+/** `browser_specific_settings.gecko.id` in the built manifest. */
+const ADDON_ID = '@diogel';
+
+const GECKODRIVER = resolve(HERE, '../../../node_modules/.bin/geckodriver');
+
+const freePort = (): Promise<number> =>
+  new Promise((res, rej) => {
+    const server = createServer();
+    server.once('error', rej);
+    server.listen(0, () => {
+      const { port } = server.address() as { port: number };
+      server.close(() => res(port));
+    });
+  });
+
+const waitForDriver = async (port: number): Promise<void> => {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/status`);
+      if (response.ok) return;
+    } catch {
+      /* not up yet */
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(`geckodriver did not start on port ${port}`);
+};
+
+export interface FirefoxFixtures {
+  /** Firefox's own driver subclass: `installAddon` and `setContext` live there, not on WebDriver. */
+  driver: firefox.Driver;
+  /** Opens an extension route and waits for the app to settle on a real surface. */
+  openExtensionPage: (hash: string) => Promise<void>;
+}
+
+export const test = base.extend<FirefoxFixtures>({
+  driver: async ({}, use) => {
+    if (!existsSync(join(DIST, 'manifest.json'))) {
+      throw new Error(
+        `No built extension at ${DIST}. Run \`npm run build:firefox\` first, or use \`npm run test:e2e:firefox\` which builds for you.`,
+      );
+    }
+
+    const port = await freePort();
+    const server: ChildProcess = spawn(
+      GECKODRIVER,
+      [`--port=${String(port)}`, '--allow-system-access'],
+      { stdio: 'ignore' },
+    );
+    await waitForDriver(port);
+
+    const options = new firefox.Options();
+    options.addArguments('-headless');
+    options.setPreference(
+      'extensions.webextensions.uuids',
+      JSON.stringify({ [ADDON_ID]: EXTENSION_UUID }),
+    );
+
+    const driver = (await new Builder()
+      .usingServer(`http://127.0.0.1:${String(port)}`)
+      .forBrowser('firefox')
+      .setFirefoxOptions(options)
+      .build()) as firefox.Driver;
+
+    // Temporary, so release Firefox accepts an unsigned build. It goes away with the profile.
+    await driver.installAddon(DIST, true);
+
+    await use(driver);
+
+    await driver.quit();
+    server.kill();
+  },
+
+  openExtensionPage: async ({ driver }, use) => {
+    await use(async (hash: string) => {
+      const target = `moz-extension://${EXTENSION_UUID}/www/index.html#${hash}`;
+
+      await driver.setContext(firefox.Context.CHROME);
+      await driver.executeScript(
+        'const url = arguments[0];' +
+          'const win = Services.wm.getMostRecentWindow("navigator:browser");' +
+          'win.gBrowser.selectedTab = win.gBrowser.addTab(url, {' +
+          '  triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal()' +
+          '});',
+        target,
+      );
+      await driver.setContext(firefox.Context.CONTENT);
+
+      const handles = await driver.getAllWindowHandles();
+      await driver.switchTo().window(handles[handles.length - 1] as string);
+
+      // The app waits on the background bridge for up to 10s before choosing a surface, so this
+      // waits for a settled one rather than asserting into a half-booted page.
+      await driver.wait(
+        until.elementLocated({ css: '.sidebar-root, .vault-card' }),
+        45_000,
+        'the app never settled on a surface',
+      );
+    });
+  },
+});
+
+export const expect = test.expect;
+export { until };


### PR DESCRIPTION
Refs #141. Completes the browser coverage that PR #159 started; NFR-17 wants both browsers shipping
from the same source with equivalent behaviour.

## Playwright runs the suite; WebDriver drives the browser

Playwright cannot install extensions in Firefox — that capability is Chromium-only. So the runner
supplies structure and reporting, and selenium supplies the driver. One command, one report, two
drivers.

## Three obstacles, each silent about its own cause

Documented in `fixtures/firefox.ts` and the README, because none of them says what is wrong:

1. **The `moz-extension://` origin is a fresh UUID per profile**, so the panel's URL is unknowable up
   front. Pinned through the `extensions.webextensions.uuids` preference, keyed by the add-on id.
2. **WebDriver refuses to navigate content to `moz-extension://`** — *"Navigation is not allowed in
   this context"*. The tab is opened from the browser's own chrome context instead.
3. **Chrome-context scripting needs `--allow-system-access`** from Firefox 137 — and Firefox rejects
   that flag when it arrives through WebDriver capabilities (*"can't be set via capabilities"*). It
   has to be on geckodriver's command line, so the fixture starts geckodriver itself rather than
   letting selenium start one.

## What Firefox asserts

Deliberately thinner than Chromium, which is where `side_panel` and the MV3 service worker live and
which keeps the deeper suite. Firefox covers the parity facts:

- the panel shell renders
- the no-vault state settles on the panel and offers setup rather than offering to unlock nothing
  (#158) — the fix from #160, confirmed to hold on Firefox too
- the manifest carries `sidebar_action`, with permissions of exactly `['storage']`; `sidePanel` is
  Chromium's alone (NFR-18)

## Commands

```bash
npm run test:e2e           # Chromium
npm run test:e2e:firefox   # Firefox
npm run test:e2e:all       # both
```

The nightly workflow now runs both.

## Verification

Both projects together, twice consecutively: **12 passed, ~17s**. `lint`, `typecheck` and
`test:run` unaffected.

## Known gaps, recorded rather than implied

- The real side panel is never opened in either browser — no automation API can, since both require
  a user gesture. The manifest keys are asserted instead; that the toolbar reveals the panel is
  manual.
- Firefox has no vault-lifecycle coverage yet. Chromium creates, locks and unlocks a vault; Firefox
  asserts panel parity only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)