### PR TITLE
fix(security): split the no-kind and any-kind meanings in permission grants

### DIFF
--- a/src-bex/background.ts
+++ b/src-bex/background.ts
@@ -538,13 +538,21 @@ const trimApprovalContentDescription = (content?: string): string | undefined =>
   return normalized.length > 240 ? `${normalized.slice(0, 237)}...` : normalized;
 };
 
+/**
+ * `-1` at these call sites means "this request carries no event kind", never "any kind". The grant
+ * store no longer conflates the two, so it is translated to null on the way in (#136).
+ */
+const toPermissionKind = (eventKind: number): number | null => (eventKind < 0 ? null : eventKind);
+
 async function requestApproval(
   origin: string,
   eventKind: number,
   details: ApprovalRequestDetails,
 ): Promise<boolean> {
+  const permissionKind = toPermissionKind(eventKind);
+
   if (!details.skipPermissionCheck) {
-    const permission = await checkPermission(origin, eventKind);
+    const permission = await checkPermission(origin, details.requestType, permissionKind);
     if (permission.granted) return true;
   }
 
@@ -583,7 +591,7 @@ async function requestApproval(
     !details.skipPermissionCheck
   ) {
     try {
-      await grantPermission(origin, eventKind, durationLabel);
+      await grantPermission(origin, details.requestType, permissionKind, durationLabel);
     } catch (error: unknown) {
       logService.log(LogLevel.ERROR, '[BEX] Failed to grant permission', {
         error: error instanceof Error ? error.message : String(error),

--- a/src-bex/handlers/nip07.ts
+++ b/src-bex/handlers/nip07.ts
@@ -60,7 +60,9 @@ export const handleSignEvent = logWrapper(async (
 
   // Check permission
   if (!options.skipPermissionCheck) {
-    const permission = await checkPermission(origin, payload.event.kind);
+    // Signing is its own key space: a grant from a request that carries no event kind can never
+    // answer this check (#136).
+    const permission = await checkPermission(origin, 'sign_event', payload.event.kind);
     if (!permission.granted) {
       return { success: false, error: 'Permission denied', code: ErrorCode.PER_DENIED };
     }

--- a/src-bex/handlers/permission-handler.ts
+++ b/src-bex/handlers/permission-handler.ts
@@ -1,23 +1,96 @@
 /**
- * Permission management for Nostr event signing
+ * Permission management for Nostr signing and non-signing requests.
+ *
+ * A grant is keyed by origin, request type, and event kind. The request type is part of the key
+ * because it used to be absent: every grant was `(origin, eventKind)`, and `-1` meant "no event
+ * kind" at the approval call sites but "any event kind" in the checker. Approving a
+ * `get_public_key` request with "always" therefore wrote a record that authorised signing any event
+ * kind, with no further prompt (#136).
  */
 
 import { PERMISSIONS_KEY, storageService } from 'src/services/storage-service';
-import type { PermissionGrant } from '../types/background';
+import { LogLevel, logService } from 'src/services/log-service';
+import type { PermissionEventKind, PermissionGrant } from '../types/background';
 
-const PERMISSION_ALWAYS = -1;
+/** Event kinds are non-negative, so this only ever appears in pre-#136 records. */
+const LEGACY_AMBIGUOUS_KIND = -1;
+
+const SIGN_EVENT = 'sign_event';
 
 // In-memory cache
 let permissionCache: PermissionGrant[] | null = null;
+
+/** A pre-#136 record: no request type, and `eventKind` carrying both meanings. */
+interface LegacyPermissionGrant {
+  origin: string;
+  eventKind: number;
+  granted: boolean;
+  timestamp: number;
+  expiry?: number;
+}
+
+const isMigrated = (grant: PermissionGrant | LegacyPermissionGrant): grant is PermissionGrant =>
+  typeof (grant as PermissionGrant).requestType === 'string';
+
+/**
+ * Bring stored grants onto the keyed shape, narrowing wherever the original scope is ambiguous.
+ *
+ * A legacy record with a real event kind can only have come from a signing request, so it migrates
+ * intact. A legacy `-1` cannot be attributed after the fact — it may have been a non-signing grant
+ * or a signing wildcard — so it is discarded rather than guessed at. The user is asked again; no
+ * authority is invented (#136).
+ */
+const migrateGrants = (
+  stored: Array<PermissionGrant | LegacyPermissionGrant>,
+): { grants: PermissionGrant[]; discarded: number } => {
+  const grants: PermissionGrant[] = [];
+  let discarded = 0;
+
+  for (const grant of stored) {
+    if (isMigrated(grant)) {
+      grants.push(grant);
+      continue;
+    }
+
+    if (grant.eventKind === LEGACY_AMBIGUOUS_KIND) {
+      discarded += 1;
+      continue;
+    }
+
+    grants.push({
+      origin: grant.origin,
+      requestType: SIGN_EVENT,
+      eventKind: grant.eventKind,
+      granted: grant.granted,
+      timestamp: grant.timestamp,
+      ...(grant.expiry !== undefined ? { expiry: grant.expiry } : {}),
+    });
+  }
+
+  return { grants, discarded };
+};
 
 async function loadPermissions(): Promise<PermissionGrant[]> {
   if (permissionCache) {
     return permissionCache;
   }
 
-  const permissions = (await storageService.get<PermissionGrant[]>(PERMISSIONS_KEY)) || [];
-  permissionCache = permissions;
-  return permissions;
+  const stored =
+    (await storageService.get<Array<PermissionGrant | LegacyPermissionGrant>>(PERMISSIONS_KEY)) ||
+    [];
+  const { grants, discarded } = migrateGrants(stored);
+
+  if (discarded > 0 || grants.length !== stored.length) {
+    logService.log(LogLevel.WARN, '[Permissions] Discarded ambiguous pre-#136 grants', {
+      discarded,
+    });
+    permissionCache = grants;
+    await storageService.set(PERMISSIONS_KEY, grants);
+    return grants;
+  }
+
+  permissionCache = grants;
+  return grants;
 }
 
 async function savePermissions(permissions: PermissionGrant[]): Promise<void> {
@@ -25,33 +98,37 @@ async function savePermissions(permissions: PermissionGrant[]): Promise<void> {
   await storageService.set(PERMISSIONS_KEY, permissions);
 }
 
+const isLive = (grant: PermissionGrant, now: number): boolean =>
+  grant.granted && (grant.expiry === undefined || grant.expiry > now);
+
+const sameScope = (
+  grant: PermissionGrant,
+  origin: string,
+  requestType: string,
+  eventKind: PermissionEventKind,
+): boolean =>
+  grant.origin === origin && grant.requestType === requestType && grant.eventKind === eventKind;
+
 export async function checkPermission(
   origin: string,
-  eventKind: number,
+  requestType: string,
+  eventKind: PermissionEventKind,
 ): Promise<{ granted: boolean; always?: boolean }> {
   const permissions = await loadPermissions();
+  const now = Date.now();
 
-  const exactMatch = permissions.find(
-    (permission) => permission.origin === origin && permission.eventKind === eventKind,
-  );
-
+  const exactMatch = permissions.find((grant) => sameScope(grant, origin, requestType, eventKind));
   if (exactMatch) {
-    if (exactMatch.expiry && exactMatch.expiry < Date.now()) {
-      return { granted: false };
-    }
-
-    return {
-      granted: true,
-      always: !exactMatch.expiry,
-    };
+    return isLive(exactMatch, now) ? { granted: true, always: exactMatch.expiry === undefined } : { granted: false };
   }
 
-  const wildcardMatch = permissions.find(
-    (permission) => permission.origin === origin && permission.eventKind === PERMISSION_ALWAYS,
-  );
+  // A wildcard only ever answers a signing request, and only one written as a wildcard on purpose.
+  // It can no longer be produced as a side effect of a request that carries no event kind.
+  if (requestType !== SIGN_EVENT) return { granted: false };
 
-  if (wildcardMatch) {
-    return { granted: true, always: !wildcardMatch.expiry };
+  const wildcard = permissions.find((grant) => sameScope(grant, origin, SIGN_EVENT, 'any'));
+  if (wildcard && isLive(wildcard, now)) {
+    return { granted: true, always: wildcard.expiry === undefined };
   }
 
   return { granted: false };
@@ -59,40 +136,42 @@ export async function checkPermission(
 
 export async function grantPermission(
   origin: string,
-  eventKind: number,
+  requestType: string,
+  // Deliberately narrower than PermissionEventKind: a wildcard must be asked for explicitly on a
+  // signing request, and nothing offers that yet, so this path cannot create one (#136).
+  eventKind: number | null,
   duration: '8h' | 'always',
 ): Promise<void> {
-  const permissions = await loadPermissions();
+  if (duration !== '8h' && duration !== 'always') {
+    throw new Error(`Unsupported permission duration: ${String(duration)}`);
+  }
 
+  const permissions = await loadPermissions();
   const filtered = permissions.filter(
-    (permission) => !(permission.origin === origin && permission.eventKind === eventKind),
+    (grant) => !sameScope(grant, origin, requestType, eventKind),
   );
 
   const grant: PermissionGrant = {
     origin,
+    requestType,
     eventKind,
     granted: true,
     timestamp: Date.now(),
+    ...(duration === '8h' ? { expiry: Date.now() + 8 * 60 * 60 * 1000 } : {}),
   };
-
-  if (duration === '8h') {
-    grant.expiry = Date.now() + 8 * 60 * 60 * 1000;
-  } else if (duration !== 'always') {
-    throw new Error(`Unsupported permission duration: ${String(duration)}`);
-  }
 
   await savePermissions([...filtered, grant]);
 }
 
 export async function revokePermission(
   origin: string,
-  eventKind: number,
+  requestType: string,
+  eventKind: PermissionEventKind,
 ): Promise<void> {
   const permissions = await loadPermissions();
-  const filtered = permissions.filter(
-    (permission) => !(permission.origin === origin && permission.eventKind === eventKind),
+  await savePermissions(
+    permissions.filter((grant) => !sameScope(grant, origin, requestType, eventKind)),
   );
-  await savePermissions(filtered);
 }
 
 export async function getGrantedPermissions(): Promise<PermissionGrant[]> {

--- a/src-bex/types/background.ts
+++ b/src-bex/types/background.ts
@@ -39,9 +39,38 @@ export interface SignedEvent extends UnsignedEvent {
 }
 
 // Permission types
+/**
+ * What an event-kind scope means on a grant.
+ *
+ * `-1` used to carry two meanings at once: the approval call sites passed it for "this request has
+ * no event kind", while the checker read it as "any event kind". A request type with no kind could
+ * therefore write a grant the checker later honoured as a signing wildcard (#136). These are now
+ * separate values in separate key spaces.
+ */
+export type PermissionEventKind =
+  /** A specific Nostr event kind. Only ever set by a signing request. */
+  | number
+  /**
+   * Every event kind for this origin.
+   *
+   * Deliberately not producible by `grantPermission`: the approved contract says a wildcard must be
+   * asked for in those words on a signing request, and nothing offers that yet. The value exists so
+   * the checker and any future explicit path agree on how it is represented.
+   */
+  | 'any'
+  /** The request carries no event kind at all, such as `get_public_key`. */
+  | null;
+
 export interface PermissionGrant {
   origin: string;
-  eventKind: number;
+  /**
+   * The request type the grant was created from.
+   *
+   * Part of the key: a grant written by `get_public_key` lives in a different space from one
+   * written by `sign_event` and can never satisfy it.
+   */
+  requestType: string;
+  eventKind: PermissionEventKind;
   granted: boolean;
   timestamp: number;
   expiry?: number;

--- a/tests/unit/handlers/permission-handler.test.ts
+++ b/tests/unit/handlers/permission-handler.test.ts
@@ -1,218 +1,266 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { checkPermission, grantPermission, revokePermission, clearPermissionCache, getGrantedPermissions } from 'app/src-bex/handlers/permission-handler';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  checkPermission,
+  clearPermissionCache,
+  getGrantedPermissions,
+  grantPermission,
+  revokePermission,
+} from 'app/src-bex/handlers/permission-handler';
 import { storageService } from 'app/src/services/storage-service';
 import type { PermissionGrant } from 'app/src-bex/types/background';
 
 vi.mock('app/src/services/storage-service', () => ({
-  storageService: {
-    get: vi.fn(),
-    set: vi.fn(),
-  },
+  storageService: { get: vi.fn(), set: vi.fn() },
   PERMISSIONS_KEY: 'permissions',
 }));
 
-describe('PermissionHandler', () => {
-  const mockOrigin = 'https://example.com';
-  const mockKind = 1;
+vi.mock('src/services/log-service', () => ({
+  LogLevel: { WARN: 'warn' },
+  logService: { log: vi.fn() },
+}));
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-    clearPermissionCache();
+const ORIGIN = 'https://example.com';
+
+/** A pre-#136 record: no request type, and `eventKind` carrying both meanings. */
+interface LegacyGrant {
+  origin: string;
+  eventKind: number;
+  granted: boolean;
+  timestamp: number;
+  expiry?: number;
+}
+
+let stored: Array<PermissionGrant | LegacyGrant> = [];
+
+const seed = (records: Array<PermissionGrant | LegacyGrant>): void => {
+  stored = records;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearPermissionCache();
+  stored = [];
+  vi.mocked(storageService).get.mockImplementation(() => Promise.resolve(stored));
+  vi.mocked(storageService).set.mockImplementation((_key, value) => {
+    stored = value as PermissionGrant[];
+    return Promise.resolve();
   });
+});
 
-  it('should grant and check "always" permission', async () => {
-    let storedPermissions: PermissionGrant[] = [];
-    vi.mocked(storageService).get.mockImplementation(() => Promise.resolve(storedPermissions));
-    vi.mocked(storageService).set.mockImplementation((_key, val) => {
-      storedPermissions = val as PermissionGrant[];
-      return Promise.resolve();
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('permission grants', () => {
+  describe('duration', () => {
+    it('grants without expiry for "always"', async () => {
+      await grantPermission(ORIGIN, 'sign_event', 1, 'always');
+
+      const result = await checkPermission(ORIGIN, 'sign_event', 1);
+      expect(result).toEqual({ granted: true, always: true });
+      expect(stored[0]?.expiry).toBeUndefined();
     });
 
-    await grantPermission(mockOrigin, mockKind, 'always');
+    it('grants with an expiry for "8h", and stops granting once it passes', async () => {
+      const now = Date.now();
+      vi.useFakeTimers();
+      vi.setSystemTime(now);
 
-    const result = await checkPermission(mockOrigin, mockKind);
-    expect(result.granted).toBe(true);
-    expect(result.always).toBe(true);
-    expect(storedPermissions[0]?.expiry).toBeUndefined();
-  });
+      await grantPermission(ORIGIN, 'sign_event', 1, '8h');
+      expect(await checkPermission(ORIGIN, 'sign_event', 1)).toEqual({
+        granted: true,
+        always: false,
+      });
+      expect(stored[0]?.expiry).toBe(now + 8 * 60 * 60 * 1000);
 
-  it('should grant and check "8h" permission', async () => {
-    let storedPermissions: PermissionGrant[] = [];
-    vi.mocked(storageService).get.mockImplementation(() => Promise.resolve(storedPermissions));
-    vi.mocked(storageService).set.mockImplementation((_key, val) => {
-      storedPermissions = val as PermissionGrant[];
-      return Promise.resolve();
+      vi.advanceTimersByTime(8 * 60 * 60 * 1000 + 1);
+      expect(await checkPermission(ORIGIN, 'sign_event', 1)).toEqual({ granted: false });
     });
 
-    const now = Date.now();
-    vi.useFakeTimers();
-    vi.setSystemTime(now);
-
-    await grantPermission(mockOrigin, mockKind, '8h');
-
-    const result = await checkPermission(mockOrigin, mockKind);
-    expect(result.granted).toBe(true);
-    expect(result.always).toBe(false);
-    expect(storedPermissions[0]?.expiry).toBe(now + 8 * 60 * 60 * 1000);
-
-    // Advance time past 8 hours
-    vi.advanceTimersByTime(8 * 60 * 60 * 1000 + 1);
-
-    const expiredResult = await checkPermission(mockOrigin, mockKind);
-    expect(expiredResult.granted).toBe(false);
-
-    vi.useRealTimers();
+    it('refuses a duration it does not model', async () => {
+      await expect(
+        grantPermission(ORIGIN, 'sign_event', 1, 'forever' as '8h'),
+      ).rejects.toThrow(/Unsupported permission duration/);
+    });
   });
 
-  it('should handle "once" duration by not calling grantPermission in background (simulated here)', async () => {
-    // In the real app, 'once' is handled in background.ts and never reaches grantPermission.
-    // Here we verify that if it somehow reached grantPermission, it would now throw an error.
-    const storedPermissions: PermissionGrant[] = [];
-    vi.mocked(storageService).get.mockImplementation(() => Promise.resolve(storedPermissions));
+  /**
+   * The defect #136 exists for.
+   *
+   * `-1` meant "this request has no event kind" at the approval call sites and "any event kind" in
+   * the checker, so approving a `get_public_key` request with "always" wrote a record that
+   * authorised signing anything.
+   */
+  describe('key spaces (#136)', () => {
+    it('does not let a public-key grant authorise signing', async () => {
+      await grantPermission(ORIGIN, 'get_public_key', null, 'always');
 
-    const initialPermissions = await getGrantedPermissions();
-    expect(initialPermissions.length).toBe(0);
-
-    // @ts-expect-error - 'once' is not a valid duration for grantPermission
-    await expect(grantPermission(mockOrigin, mockKind, 'once'))
-      .rejects.toThrow('Unsupported permission duration: once');
-
-    const result = await checkPermission(mockOrigin, mockKind);
-    expect(result.granted).toBe(false);
-  });
-
-  it('should replace an existing permission with a new duration', async () => {
-    let storedPermissions: PermissionGrant[] = [];
-    vi.mocked(storageService).get.mockImplementation(() => Promise.resolve(storedPermissions));
-    vi.mocked(storageService).set.mockImplementation((_key, val) => {
-      storedPermissions = val as PermissionGrant[];
-      return Promise.resolve();
+      expect(await checkPermission(ORIGIN, 'sign_event', 1)).toEqual({ granted: false });
     });
 
-    // First grant "always"
-    await grantPermission(mockOrigin, mockKind, 'always');
-    expect(storedPermissions[0]?.expiry).toBeUndefined();
+    it('does not let a signing grant authorise a different request type', async () => {
+      await grantPermission(ORIGIN, 'sign_event', 1, 'always');
 
-    // Now grant "8h"
-    const now = Date.now();
-    vi.useFakeTimers();
-    vi.setSystemTime(now);
-
-    await grantPermission(mockOrigin, mockKind, '8h');
-    expect(storedPermissions.length).toBe(1);
-    expect(storedPermissions[0]?.expiry).toBe(now + 8 * 60 * 60 * 1000);
-
-    vi.useRealTimers();
-  });
-
-  it('should handle multiple origins and event kinds separately', async () => {
-    let storedPermissions: PermissionGrant[] = [];
-    vi.mocked(storageService).get.mockImplementation(() => Promise.resolve(storedPermissions));
-    vi.mocked(storageService).set.mockImplementation((_key, val) => {
-      storedPermissions = val as PermissionGrant[];
-      return Promise.resolve();
+      expect(await checkPermission(ORIGIN, 'nip04_decrypt', null)).toEqual({ granted: false });
     });
 
-    await grantPermission('https://site1.com', 1, 'always');
-    await grantPermission('https://site2.com', 1, '8h');
-    await grantPermission('https://site1.com', 4, 'always');
+    it('keeps each kindless request type separate from the others', async () => {
+      await grantPermission(ORIGIN, 'nip04_decrypt', null, 'always');
 
-    expect(storedPermissions.length).toBe(3);
-
-    const res1 = await checkPermission('https://site1.com', 1);
-    expect(res1.granted).toBe(true);
-    expect(res1.always).toBe(true);
-
-    const res2 = await checkPermission('https://site2.com', 1);
-    expect(res2.granted).toBe(true);
-    expect(res2.always).toBe(false);
-
-    const res3 = await checkPermission('https://site1.com', 4);
-    expect(res3.granted).toBe(true);
-    expect(res3.always).toBe(true);
-
-    const res4 = await checkPermission('https://site1.com', 7); // Not granted
-    expect(res4.granted).toBe(false);
-  });
-
-  it('should handle wildcard permission (eventKind -1)', async () => {
-    let storedPermissions: PermissionGrant[] = [];
-    vi.mocked(storageService).get.mockImplementation(() => Promise.resolve(storedPermissions));
-    vi.mocked(storageService).set.mockImplementation((_key, val) => {
-      storedPermissions = val as PermissionGrant[];
-      return Promise.resolve();
+      expect(await checkPermission(ORIGIN, 'nip44_decrypt', null)).toEqual({ granted: false });
+      expect(await checkPermission(ORIGIN, 'nip04_decrypt', null)).toEqual({
+        granted: true,
+        always: true,
+      });
     });
 
-    await grantPermission(mockOrigin, -1, 'always');
+    it('keeps each event kind separate', async () => {
+      await grantPermission(ORIGIN, 'sign_event', 1, 'always');
 
-    const result = await checkPermission(mockOrigin, 99);
-    expect(result.granted).toBe(true);
-  });
-
-  it('should revoke permission', async () => {
-    let storedPermissions: PermissionGrant[] = [{ origin: mockOrigin, eventKind: mockKind, granted: true, timestamp: Date.now() }];
-    vi.mocked(storageService).get.mockImplementation(() => Promise.resolve(storedPermissions));
-    vi.mocked(storageService).set.mockImplementation((_key, val) => {
-      storedPermissions = val as PermissionGrant[];
-      return Promise.resolve();
+      expect(await checkPermission(ORIGIN, 'sign_event', 5)).toEqual({ granted: false });
     });
 
-    await revokePermission(mockOrigin, mockKind);
+    it('keeps each origin separate', async () => {
+      await grantPermission(ORIGIN, 'sign_event', 1, 'always');
 
-    expect(storedPermissions.length).toBe(0);
-    const result = await checkPermission(mockOrigin, mockKind);
-    expect(result.granted).toBe(false);
+      expect(await checkPermission('https://other.example', 'sign_event', 1)).toEqual({
+        granted: false,
+      });
+    });
   });
 
-  it('should return all granted permissions via getGrantedPermissions', async () => {
-    let storedPermissions: PermissionGrant[] = [];
-    vi.mocked(storageService).get.mockImplementation(() => Promise.resolve(storedPermissions));
-    vi.mocked(storageService).set.mockImplementation((_key, val) => {
-      storedPermissions = val as PermissionGrant[];
-      return Promise.resolve();
+  /**
+   * The wildcard match is intentional and kept. What changed is that nothing can produce one as a
+   * side effect: it must be written as a wildcard on a signing request, and no path offers that yet.
+   */
+  describe('the signing wildcard', () => {
+    it('answers any kind for the same origin when one exists', async () => {
+      seed([
+        { origin: ORIGIN, requestType: 'sign_event', eventKind: 'any', granted: true, timestamp: 1 },
+      ]);
+
+      expect(await checkPermission(ORIGIN, 'sign_event', 30023)).toEqual({
+        granted: true,
+        always: true,
+      });
     });
 
-    await grantPermission('https://site1.com', 1, 'always');
-    await grantPermission('https://site2.com', 4, '8h');
+    it('answers only signing, never another request type', async () => {
+      seed([
+        { origin: ORIGIN, requestType: 'sign_event', eventKind: 'any', granted: true, timestamp: 1 },
+      ]);
 
-    const all = await getGrantedPermissions();
-    expect(all.length).toBe(2);
-    expect(all.find(p => p.origin === 'https://site1.com')?.eventKind).toBe(1);
-    expect(all.find(p => p.origin === 'https://site2.com')?.eventKind).toBe(4);
+      expect(await checkPermission(ORIGIN, 'get_public_key', null)).toEqual({ granted: false });
+    });
+
+    it('cannot be created through grantPermission', async () => {
+      await grantPermission(ORIGIN, 'sign_event', null, 'always');
+
+      // null is "this request carries no kind", not a wildcard, so signing stays unauthorised.
+      expect(await checkPermission(ORIGIN, 'sign_event', 1)).toEqual({ granted: false });
+      expect(stored.every((grant) => grant.eventKind !== 'any')).toBe(true);
+    });
   });
 
-  it('should respect the permission cache and allow clearing it', async () => {
-    const storedPermissions: PermissionGrant[] = [{ origin: mockOrigin, eventKind: mockKind, granted: true, timestamp: Date.now() }];
-    vi.mocked(storageService).get.mockResolvedValue(storedPermissions);
+  describe('migrating 0.0.32 records', () => {
+    it('keeps a legacy grant that names a real event kind, as signing', async () => {
+      seed([{ origin: ORIGIN, eventKind: 1, granted: true, timestamp: 1 }]);
 
-    // First call loads from storage
-    const firstCall = await getGrantedPermissions();
-    expect(firstCall.length).toBe(1);
-    expect(vi.mocked(storageService).get.mock.calls.length).toBe(1);
+      expect(await checkPermission(ORIGIN, 'sign_event', 1)).toEqual({ granted: true, always: true });
+    });
 
-    // Second call should use cache, so storage.get is NOT called again
-    const secondCall = await getGrantedPermissions();
-    expect(secondCall.length).toBe(1);
-    expect(vi.mocked(storageService).get.mock.calls.length).toBe(1);
+    it('discards a legacy -1, which cannot be attributed after the fact', async () => {
+      seed([{ origin: ORIGIN, eventKind: -1, granted: true, timestamp: 1 }]);
 
-    // Clearing cache should force a new storage read
-    clearPermissionCache();
-    const thirdCall = await getGrantedPermissions();
-    expect(thirdCall.length).toBe(1);
-    expect(vi.mocked(storageService).get.mock.calls.length).toBe(2);
+      // It may have been a non-signing grant or a signing wildcard. Neither is assumed.
+      expect(await checkPermission(ORIGIN, 'sign_event', 1)).toEqual({ granted: false });
+      expect(await checkPermission(ORIGIN, 'get_public_key', null)).toEqual({ granted: false });
+      expect(await getGrantedPermissions()).toEqual([]);
+    });
+
+    it('broadens nothing: a legacy kind grant still answers only that kind', async () => {
+      seed([{ origin: ORIGIN, eventKind: 1, granted: true, timestamp: 1 }]);
+
+      expect(await checkPermission(ORIGIN, 'sign_event', 5)).toEqual({ granted: false });
+    });
+
+    it('preserves a legacy expiry', async () => {
+      const expiry = Date.now() + 60_000;
+      seed([{ origin: ORIGIN, eventKind: 1, granted: true, timestamp: 1, expiry }]);
+
+      const [grant] = await getGrantedPermissions();
+      expect(grant?.expiry).toBe(expiry);
+      expect(await checkPermission(ORIGIN, 'sign_event', 1)).toEqual({ granted: true, always: false });
+    });
+
+    it('writes the migrated shape back, so the discard is not re-done on every read', async () => {
+      seed([
+        { origin: ORIGIN, eventKind: 1, granted: true, timestamp: 1 },
+        { origin: ORIGIN, eventKind: -1, granted: true, timestamp: 1 },
+      ]);
+
+      await getGrantedPermissions();
+
+      expect(vi.mocked(storageService).set).toHaveBeenCalled();
+      expect(stored).toHaveLength(1);
+      expect(stored[0]).toMatchObject({ requestType: 'sign_event', eventKind: 1 });
+    });
+
+    it('leaves already-migrated records alone', async () => {
+      seed([
+        { origin: ORIGIN, requestType: 'sign_event', eventKind: 1, granted: true, timestamp: 1 },
+      ]);
+
+      await getGrantedPermissions();
+
+      expect(vi.mocked(storageService).set).not.toHaveBeenCalled();
+    });
   });
 
-  it('should reject unsupported duration values', async () => {
-    // @ts-expect-error - testing invalid duration
-    await expect(grantPermission(mockOrigin, mockKind, 'unsupported'))
-      .rejects.toThrow('Unsupported permission duration: unsupported');
+  describe('revoking', () => {
+    it('removes only the scope named', async () => {
+      await grantPermission(ORIGIN, 'sign_event', 1, 'always');
+      await grantPermission(ORIGIN, 'get_public_key', null, 'always');
 
-    // @ts-expect-error - Testing runtime rejection of invalid type
-    await expect(grantPermission(mockOrigin, mockKind, 'invalid'))
-      .rejects.toThrow('Unsupported permission duration: invalid');
+      await revokePermission(ORIGIN, 'sign_event', 1);
 
-    // @ts-expect-error - Testing runtime rejection of another invalid type
-    await expect(grantPermission(mockOrigin, mockKind, '24h'))
-      .rejects.toThrow('Unsupported permission duration: 24h');
+      expect(await checkPermission(ORIGIN, 'sign_event', 1)).toEqual({ granted: false });
+      expect(await checkPermission(ORIGIN, 'get_public_key', null)).toEqual({
+        granted: true,
+        always: true,
+      });
+    });
+  });
+
+  describe('listing', () => {
+    it('returns every live grant', async () => {
+      await grantPermission('https://site1.example', 'sign_event', 1, 'always');
+      await grantPermission('https://site2.example', 'sign_event', 4, '8h');
+
+      const all = await getGrantedPermissions();
+
+      expect(all).toHaveLength(2);
+      expect(all.map((grant) => grant.origin).sort()).toEqual([
+        'https://site1.example',
+        'https://site2.example',
+      ]);
+    });
+  });
+
+  describe('caching', () => {
+    it('reads storage once until the cache is cleared', async () => {
+      seed([
+        { origin: ORIGIN, requestType: 'sign_event', eventKind: 1, granted: true, timestamp: 1 },
+      ]);
+
+      await getGrantedPermissions();
+      await getGrantedPermissions();
+      expect(vi.mocked(storageService).get).toHaveBeenCalledTimes(1);
+
+      clearPermissionCache();
+      await getGrantedPermissions();
+      expect(vi.mocked(storageService).get).toHaveBeenCalledTimes(2);
+    });
   });
 });


### PR DESCRIPTION
Fixes #136.

Taken first because **#116's own plan says to** — both migrate the same record, and doing them in the
other order means two migrations over the same data. It is also a live privilege escalation.

## The escalation, confirmed before changing anything

`-1` carried two meanings at once:

- the approval call sites pass it for *"this request has no event kind"*
- `checkPermission` read it as *"any event kind"*

So approving **"share my public key — always"** wrote a record the checker later honoured as a
signing wildcard. The site could then sign **any event kind** without ever asking to sign.

I probed the current code before touching it:

```
grantPermission('https://example.com', -1, 'always')   // what the get_public_key path does
checkPermission('https://example.com', 1).granted      // → true
```

## The fix

A grant is now keyed by **origin, request type, and event kind**.

| Request | Stored as | Answers |
|---|---|---|
| `sign_event` kind 1 | `{sign_event, 1}` | only kind 1 signing |
| `get_public_key` | `{get_public_key, null}` | only public-key requests |
| `nip04_decrypt` | `{nip04_decrypt, null}` | only NIP-04 decrypt — not NIP-44 |

Kindless request types get their own key space and cannot answer a signing check. They are also
separate from each other, which the old model could not express at all.

**The wildcard is kept but can no longer be produced as a side effect.** It is intentional, so the
checker still honours one; `grantPermission` now takes `number | null` and cannot write one. A
genuine "sign any kind" grant has to be asked for in those words on a signing request, and nothing
offers that yet — which is what #136 asked for.

## Migration narrows, never broadens

On read, stored records move onto the keyed shape:

- a legacy grant naming a **real event kind** can only have come from a signing request, so it
  survives as one, expiry intact
- a legacy **`-1` is discarded** — it may have been a non-signing grant or a signing wildcard, and
  the record does not say, so nothing is assumed

The migrated shape is written back, so the discard is not repeated on every read.

## User-visible impact, deliberately

Anyone who granted "always" on a public-key or encryption request **will be asked again**. That is
the point: those grants authorised more than they appeared to.

## Tests

The suite is rewritten around the security properties rather than the old signature — 20 tests
covering duration handling, key-space separation, the wildcard's new limits, migration in both
directions, revocation scope, and caching.

The wildcard test #136 warned about is changed **deliberately**, as that issue asked: it now asserts
the wildcard answers signing only, and separately that `grantPermission` cannot create one.

`lint`, `typecheck` and `test:run` pass — 745 tests, up from 734.

## Next

This unblocks #116, which adds the account dimension on top of the corrected shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)