### PR TITLE
feat(security): act as the bound account in encryption and zap handlers

### DIFF
--- a/src-bex/handlers/nip04.ts
+++ b/src-bex/handlers/nip04.ts
@@ -1,14 +1,13 @@
 import { nip04 } from 'nostr-tools';
 import type { HandlerResult } from '../types/background';
-import { getActiveSecretKey } from './active-key';
+import { resolveSigningSecretKey } from '../services/signing-account';
 
 export async function handleNip04Encrypt(
   payload: { pubkey: string; plaintext: string },
-  _origin?: string,
+  origin: string,
 ): Promise<HandlerResult<string>> {
-  void _origin;
   try {
-    const secretKey = await getActiveSecretKey();
+    const secretKey = await resolveSigningSecretKey(origin);
     const ciphertext = nip04.encrypt(secretKey, payload.pubkey, payload.plaintext);
     return { success: true, data: ciphertext };
   } catch (error: unknown) {
@@ -21,11 +20,10 @@ export async function handleNip04Encrypt(
 
 export async function handleNip04Decrypt(
   payload: { pubkey: string; ciphertext: string },
-  _origin?: string,
+  origin: string,
 ): Promise<HandlerResult<string>> {
-  void _origin;
   try {
-    const secretKey = await getActiveSecretKey();
+    const secretKey = await resolveSigningSecretKey(origin);
     const plaintext = nip04.decrypt(secretKey, payload.pubkey, payload.ciphertext);
     return { success: true, data: plaintext };
   } catch (error: unknown) {

--- a/src-bex/handlers/nip07.ts
+++ b/src-bex/handlers/nip07.ts
@@ -3,13 +3,11 @@
  */
 
 import type { HandlerResult, UnsignedEvent, SignedEvent } from '../types/background';
-import type { StoredKey } from 'src/types';
 import { finalizeEvent } from 'nostr-tools';
 import { hexToBytes } from '@noble/hashes/utils';
-import { isVaultUnlocked, getVaultData } from '../vault';
-import { NOSTR_ACTIVE, storageService } from 'src/services/storage-service';
+import { isVaultUnlocked } from '../vault';
 import { checkPermission } from './permission-handler';
-import { bindOriginIfUnbound, getBinding } from '../services/site-binding-store';
+import { resolveSigningAccount } from '../services/signing-account';
 import { logService } from 'src/services/log-service';
 import { ErrorCode } from 'src/types/error-codes.d';
 
@@ -17,57 +15,6 @@ const logWrapper = <TArgs extends unknown[], TResult>(
   fn: (...args: TArgs) => Promise<TResult>,
   name: string,
 ) => logService.wrapWithLogging(fn, 'Nip07Handler', name);
-
-async function listAccounts(): Promise<StoredKey[]> {
-  const vaultDataRes = await getVaultData();
-  if (!vaultDataRes.success || !vaultDataRes.vaultData) return [];
-
-  const data = vaultDataRes.vaultData as { accounts?: StoredKey[] };
-  return data.accounts ?? [];
-}
-
-async function getActiveAccount(): Promise<StoredKey | null> {
-  const alias = await storageService.get<string>(NOSTR_ACTIVE);
-
-  if (!alias) return null;
-
-  const accounts = await listAccounts();
-  return accounts.find((acc) => acc.alias === alias) || null;
-}
-
-/**
- * The account a site signs as.
- *
- * Bound accounts only: a site keeps the identity it was bound to, whatever is active now (#116). A
- * client caches the public key it received at login and assumes every later signature comes from
- * it, so following the active account would silently make that untrue.
- *
- * An unbound site binds to the active account here, because the first request has to establish it
- * somehow. Everything after that is fixed.
- */
-async function getSigningAccount(origin: string): Promise<
-  { account: StoredKey } | { error: string; code: ErrorCode }
-> {
-  const accounts = await listAccounts();
-  const binding = await getBinding(origin);
-
-  if (binding) {
-    const bound = accounts.find((acc) => acc.id === binding.pubkey);
-    if (bound) return { account: bound };
-
-    // Fail closed. Falling back to the active account is exactly the substitution this prevents.
-    return {
-      error: 'The account this site is connected to is no longer available',
-      code: ErrorCode.SIG_NO_ACTIVE_KEY,
-    };
-  }
-
-  const active = await getActiveAccount();
-  if (!active) return { error: 'No active account', code: ErrorCode.SIG_NO_ACTIVE_KEY };
-
-  await bindOriginIfUnbound(origin, active.id);
-  return { account: active };
-}
 
 export const handleGetPublicKey = logWrapper(async (
   _payload: unknown,
@@ -79,7 +26,7 @@ export const handleGetPublicKey = logWrapper(async (
   }
 
   // This is where a site's identity is established, and the answer a client will cache.
-  const resolved = await getSigningAccount(origin);
+  const resolved = await resolveSigningAccount(origin);
   if ('error' in resolved) {
     return { success: false, error: resolved.error, code: resolved.code };
   }
@@ -109,7 +56,7 @@ export const handleSignEvent = logWrapper(async (
 
   // The site's bound account, not the active one: a signature must come from the identity the site
   // was given at login (#116).
-  const resolved = await getSigningAccount(origin);
+  const resolved = await resolveSigningAccount(origin);
   if ('error' in resolved) {
     return { success: false, error: resolved.error, code: resolved.code };
   }

--- a/src-bex/handlers/nip44.ts
+++ b/src-bex/handlers/nip44.ts
@@ -1,15 +1,14 @@
 import { nip44 } from 'nostr-tools';
 import type { HandlerResult } from '../types/background';
-import { getActiveSecretKey } from './active-key';
+import { resolveSigningSecretKey } from '../services/signing-account';
 
 export async function handleNip44Encrypt(
   payload: { pubkey: string; plaintext: string },
-  _origin?: string,
+  origin: string,
 ): Promise<HandlerResult<string>> {
-  void _origin;
 
   try {
-    const secretKey = await getActiveSecretKey();
+    const secretKey = await resolveSigningSecretKey(origin);
     const conversationKey = nip44.getConversationKey(secretKey, payload.pubkey);
     const ciphertext = nip44.encrypt(payload.plaintext, conversationKey);
 
@@ -25,12 +24,11 @@ export async function handleNip44Encrypt(
 
 export async function handleNip44Decrypt(
   payload: { pubkey: string; ciphertext: string },
-  _origin?: string,
+  origin: string,
 ): Promise<HandlerResult<string>> {
-  void _origin;
 
   try {
-    const secretKey = await getActiveSecretKey();
+    const secretKey = await resolveSigningSecretKey(origin);
     const conversationKey = nip44.getConversationKey(secretKey, payload.pubkey);
     const plaintext = nip44.decrypt(payload.ciphertext, conversationKey);
 

--- a/src-bex/handlers/nip57.ts
+++ b/src-bex/handlers/nip57.ts
@@ -1,5 +1,6 @@
 import type { HandlerResult } from '../types/background';
 import type { StoredKey } from 'src/types';
+import { resolveSigningAccount } from '../services/signing-account';
 import type { VaultData } from 'src/types/bridge';
 import type {
   Nip57ZapHistoryEntry,
@@ -9,7 +10,6 @@ import type {
   ZapCapabilities,
 } from 'src/types/nip57';
 import { getVaultData, updateVaultData } from '../vault';
-import { NOSTR_ACTIVE, storageService } from 'src/services/storage-service';
 import { findNip47Connection, listNip47Connections } from '../services/nip47-connection-store';
 import { nip47Client } from '../services/nip47-client';
 import { appendNip57ZapHistory, listNip57ZapHistory } from '../services/nip57-zap-history-store';
@@ -25,12 +25,21 @@ async function requireUnlockedVaultData(): Promise<VaultData> {
   return result.vaultData as VaultData;
 }
 
-async function getActiveAccount(vaultData: VaultData): Promise<StoredKey | undefined> {
-  const activeAlias = await storageService.get<string>(NOSTR_ACTIVE);
-  if (activeAlias) {
-    return vaultData.accounts.find((account) => account.alias === activeAlias);
-  }
-  return vaultData.accounts[0];
+/**
+ * The account a zap is sent from.
+ *
+ * A zap request is a signed Nostr event carrying the sender's identity, so it follows the same rule
+ * as every other site-initiated action: the site's bound account, never whichever is active (#116).
+ * Falling back to `accounts[0]` when nothing is active, as this used to, could attribute a payment
+ * to an identity the user never chose.
+ */
+async function getZapAccount(vaultData: VaultData, origin: string): Promise<StoredKey | undefined> {
+  const resolved = await resolveSigningAccount(origin);
+  if ('error' in resolved) return undefined;
+
+  // Resolved against the vault snapshot this call already holds, so the account and the wallet
+  // connection below are read from one consistent view.
+  return vaultData.accounts.find((account) => account.id === resolved.account.id);
 }
 
 function normalizeAmountMsat(request: SendZapRequest): number {
@@ -164,9 +173,9 @@ export async function handleNip57SendZap(payload: {
 
   const amountMsat = normalizeAmountMsat(payload.request);
   const vaultData = await requireUnlockedVaultData();
-  const account = await getActiveAccount(vaultData);
+  const account = await getZapAccount(vaultData, payload.origin);
   if (!account) {
-    throw new Error('No active account');
+    throw new Error('No account is available for this site');
   }
   const connection = payload.request.walletConnectionId
     ? findNip47Connection(vaultData, payload.request.walletConnectionId)

--- a/src-bex/services/signing-account.ts
+++ b/src-bex/services/signing-account.ts
@@ -1,0 +1,88 @@
+/**
+ * Which account acts for a site.
+ *
+ * A site is bound to an account, and everything done on that site's behalf — signing, encrypting,
+ * decrypting, zapping — uses the bound account rather than whichever account happens to be active
+ * (#116). A NIP-07 client caches the public key it received at login and attributes everything
+ * afterwards to that identity, so following the active account would silently break that.
+ *
+ * Encryption matters here as much as signing. Encrypting under the wrong identity tells the
+ * recipient the wrong thing about who is talking to them, and decryption under the wrong key simply
+ * fails, which looks like data loss rather than an identity mix-up.
+ */
+
+import { hexToBytes } from '@noble/hashes/utils';
+
+import { NOSTR_ACTIVE, storageService } from 'src/services/storage-service';
+import type { StoredKey } from 'src/types';
+import { ErrorCode } from 'src/types/error-codes.d';
+import { getVaultData, isVaultUnlocked } from '../vault';
+import { bindOriginIfUnbound, getBinding } from './site-binding-store';
+
+export type SigningAccountResult =
+  | { account: StoredKey }
+  | { error: string; code: ErrorCode };
+
+export const BOUND_ACCOUNT_GONE =
+  'The account this site is connected to is no longer available';
+
+async function listAccounts(): Promise<StoredKey[]> {
+  const vaultDataRes = await getVaultData();
+  if (!vaultDataRes.success || !vaultDataRes.vaultData) return [];
+
+  const data = vaultDataRes.vaultData as { accounts?: StoredKey[] };
+  return data.accounts ?? [];
+}
+
+export async function getActiveAccount(): Promise<StoredKey | null> {
+  const alias = await storageService.get<string>(NOSTR_ACTIVE);
+  if (!alias) return null;
+
+  const accounts = await listAccounts();
+  return accounts.find((acc) => acc.alias === alias) ?? null;
+}
+
+/**
+ * Resolves the account a site acts as, binding it on first contact.
+ *
+ * An unbound site binds to the active account, because the first request has to establish the
+ * binding somehow. Everything after that is fixed: `bindOriginIfUnbound` never overwrites.
+ */
+export async function resolveSigningAccount(origin: string): Promise<SigningAccountResult> {
+  // Checked here rather than inferred from an empty account list: a locked vault and a vault with
+  // no accounts are different problems, and the caller's error message should say which. The
+  // encryption handlers used to get this from `getActiveSecretKey`, which this replaced.
+  if (!isVaultUnlocked()) {
+    return { error: 'Vault is locked', code: ErrorCode.VLT_LOCKED };
+  }
+
+  const binding = await getBinding(origin);
+
+  if (binding) {
+    const accounts = await listAccounts();
+    const bound = accounts.find((acc) => acc.id === binding.pubkey);
+    if (bound) return { account: bound };
+
+    // Fail closed. Falling back to the active account is the substitution this exists to prevent.
+    return { error: BOUND_ACCOUNT_GONE, code: ErrorCode.SIG_NO_ACTIVE_KEY };
+  }
+
+  const active = await getActiveAccount();
+  if (!active) return { error: 'No active account', code: ErrorCode.SIG_NO_ACTIVE_KEY };
+
+  await bindOriginIfUnbound(origin, active.id);
+  return { account: active };
+}
+
+/**
+ * The bound account's secret key, for the encryption handlers.
+ *
+ * Throws rather than returning a result, because those handlers already turn a thrown error into
+ * their failure shape and there is nothing useful to add on the way through.
+ */
+export async function resolveSigningSecretKey(origin: string): Promise<Uint8Array> {
+  const resolved = await resolveSigningAccount(origin);
+  if ('error' in resolved) throw new Error(resolved.error);
+
+  return hexToBytes(resolved.account.account.privkey);
+}

--- a/tests/unit/handlers/nip04.test.ts
+++ b/tests/unit/handlers/nip04.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleNip04Encrypt, handleNip04Decrypt } from 'app/src-bex/handlers/nip04';
 import { handleVaultGetData, handleVaultIsUnlocked } from 'app/src-bex/handlers/vault-handler';
 import { storageService } from 'src/services/storage-service';
+import { isVaultUnlocked, getVaultData } from 'app/src-bex/vault';
+import { clearSiteBindingCache } from 'app/src-bex/services/site-binding-store';
 import { nip04 } from 'nostr-tools';
 
 // Mock dependencies
@@ -10,11 +12,23 @@ vi.mock('app/src-bex/handlers/vault-handler', () => ({
   handleVaultGetData: vi.fn(),
 }));
 
+vi.mock('app/src-bex/vault', () => ({
+  isVaultUnlocked: vi.fn(),
+  getVaultData: vi.fn(),
+}));
+
+vi.mock('src/services/log-service', () => ({
+  LogLevel: { INFO: 'info' },
+  logService: { log: vi.fn() },
+}));
+
 vi.mock('src/services/storage-service', () => ({
   storageService: {
     get: vi.fn(),
+    set: vi.fn(() => Promise.resolve()),
   },
   NOSTR_ACTIVE: 'nostr_active_account',
+  SITE_BINDINGS_KEY: 'nostr:site-bindings',
 }));
 
 vi.mock('nostr-tools', () => ({
@@ -28,6 +42,8 @@ vi.mock('@noble/hashes/utils', () => ({
   hexToBytes: vi.fn((hex) => Buffer.from(hex, 'hex')),
 }));
 
+const ORIGIN = 'https://example.com';
+
 describe('Nip04Handler', () => {
   const mockAccount = {
     id: 'test-pubkey',
@@ -40,23 +56,18 @@ describe('Nip04Handler', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Bindings are cached in module scope, so one test's binding would decide the next one's key.
+    clearSiteBindingCache();
   });
 
   describe('handleNip04Encrypt', () => {
     it('should encrypt when vault is unlocked and account exists', async () => {
-      vi.mocked(handleVaultIsUnlocked).mockResolvedValue({ success: true, data: true });
+      vi.mocked(isVaultUnlocked).mockReturnValue(true);
       vi.mocked(storageService['get']).mockResolvedValue('test-alias');
-      vi.mocked(handleVaultGetData).mockResolvedValue({
-        success: true,
-        data: {
-          vaultData: {
-            accounts: [mockAccount],
-          },
-        },
-      });
+      vi.mocked(getVaultData).mockResolvedValue({ success: true, vaultData: { accounts: [mockAccount] } });
       vi.mocked(nip04.encrypt).mockReturnValue('ciphertext');
 
-      const result = await handleNip04Encrypt({ pubkey: 'recipient-pubkey', plaintext: 'hello' });
+      const result = await handleNip04Encrypt({ pubkey: 'recipient-pubkey', plaintext: 'hello' }, ORIGIN);
 
       expect(result.success).toBe(true);
       if (result.success) {
@@ -66,9 +77,9 @@ describe('Nip04Handler', () => {
     });
 
     it('should return error when vault is locked', async () => {
-      vi.mocked(handleVaultIsUnlocked).mockResolvedValue({ success: true, data: false });
+      vi.mocked(isVaultUnlocked).mockReturnValue(false);
 
-      const result = await handleNip04Encrypt({ pubkey: 'recipient-pubkey', plaintext: 'hello' });
+      const result = await handleNip04Encrypt({ pubkey: 'recipient-pubkey', plaintext: 'hello' }, ORIGIN);
 
       expect(result.success).toBe(false);
       if (!result.success) {
@@ -77,33 +88,26 @@ describe('Nip04Handler', () => {
     });
 
     it('should return error when no active account', async () => {
-      vi.mocked(handleVaultIsUnlocked).mockResolvedValue({ success: true, data: true });
+      vi.mocked(isVaultUnlocked).mockReturnValue(true);
       vi.mocked(storageService['get']).mockResolvedValue(null);
 
-      const result = await handleNip04Encrypt({ pubkey: 'recipient-pubkey', plaintext: 'hello' });
+      const result = await handleNip04Encrypt({ pubkey: 'recipient-pubkey', plaintext: 'hello' }, ORIGIN);
 
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.error).toBe('No active account found');
+        expect(result.error).toBe('No active account');
       }
     });
   });
 
   describe('handleNip04Decrypt', () => {
     it('should decrypt when vault is unlocked and account exists', async () => {
-      vi.mocked(handleVaultIsUnlocked).mockResolvedValue({ success: true, data: true });
+      vi.mocked(isVaultUnlocked).mockReturnValue(true);
       vi.mocked(storageService['get']).mockResolvedValue('test-alias');
-      vi.mocked(handleVaultGetData).mockResolvedValue({
-        success: true,
-        data: {
-          vaultData: {
-            accounts: [mockAccount],
-          },
-        },
-      });
+      vi.mocked(getVaultData).mockResolvedValue({ success: true, vaultData: { accounts: [mockAccount] } });
       vi.mocked(nip04.decrypt).mockReturnValue('plaintext');
 
-      const result = await handleNip04Decrypt({ pubkey: 'sender-pubkey', ciphertext: 'ciphertext' });
+      const result = await handleNip04Decrypt({ pubkey: 'sender-pubkey', ciphertext: 'ciphertext' }, ORIGIN);
 
       expect(result.success).toBe(true);
       if (result.success) {
@@ -113,21 +117,14 @@ describe('Nip04Handler', () => {
     });
 
     it('should catch and return errors during decryption', async () => {
-      vi.mocked(handleVaultIsUnlocked).mockResolvedValue({ success: true, data: true });
+      vi.mocked(isVaultUnlocked).mockReturnValue(true);
       vi.mocked(storageService['get']).mockResolvedValue('test-alias');
-      vi.mocked(handleVaultGetData).mockResolvedValue({
-        success: true,
-        data: {
-          vaultData: {
-            accounts: [mockAccount],
-          },
-        },
-      });
+      vi.mocked(getVaultData).mockResolvedValue({ success: true, vaultData: { accounts: [mockAccount] } });
       vi.mocked(nip04.decrypt).mockImplementation(() => {
         throw new Error('Decryption failed');
       });
 
-      const result = await handleNip04Decrypt({ pubkey: 'sender-pubkey', ciphertext: 'ciphertext' });
+      const result = await handleNip04Decrypt({ pubkey: 'sender-pubkey', ciphertext: 'ciphertext' }, ORIGIN);
 
       expect(result.success).toBe(false);
       if (!result.success) {

--- a/tests/unit/handlers/nip44.test.ts
+++ b/tests/unit/handlers/nip44.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleNip44Encrypt, handleNip44Decrypt } from 'app/src-bex/handlers/nip44';
 import { handleVaultGetData, handleVaultIsUnlocked } from 'app/src-bex/handlers/vault-handler';
 import { storageService } from 'src/services/storage-service';
+import { isVaultUnlocked, getVaultData } from 'app/src-bex/vault';
+import { clearSiteBindingCache } from 'app/src-bex/services/site-binding-store';
 import { nip44 } from 'nostr-tools';
 import { resetAutoLockTimer } from 'app/src-bex/services/auto-lock';
 
@@ -10,11 +12,23 @@ vi.mock('app/src-bex/handlers/vault-handler', () => ({
   handleVaultGetData: vi.fn(),
 }));
 
+vi.mock('app/src-bex/vault', () => ({
+  isVaultUnlocked: vi.fn(),
+  getVaultData: vi.fn(),
+}));
+
+vi.mock('src/services/log-service', () => ({
+  LogLevel: { INFO: 'info' },
+  logService: { log: vi.fn() },
+}));
+
 vi.mock('src/services/storage-service', () => ({
   storageService: {
     get: vi.fn(),
+    set: vi.fn(() => Promise.resolve()),
   },
   NOSTR_ACTIVE: 'nostr_active_account',
+  SITE_BINDINGS_KEY: 'nostr:site-bindings',
 }));
 
 vi.mock('nostr-tools', () => ({
@@ -33,6 +47,8 @@ vi.mock('app/src-bex/services/auto-lock', () => ({
   resetAutoLockTimer: vi.fn(),
 }));
 
+const ORIGIN = 'https://example.com';
+
 describe('Nip44Handler', () => {
   const mockAccount = {
     id: 'test-pubkey',
@@ -45,19 +61,14 @@ describe('Nip44Handler', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Bindings are cached in module scope, so one test's binding would decide the next one's key.
+    clearSiteBindingCache();
   });
 
   function mockUnlockedActiveAccount(): void {
-    vi.mocked(handleVaultIsUnlocked).mockResolvedValue({ success: true, data: true });
+    vi.mocked(isVaultUnlocked).mockReturnValue(true);
     vi.mocked(storageService.get).mockResolvedValue('test-alias');
-    vi.mocked(handleVaultGetData).mockResolvedValue({
-      success: true,
-      data: {
-        vaultData: {
-          accounts: [mockAccount],
-        },
-      },
-    });
+    vi.mocked(getVaultData).mockResolvedValue({ success: true, vaultData: { accounts: [mockAccount] } });
   }
 
   it('encrypts when vault is unlocked and active account exists', async () => {
@@ -65,7 +76,7 @@ describe('Nip44Handler', () => {
     vi.mocked(nip44.getConversationKey).mockReturnValue(Uint8Array.from([1, 2, 3]));
     vi.mocked(nip44.encrypt).mockReturnValue('nip44-ciphertext');
 
-    const result = await handleNip44Encrypt({ pubkey: 'recipient-pubkey', plaintext: 'hello' });
+    const result = await handleNip44Encrypt({ pubkey: 'recipient-pubkey', plaintext: 'hello' }, ORIGIN);
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -82,7 +93,7 @@ describe('Nip44Handler', () => {
     vi.mocked(nip44.getConversationKey).mockReturnValue(Uint8Array.from([4, 5, 6]));
     vi.mocked(nip44.decrypt).mockReturnValue('hello');
 
-    const result = await handleNip44Decrypt({ pubkey: 'sender-pubkey', ciphertext: 'nip44-ciphertext' });
+    const result = await handleNip44Decrypt({ pubkey: 'sender-pubkey', ciphertext: 'nip44-ciphertext' }, ORIGIN);
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -95,9 +106,9 @@ describe('Nip44Handler', () => {
   });
 
   it('returns error when vault is locked', async () => {
-    vi.mocked(handleVaultIsUnlocked).mockResolvedValue({ success: true, data: false });
+    vi.mocked(isVaultUnlocked).mockReturnValue(false);
 
-    const result = await handleNip44Encrypt({ pubkey: 'recipient-pubkey', plaintext: 'hello' });
+    const result = await handleNip44Encrypt({ pubkey: 'recipient-pubkey', plaintext: 'hello' }, ORIGIN);
 
     expect(result.success).toBe(false);
     if (!result.success) {
@@ -106,14 +117,14 @@ describe('Nip44Handler', () => {
   });
 
   it('returns error when no active account exists', async () => {
-    vi.mocked(handleVaultIsUnlocked).mockResolvedValue({ success: true, data: true });
+    vi.mocked(isVaultUnlocked).mockReturnValue(true);
     vi.mocked(storageService.get).mockResolvedValue(null);
 
-    const result = await handleNip44Decrypt({ pubkey: 'sender-pubkey', ciphertext: 'nip44-ciphertext' });
+    const result = await handleNip44Decrypt({ pubkey: 'sender-pubkey', ciphertext: 'nip44-ciphertext' }, ORIGIN);
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error).toBe('No active account found');
+      expect(result.error).toBe('No active account');
     }
   });
 
@@ -124,7 +135,7 @@ describe('Nip44Handler', () => {
       throw new Error('invalid MAC');
     });
 
-    const result = await handleNip44Decrypt({ pubkey: 'sender-pubkey', ciphertext: 'bad-ciphertext' });
+    const result = await handleNip44Decrypt({ pubkey: 'sender-pubkey', ciphertext: 'bad-ciphertext' }, ORIGIN);
 
     expect(result.success).toBe(false);
     if (!result.success) {

--- a/tests/unit/handlers/nip57.test.ts
+++ b/tests/unit/handlers/nip57.test.ts
@@ -9,11 +9,18 @@ import { ErrorCode } from 'src/types/error-codes.d';
 vi.mock('app/src-bex/vault', () => ({
   getVaultData: vi.fn(),
   updateVaultData: vi.fn(),
+  isVaultUnlocked: vi.fn(() => true),
 }));
 
 vi.mock('src/services/storage-service', () => ({
   NOSTR_ACTIVE: 'NOSTR_ACTIVE',
-  storageService: { get: vi.fn() },
+  SITE_BINDINGS_KEY: 'nostr:site-bindings',
+  storageService: { get: vi.fn(), set: vi.fn(() => Promise.resolve()) },
+}));
+
+vi.mock('src/services/log-service', () => ({
+  LogLevel: { INFO: 'info' },
+  logService: { log: vi.fn() },
 }));
 
 vi.mock('app/src-bex/services/nip47-connection-store', () => ({
@@ -47,6 +54,7 @@ vi.mock('src/services/nip47-invoice', () => ({
 
 import { getVaultData, updateVaultData } from 'app/src-bex/vault';
 import { storageService } from 'src/services/storage-service';
+import { clearSiteBindingCache } from 'app/src-bex/services/site-binding-store';
 import { findNip47Connection, listNip47Connections } from 'app/src-bex/services/nip47-connection-store';
 import { nip47Client } from 'app/src-bex/services/nip47-client';
 import { appendNip57ZapHistory, listNip57ZapHistory } from 'app/src-bex/services/nip57-zap-history-store';
@@ -158,8 +166,14 @@ describe('handleNip57SendZap', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     globalThis.crypto.randomUUID = vi.fn(() => 'zap-entry-id') as () => `${string}-${string}-${string}-${string}-${string}`;
+    clearSiteBindingCache();
     vi.mocked(getVaultData).mockResolvedValue({ success: true, vaultData: baseVaultData() });
-    vi.mocked(storageService.get).mockResolvedValue(undefined);
+    // The zap now uses the site's bound account, which binds to the active one on first contact.
+    // This used to fall back to `accounts[0]` when nothing was active, which could attribute a
+    // payment to an identity the user never chose (#116).
+    vi.mocked(storageService.get).mockImplementation((key: string) =>
+      Promise.resolve(key === 'NOSTR_ACTIVE' ? account.alias : undefined),
+    );
     vi.mocked(updateVaultData).mockResolvedValue({ success: true });
   });
 

--- a/tests/unit/services/signing-account.test.ts
+++ b/tests/unit/services/signing-account.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('app/src-bex/vault', () => ({
+  isVaultUnlocked: vi.fn(() => true),
+  getVaultData: vi.fn(),
+}));
+
+vi.mock('src/services/storage-service', () => ({
+  storageService: { get: vi.fn(), set: vi.fn(() => Promise.resolve()) },
+  NOSTR_ACTIVE: 'nostr_active_account',
+  SITE_BINDINGS_KEY: 'nostr:site-bindings',
+}));
+
+vi.mock('src/services/log-service', () => ({
+  LogLevel: { INFO: 'info' },
+  logService: { log: vi.fn() },
+}));
+
+import { getVaultData, isVaultUnlocked } from 'app/src-bex/vault';
+import { storageService } from 'src/services/storage-service';
+import { clearSiteBindingCache } from 'app/src-bex/services/site-binding-store';
+import {
+  resolveSigningAccount,
+  resolveSigningSecretKey,
+} from 'app/src-bex/services/signing-account';
+import { ErrorCode } from 'src/types/error-codes.d';
+
+const alice = { id: 'a'.repeat(64), alias: 'alice', account: { privkey: '11'.repeat(32) } };
+const bob = { id: 'b'.repeat(64), alias: 'bob', account: { privkey: '22'.repeat(32) } };
+
+const ORIGIN = 'https://example.com';
+
+const withAccounts = (accounts: unknown[], activeAlias?: string): void => {
+  vi.mocked(storageService).get.mockImplementation((key: string) =>
+    Promise.resolve(key === 'nostr_active_account' ? activeAlias : []),
+  );
+  vi.mocked(getVaultData).mockResolvedValue({ success: true, vaultData: { accounts } });
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearSiteBindingCache();
+  vi.mocked(isVaultUnlocked).mockReturnValue(true);
+});
+
+describe('resolving the account that acts for a site', () => {
+  it('binds to the active account on first contact', async () => {
+    withAccounts([alice, bob], 'alice');
+
+    const resolved = await resolveSigningAccount(ORIGIN);
+
+    expect('account' in resolved && resolved.account.id).toBe(alice.id);
+  });
+
+  it('keeps the bound account after the active one changes', async () => {
+    withAccounts([alice, bob], 'alice');
+    await resolveSigningAccount(ORIGIN);
+
+    withAccounts([alice, bob], 'bob');
+    const resolved = await resolveSigningAccount(ORIGIN);
+
+    expect('account' in resolved && resolved.account.id).toBe(alice.id);
+  });
+
+  it('refuses rather than substituting when the bound account is gone', async () => {
+    withAccounts([alice, bob], 'alice');
+    await resolveSigningAccount(ORIGIN);
+
+    withAccounts([bob], 'bob');
+    const resolved = await resolveSigningAccount(ORIGIN);
+
+    expect('error' in resolved && resolved.error).toMatch(/no longer available/);
+  });
+
+  describe('when it cannot resolve', () => {
+    it('says the vault is locked, rather than reporting no account', async () => {
+      // The encryption handlers used to get this distinction from `getActiveSecretKey`; losing it
+      // would turn a locked vault into a confusing "no account" error.
+      vi.mocked(isVaultUnlocked).mockReturnValue(false);
+
+      const resolved = await resolveSigningAccount(ORIGIN);
+
+      expect(resolved).toEqual({ error: 'Vault is locked', code: ErrorCode.VLT_LOCKED });
+    });
+
+    it('reports no active account when the vault holds none', async () => {
+      withAccounts([], undefined);
+
+      const resolved = await resolveSigningAccount(ORIGIN);
+
+      expect('error' in resolved && resolved.error).toBe('No active account');
+    });
+  });
+
+  describe('the secret key for encryption', () => {
+    it('is the bound account key, never the active account key', async () => {
+      withAccounts([alice, bob], 'alice');
+      await resolveSigningAccount(ORIGIN);
+
+      withAccounts([alice, bob], 'bob');
+      const key = await resolveSigningSecretKey(ORIGIN);
+
+      // Encrypting under the wrong identity tells the recipient the wrong thing about who is
+      // talking to them, and decrypting under it simply fails.
+      expect(Buffer.from(key).toString('hex')).toBe(alice.account.privkey);
+    });
+
+    it('throws rather than returning a key it could not resolve', async () => {
+      vi.mocked(isVaultUnlocked).mockReturnValue(false);
+
+      await expect(resolveSigningSecretKey(ORIGIN)).rejects.toThrow('Vault is locked');
+    });
+  });
+});


### PR DESCRIPTION
Refs #116. Extends the binding rule from #164 to every remaining site-initiated action.

> **Stacked on #164**, which introduces the binding store this uses. Targets that branch and will
> retarget to `master` when it merges. Merge order: #163, then #164, then this.

## The gap

#164 made *signing* follow the site's bound account. Encryption, decryption and zaps still followed
whichever account was active — so a site that logged in as one identity could be handed a message
encrypted under another, or have a payment attributed to one the user never chose.

**Encryption matters as much as signing here.** Encrypting under the wrong identity tells the
recipient the wrong thing about who is talking to them, and decrypting under the wrong key fails in a
way that reads as data loss rather than an identity mix-up.

## What changed

| Handler | Before | After |
|---|---|---|
| `nip04` encrypt/decrypt | received `_origin`, discarded it | resolves the bound account |
| `nip44` encrypt/decrypt | received `_origin`, discarded it | resolves the bound account |
| `nip57` send zap | active account, falling back to `accounts[0]` | bound account, no fallback |

That nip57 fallback is worth calling out: with no active account it signed the zap request as
whichever account happened to be first in the vault. A payment attributed to an identity the user
never selected.

The resolver moves out of `nip07.ts` into `services/signing-account.ts`, so one rule covers every
site-initiated action instead of being restated per handler.

## A check the move would have dropped

The encryption handlers reached the vault through `getActiveSecretKey`, which threw **"Vault is
locked"**. Resolving through `getVaultData` alone would still have failed closed, but reported **"no
active account"** — a misleading error for a locked vault.

I caught this from an existing test's expectation rather than by reading the new path. The resolver
now checks the lock itself and says which problem it is, and there is a test asserting the
distinction.

## Tests

The suites that mocked the old `active-key` path are rewired onto the resolver. The nip57 suite
relied on the `accounts[0]` fallback, so it now sets an active account — which is what a real vault
has.

**Mutation-checked:** making the resolver ignore the binding fails exactly the six tests that assert
the security property, across both the resolver and the nip07 suites.

`lint`, `typecheck` and `test:run` pass — 768 tests, up from 761.

## Still open on #116

The account dimension on the permission record, bridge events to list and revoke grants, the
Connected Sites view, the 0.0.32 grant migration, the "Approved Clients" metric, and the header
account switcher slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)