### PR TITLE
feat(security): key permission grants by account

### DIFF
--- a/src-bex/background.ts
+++ b/src-bex/background.ts
@@ -36,6 +36,7 @@ import {
 } from './services/request-queue';
 import { observePanelConnections } from './services/panel-presence';
 import { refreshAttention } from './services/attention-badge';
+import { resolveSigningAccount } from './services/signing-account';
 import {
   getPageOrigin,
   listPageOrigins,
@@ -551,20 +552,28 @@ async function requestApproval(
 ): Promise<boolean> {
   const permissionKind = toPermissionKind(eventKind);
 
-  if (!details.skipPermissionCheck) {
-    const permission = await checkPermission(origin, details.requestType, permissionKind);
+  // The account that will act for this site, which is the one a grant belongs to. Resolved before
+  // the permission check so a grant given to one identity cannot answer for another (#116).
+  const resolved = await resolveSigningAccount(origin);
+  const actingAccount = 'account' in resolved ? resolved.account : null;
+
+  if (!details.skipPermissionCheck && actingAccount) {
+    const permission = await checkPermission(
+      origin,
+      actingAccount.id,
+      details.requestType,
+      permissionKind,
+    );
     if (permission.granted) return true;
   }
 
-  const activeStoredKey = await getActiveStoredKey();
   const { record, decision } = await enqueueRequest({
     origin,
     requestType: details.requestType,
     eventKind,
-    accountAlias: activeStoredKey?.alias ?? null,
-    // StoredKey carries no public key, and deriving one would need an unlocked vault and key
-    // material for a display field. #116 owns the account dimension and populates this.
-    accountPubkey: null,
+    accountAlias: actingAccount?.alias ?? null,
+    // The identity the user is deciding for, shown on the approval and recorded on the grant.
+    accountPubkey: actingAccount?.id ?? null,
   }, {
     // Reviewable detail stays in worker memory for the life of the request.
     ...(details.contentDescription !== undefined
@@ -591,7 +600,13 @@ async function requestApproval(
     !details.skipPermissionCheck
   ) {
     try {
-      await grantPermission(origin, details.requestType, permissionKind, durationLabel);
+      await grantPermission(
+        origin,
+        record.accountPubkey ?? '',
+        details.requestType,
+        permissionKind,
+        durationLabel,
+      );
     } catch (error: unknown) {
       logService.log(LogLevel.ERROR, '[BEX] Failed to grant permission', {
         error: error instanceof Error ? error.message : String(error),

--- a/src-bex/handlers/nip07.ts
+++ b/src-bex/handlers/nip07.ts
@@ -44,23 +44,24 @@ export const handleSignEvent = logWrapper(async (
     return { success: false, error: 'Vault is locked', code: ErrorCode.VLT_LOCKED };
   }
 
-  // Check permission
-  if (!options.skipPermissionCheck) {
-    // Signing is its own key space: a grant from a request that carries no event kind can never
-    // answer this check (#136).
-    const permission = await checkPermission(origin, 'sign_event', payload.event.kind);
-    if (!permission.granted) {
-      return { success: false, error: 'Permission denied', code: ErrorCode.PER_DENIED };
-    }
-  }
-
-  // The site's bound account, not the active one: a signature must come from the identity the site
-  // was given at login (#116).
+  // Resolved before the permission check, not after: the check is against the account that will
+  // actually sign. The site's bound account, never the active one, so a signature comes from the
+  // identity the site was given at login (#116).
   const resolved = await resolveSigningAccount(origin);
   if ('error' in resolved) {
     return { success: false, error: resolved.error, code: resolved.code };
   }
   const account = resolved.account;
+
+  // Check permission
+  if (!options.skipPermissionCheck) {
+    // In signing's own key space, and against this account: a grant given to another identity, or
+    // by a request carrying no event kind, cannot answer it (#116, #136).
+    const permission = await checkPermission(origin, account.id, 'sign_event', payload.event.kind);
+    if (!permission.granted) {
+      return { success: false, error: 'Permission denied', code: ErrorCode.PER_DENIED };
+    }
+  }
 
   try {
     // Set the correct pubkey

--- a/src-bex/handlers/permission-handler.ts
+++ b/src-bex/handlers/permission-handler.ts
@@ -1,44 +1,52 @@
 /**
  * Permission management for Nostr signing and non-signing requests.
  *
- * A grant is keyed by origin, request type, and event kind. The request type is part of the key
- * because it used to be absent: every grant was `(origin, eventKind)`, and `-1` meant "no event
- * kind" at the approval call sites but "any event kind" in the checker. Approving a
- * `get_public_key` request with "always" therefore wrote a record that authorised signing any event
- * kind, with no further prompt (#136).
+ * A grant is keyed by origin, account, request type, and event kind.
+ *
+ * The request type is part of the key because it used to be absent: every grant was
+ * `(origin, eventKind)`, and `-1` meant "no event kind" at the approval call sites but "any event
+ * kind" in the checker, so approving a `get_public_key` request with "always" wrote a record that
+ * authorised signing any event kind (#136).
+ *
+ * The account is part of the key because a grant belongs to the identity the user was looking at
+ * when they gave it. Without it, connecting a second account to a site inherited the first
+ * account's permissions (#116).
  */
 
 import { PERMISSIONS_KEY, storageService } from 'src/services/storage-service';
 import { LogLevel, logService } from 'src/services/log-service';
 import type { PermissionEventKind, PermissionGrant } from '../types/background';
 
-/** Event kinds are non-negative, so this only ever appears in pre-#136 records. */
-const LEGACY_AMBIGUOUS_KIND = -1;
-
 const SIGN_EVENT = 'sign_event';
 
 // In-memory cache
 let permissionCache: PermissionGrant[] | null = null;
 
-/** A pre-#136 record: no request type, and `eventKind` carrying both meanings. */
+/** Anything written before the current shape: missing a request type, an account, or both. */
 interface LegacyPermissionGrant {
   origin: string;
-  eventKind: number;
+  eventKind: number | PermissionEventKind;
+  requestType?: string;
+  accountPubkey?: string;
   granted: boolean;
   timestamp: number;
   expiry?: number;
 }
 
 const isMigrated = (grant: PermissionGrant | LegacyPermissionGrant): grant is PermissionGrant =>
-  typeof (grant as PermissionGrant).requestType === 'string';
+  typeof (grant as PermissionGrant).requestType === 'string' &&
+  typeof (grant as PermissionGrant).accountPubkey === 'string';
 
 /**
- * Bring stored grants onto the keyed shape, narrowing wherever the original scope is ambiguous.
+ * Bring stored grants onto the keyed shape, discarding whatever cannot be attributed.
  *
- * A legacy record with a real event kind can only have come from a signing request, so it migrates
- * intact. A legacy `-1` cannot be attributed after the fact — it may have been a non-signing grant
- * or a signing wildcard — so it is discarded rather than guessed at. The user is asked again; no
- * authority is invented (#136).
+ * Every record written before the account dimension existed is ambiguous in the same way: it does
+ * not say which identity the user was granting for. A vault with several accounts gives no way to
+ * tell, and a vault with one today may have had others yesterday. Guessing would hand one identity
+ * the authority another was given, which is the defect this dimension exists to prevent.
+ *
+ * So they are discarded. The user is asked again the next time a site requests something, and the
+ * new grant records the account. Nothing is broadened, and no authority is invented (#116, SR-6).
  */
 const migrateGrants = (
   stored: Array<PermissionGrant | LegacyPermissionGrant>,
@@ -52,19 +60,7 @@ const migrateGrants = (
       continue;
     }
 
-    if (grant.eventKind === LEGACY_AMBIGUOUS_KIND) {
-      discarded += 1;
-      continue;
-    }
-
-    grants.push({
-      origin: grant.origin,
-      requestType: SIGN_EVENT,
-      eventKind: grant.eventKind,
-      granted: grant.granted,
-      timestamp: grant.timestamp,
-      ...(grant.expiry !== undefined ? { expiry: grant.expiry } : {}),
-    });
+    discarded += 1;
   }
 
   return { grants, discarded };
@@ -81,7 +77,7 @@ async function loadPermissions(): Promise<PermissionGrant[]> {
   const { grants, discarded } = migrateGrants(stored);
 
   if (discarded > 0 || grants.length !== stored.length) {
-    logService.log(LogLevel.WARN, '[Permissions] Discarded ambiguous pre-#136 grants', {
+    logService.log(LogLevel.WARN, '[Permissions] Discarded grants that name no account', {
       discarded,
     });
     permissionCache = grants;
@@ -104,20 +100,31 @@ const isLive = (grant: PermissionGrant, now: number): boolean =>
 const sameScope = (
   grant: PermissionGrant,
   origin: string,
+  accountPubkey: string,
   requestType: string,
   eventKind: PermissionEventKind,
 ): boolean =>
-  grant.origin === origin && grant.requestType === requestType && grant.eventKind === eventKind;
+  grant.origin === origin &&
+  grant.accountPubkey === accountPubkey &&
+  grant.requestType === requestType &&
+  grant.eventKind === eventKind;
 
 export async function checkPermission(
   origin: string,
+  accountPubkey: string,
   requestType: string,
   eventKind: PermissionEventKind,
 ): Promise<{ granted: boolean; always?: boolean }> {
+  // No account means nothing to check against. Matching "any account" here would reintroduce the
+  // inheritance this dimension removes.
+  if (!accountPubkey) return { granted: false };
+
   const permissions = await loadPermissions();
   const now = Date.now();
 
-  const exactMatch = permissions.find((grant) => sameScope(grant, origin, requestType, eventKind));
+  const exactMatch = permissions.find((grant) =>
+    sameScope(grant, origin, accountPubkey, requestType, eventKind),
+  );
   if (exactMatch) {
     return isLive(exactMatch, now) ? { granted: true, always: exactMatch.expiry === undefined } : { granted: false };
   }
@@ -126,7 +133,9 @@ export async function checkPermission(
   // It can no longer be produced as a side effect of a request that carries no event kind.
   if (requestType !== SIGN_EVENT) return { granted: false };
 
-  const wildcard = permissions.find((grant) => sameScope(grant, origin, SIGN_EVENT, 'any'));
+  const wildcard = permissions.find((grant) =>
+    sameScope(grant, origin, accountPubkey, SIGN_EVENT, 'any'),
+  );
   if (wildcard && isLive(wildcard, now)) {
     return { granted: true, always: wildcard.expiry === undefined };
   }
@@ -136,6 +145,7 @@ export async function checkPermission(
 
 export async function grantPermission(
   origin: string,
+  accountPubkey: string,
   requestType: string,
   // Deliberately narrower than PermissionEventKind: a wildcard must be asked for explicitly on a
   // signing request, and nothing offers that yet, so this path cannot create one (#136).
@@ -146,13 +156,18 @@ export async function grantPermission(
     throw new Error(`Unsupported permission duration: ${String(duration)}`);
   }
 
+  if (!accountPubkey) {
+    throw new Error('A permission grant must name the account it was given to');
+  }
+
   const permissions = await loadPermissions();
   const filtered = permissions.filter(
-    (grant) => !sameScope(grant, origin, requestType, eventKind),
+    (grant) => !sameScope(grant, origin, accountPubkey, requestType, eventKind),
   );
 
   const grant: PermissionGrant = {
     origin,
+    accountPubkey,
     requestType,
     eventKind,
     granted: true,
@@ -165,13 +180,29 @@ export async function grantPermission(
 
 export async function revokePermission(
   origin: string,
+  accountPubkey: string,
   requestType: string,
   eventKind: PermissionEventKind,
 ): Promise<void> {
   const permissions = await loadPermissions();
   await savePermissions(
-    permissions.filter((grant) => !sameScope(grant, origin, requestType, eventKind)),
+    permissions.filter((grant) => !sameScope(grant, origin, accountPubkey, requestType, eventKind)),
   );
+}
+
+/** Every grant for one origin, whichever account holds it. For the Connected Sites view. */
+export async function getGrantsForOrigin(origin: string): Promise<PermissionGrant[]> {
+  const permissions = await loadPermissions();
+  return permissions.filter((grant) => grant.origin === origin);
+}
+
+/** Drops every grant an account holds, for when that account is removed or disconnected. */
+export async function revokeGrantsForAccount(accountPubkey: string): Promise<number> {
+  const permissions = await loadPermissions();
+  const remaining = permissions.filter((grant) => grant.accountPubkey !== accountPubkey);
+
+  if (remaining.length !== permissions.length) await savePermissions(remaining);
+  return permissions.length - remaining.length;
 }
 
 export async function getGrantedPermissions(): Promise<PermissionGrant[]> {

--- a/src-bex/types/background.ts
+++ b/src-bex/types/background.ts
@@ -64,6 +64,16 @@ export type PermissionEventKind =
 export interface PermissionGrant {
   origin: string;
   /**
+   * The account the grant was given to, as a public key.
+   *
+   * Part of the key. A grant belongs to the identity the user was looking at when they gave it, so
+   * it cannot be inherited by another account on the same site (#116).
+   *
+   * Keyed by public key, never alias: aliases are user-editable, and a rename must not orphan a
+   * grant or silently transfer it to a different identity.
+   */
+  accountPubkey: string;
+  /**
    * The request type the grant was created from.
    *
    * Part of the key: a grant written by `get_public_key` lives in a different space from one

--- a/tests/unit/handlers/permission-handler.test.ts
+++ b/tests/unit/handlers/permission-handler.test.ts
@@ -21,11 +21,14 @@ vi.mock('src/services/log-service', () => ({
 }));
 
 const ORIGIN = 'https://example.com';
+const ALICE = 'a'.repeat(64);
+const BOB = 'b'.repeat(64);
 
-/** A pre-#136 record: no request type, and `eventKind` carrying both meanings. */
+/** Anything written before the current shape: missing a request type, an account, or both. */
 interface LegacyGrant {
   origin: string;
-  eventKind: number;
+  eventKind: number | 'any' | null;
+  requestType?: string;
   granted: boolean;
   timestamp: number;
   expiry?: number;
@@ -55,9 +58,9 @@ afterEach(() => {
 describe('permission grants', () => {
   describe('duration', () => {
     it('grants without expiry for "always"', async () => {
-      await grantPermission(ORIGIN, 'sign_event', 1, 'always');
+      await grantPermission(ORIGIN, ALICE, 'sign_event', 1, 'always');
 
-      const result = await checkPermission(ORIGIN, 'sign_event', 1);
+      const result = await checkPermission(ORIGIN, ALICE, 'sign_event', 1);
       expect(result).toEqual({ granted: true, always: true });
       expect(stored[0]?.expiry).toBeUndefined();
     });
@@ -67,20 +70,20 @@ describe('permission grants', () => {
       vi.useFakeTimers();
       vi.setSystemTime(now);
 
-      await grantPermission(ORIGIN, 'sign_event', 1, '8h');
-      expect(await checkPermission(ORIGIN, 'sign_event', 1)).toEqual({
+      await grantPermission(ORIGIN, ALICE, 'sign_event', 1, '8h');
+      expect(await checkPermission(ORIGIN, ALICE, 'sign_event', 1)).toEqual({
         granted: true,
         always: false,
       });
       expect(stored[0]?.expiry).toBe(now + 8 * 60 * 60 * 1000);
 
       vi.advanceTimersByTime(8 * 60 * 60 * 1000 + 1);
-      expect(await checkPermission(ORIGIN, 'sign_event', 1)).toEqual({ granted: false });
+      expect(await checkPermission(ORIGIN, ALICE, 'sign_event', 1)).toEqual({ granted: false });
     });
 
     it('refuses a duration it does not model', async () => {
       await expect(
-        grantPermission(ORIGIN, 'sign_event', 1, 'forever' as '8h'),
+        grantPermission(ORIGIN, ALICE, 'sign_event', 1, 'forever' as '8h'),
       ).rejects.toThrow(/Unsupported permission duration/);
     });
   });
@@ -94,37 +97,37 @@ describe('permission grants', () => {
    */
   describe('key spaces (#136)', () => {
     it('does not let a public-key grant authorise signing', async () => {
-      await grantPermission(ORIGIN, 'get_public_key', null, 'always');
+      await grantPermission(ORIGIN, ALICE, 'get_public_key', null, 'always');
 
-      expect(await checkPermission(ORIGIN, 'sign_event', 1)).toEqual({ granted: false });
+      expect(await checkPermission(ORIGIN, ALICE, 'sign_event', 1)).toEqual({ granted: false });
     });
 
     it('does not let a signing grant authorise a different request type', async () => {
-      await grantPermission(ORIGIN, 'sign_event', 1, 'always');
+      await grantPermission(ORIGIN, ALICE, 'sign_event', 1, 'always');
 
-      expect(await checkPermission(ORIGIN, 'nip04_decrypt', null)).toEqual({ granted: false });
+      expect(await checkPermission(ORIGIN, ALICE, 'nip04_decrypt', null)).toEqual({ granted: false });
     });
 
     it('keeps each kindless request type separate from the others', async () => {
-      await grantPermission(ORIGIN, 'nip04_decrypt', null, 'always');
+      await grantPermission(ORIGIN, ALICE, 'nip04_decrypt', null, 'always');
 
-      expect(await checkPermission(ORIGIN, 'nip44_decrypt', null)).toEqual({ granted: false });
-      expect(await checkPermission(ORIGIN, 'nip04_decrypt', null)).toEqual({
+      expect(await checkPermission(ORIGIN, ALICE, 'nip44_decrypt', null)).toEqual({ granted: false });
+      expect(await checkPermission(ORIGIN, ALICE, 'nip04_decrypt', null)).toEqual({
         granted: true,
         always: true,
       });
     });
 
     it('keeps each event kind separate', async () => {
-      await grantPermission(ORIGIN, 'sign_event', 1, 'always');
+      await grantPermission(ORIGIN, ALICE, 'sign_event', 1, 'always');
 
-      expect(await checkPermission(ORIGIN, 'sign_event', 5)).toEqual({ granted: false });
+      expect(await checkPermission(ORIGIN, ALICE, 'sign_event', 5)).toEqual({ granted: false });
     });
 
     it('keeps each origin separate', async () => {
-      await grantPermission(ORIGIN, 'sign_event', 1, 'always');
+      await grantPermission(ORIGIN, ALICE, 'sign_event', 1, 'always');
 
-      expect(await checkPermission('https://other.example', 'sign_event', 1)).toEqual({
+      expect(await checkPermission('https://other.example', ALICE, 'sign_event', 1)).toEqual({
         granted: false,
       });
     });
@@ -137,10 +140,10 @@ describe('permission grants', () => {
   describe('the signing wildcard', () => {
     it('answers any kind for the same origin when one exists', async () => {
       seed([
-        { origin: ORIGIN, requestType: 'sign_event', eventKind: 'any', granted: true, timestamp: 1 },
+        { origin: ORIGIN, accountPubkey: ALICE, requestType: 'sign_event', eventKind: 'any', granted: true, timestamp: 1 },
       ]);
 
-      expect(await checkPermission(ORIGIN, 'sign_event', 30023)).toEqual({
+      expect(await checkPermission(ORIGIN, ALICE, 'sign_event', 30023)).toEqual({
         granted: true,
         always: true,
       });
@@ -148,68 +151,76 @@ describe('permission grants', () => {
 
     it('answers only signing, never another request type', async () => {
       seed([
-        { origin: ORIGIN, requestType: 'sign_event', eventKind: 'any', granted: true, timestamp: 1 },
+        { origin: ORIGIN, accountPubkey: ALICE, requestType: 'sign_event', eventKind: 'any', granted: true, timestamp: 1 },
       ]);
 
-      expect(await checkPermission(ORIGIN, 'get_public_key', null)).toEqual({ granted: false });
+      expect(await checkPermission(ORIGIN, ALICE, 'get_public_key', null)).toEqual({ granted: false });
     });
 
     it('cannot be created through grantPermission', async () => {
-      await grantPermission(ORIGIN, 'sign_event', null, 'always');
+      await grantPermission(ORIGIN, ALICE, 'sign_event', null, 'always');
 
       // null is "this request carries no kind", not a wildcard, so signing stays unauthorised.
-      expect(await checkPermission(ORIGIN, 'sign_event', 1)).toEqual({ granted: false });
+      expect(await checkPermission(ORIGIN, ALICE, 'sign_event', 1)).toEqual({ granted: false });
       expect(stored.every((grant) => grant.eventKind !== 'any')).toBe(true);
     });
   });
 
-  describe('migrating 0.0.32 records', () => {
-    it('keeps a legacy grant that names a real event kind, as signing', async () => {
+  /**
+   * Stricter than #136's migration, deliberately.
+   *
+   * #136 kept a legacy grant that named a real event kind, because it could only have come from a
+   * signing request. The account dimension changes that: no pre-#116 record says which identity the
+   * user was granting for, and a vault with several accounts gives no way to tell. Keeping one
+   * would hand an identity authority another was given.
+   */
+  describe('migrating records written before the account dimension', () => {
+    it('discards a legacy record that names no account, even with a real event kind', async () => {
       seed([{ origin: ORIGIN, eventKind: 1, granted: true, timestamp: 1 }]);
 
-      expect(await checkPermission(ORIGIN, 'sign_event', 1)).toEqual({ granted: true, always: true });
-    });
-
-    it('discards a legacy -1, which cannot be attributed after the fact', async () => {
-      seed([{ origin: ORIGIN, eventKind: -1, granted: true, timestamp: 1 }]);
-
-      // It may have been a non-signing grant or a signing wildcard. Neither is assumed.
-      expect(await checkPermission(ORIGIN, 'sign_event', 1)).toEqual({ granted: false });
-      expect(await checkPermission(ORIGIN, 'get_public_key', null)).toEqual({ granted: false });
+      expect(await checkPermission(ORIGIN, ALICE, 'sign_event', 1)).toEqual({ granted: false });
       expect(await getGrantedPermissions()).toEqual([]);
     });
 
-    it('broadens nothing: a legacy kind grant still answers only that kind', async () => {
-      seed([{ origin: ORIGIN, eventKind: 1, granted: true, timestamp: 1 }]);
+    it('discards a #136-shaped record that has a request type but no account', async () => {
+      seed([
+        { origin: ORIGIN, requestType: 'sign_event', eventKind: 1, granted: true, timestamp: 1 },
+      ]);
 
-      expect(await checkPermission(ORIGIN, 'sign_event', 5)).toEqual({ granted: false });
+      expect(await checkPermission(ORIGIN, ALICE, 'sign_event', 1)).toEqual({ granted: false });
+      expect(await getGrantedPermissions()).toEqual([]);
     });
 
-    it('preserves a legacy expiry', async () => {
-      const expiry = Date.now() + 60_000;
-      seed([{ origin: ORIGIN, eventKind: 1, granted: true, timestamp: 1, expiry }]);
-
-      const [grant] = await getGrantedPermissions();
-      expect(grant?.expiry).toBe(expiry);
-      expect(await checkPermission(ORIGIN, 'sign_event', 1)).toEqual({ granted: true, always: false });
-    });
-
-    it('writes the migrated shape back, so the discard is not re-done on every read', async () => {
+    it('writes the discard back, so it is not re-done on every read', async () => {
       seed([
         { origin: ORIGIN, eventKind: 1, granted: true, timestamp: 1 },
-        { origin: ORIGIN, eventKind: -1, granted: true, timestamp: 1 },
+        {
+          origin: ORIGIN,
+          accountPubkey: ALICE,
+          requestType: 'sign_event',
+          eventKind: 5,
+          granted: true,
+          timestamp: 1,
+        },
       ]);
 
       await getGrantedPermissions();
 
       expect(vi.mocked(storageService).set).toHaveBeenCalled();
       expect(stored).toHaveLength(1);
-      expect(stored[0]).toMatchObject({ requestType: 'sign_event', eventKind: 1 });
+      expect(stored[0]).toMatchObject({ accountPubkey: ALICE, eventKind: 5 });
     });
 
-    it('leaves already-migrated records alone', async () => {
+    it('leaves fully-keyed records alone', async () => {
       seed([
-        { origin: ORIGIN, requestType: 'sign_event', eventKind: 1, granted: true, timestamp: 1 },
+        {
+          origin: ORIGIN,
+          accountPubkey: ALICE,
+          requestType: 'sign_event',
+          eventKind: 1,
+          granted: true,
+          timestamp: 1,
+        },
       ]);
 
       await getGrantedPermissions();
@@ -218,15 +229,67 @@ describe('permission grants', () => {
     });
   });
 
+  describe('accounts do not inherit each other (#116)', () => {
+    it('does not let one account use another account grant on the same site', async () => {
+      await grantPermission(ORIGIN, ALICE, 'sign_event', 1, 'always');
+
+      expect(await checkPermission(ORIGIN, BOB, 'sign_event', 1)).toEqual({ granted: false });
+    });
+
+    it('keeps a wildcard to the account it was given to', async () => {
+      seed([
+        {
+          origin: ORIGIN,
+          accountPubkey: ALICE,
+          requestType: 'sign_event',
+          eventKind: 'any',
+          granted: true,
+          timestamp: 1,
+        },
+      ]);
+
+      expect(await checkPermission(ORIGIN, ALICE, 'sign_event', 7)).toEqual({
+        granted: true,
+        always: true,
+      });
+      expect(await checkPermission(ORIGIN, BOB, 'sign_event', 7)).toEqual({ granted: false });
+    });
+
+    it('refuses to check without an account rather than matching any', async () => {
+      await grantPermission(ORIGIN, ALICE, 'sign_event', 1, 'always');
+
+      expect(await checkPermission(ORIGIN, '', 'sign_event', 1)).toEqual({ granted: false });
+    });
+
+    it('refuses to grant without an account', async () => {
+      await expect(grantPermission(ORIGIN, '', 'sign_event', 1, 'always')).rejects.toThrow(
+        /must name the account/,
+      );
+    });
+
+    it('revokes only the named account grant', async () => {
+      await grantPermission(ORIGIN, ALICE, 'sign_event', 1, 'always');
+      await grantPermission(ORIGIN, BOB, 'sign_event', 1, 'always');
+
+      await revokePermission(ORIGIN, ALICE, 'sign_event', 1);
+
+      expect(await checkPermission(ORIGIN, ALICE, 'sign_event', 1)).toEqual({ granted: false });
+      expect(await checkPermission(ORIGIN, BOB, 'sign_event', 1)).toEqual({
+        granted: true,
+        always: true,
+      });
+    });
+  });
+
   describe('revoking', () => {
     it('removes only the scope named', async () => {
-      await grantPermission(ORIGIN, 'sign_event', 1, 'always');
-      await grantPermission(ORIGIN, 'get_public_key', null, 'always');
+      await grantPermission(ORIGIN, ALICE, 'sign_event', 1, 'always');
+      await grantPermission(ORIGIN, ALICE, 'get_public_key', null, 'always');
 
-      await revokePermission(ORIGIN, 'sign_event', 1);
+      await revokePermission(ORIGIN, ALICE, 'sign_event', 1);
 
-      expect(await checkPermission(ORIGIN, 'sign_event', 1)).toEqual({ granted: false });
-      expect(await checkPermission(ORIGIN, 'get_public_key', null)).toEqual({
+      expect(await checkPermission(ORIGIN, ALICE, 'sign_event', 1)).toEqual({ granted: false });
+      expect(await checkPermission(ORIGIN, ALICE, 'get_public_key', null)).toEqual({
         granted: true,
         always: true,
       });
@@ -235,8 +298,8 @@ describe('permission grants', () => {
 
   describe('listing', () => {
     it('returns every live grant', async () => {
-      await grantPermission('https://site1.example', 'sign_event', 1, 'always');
-      await grantPermission('https://site2.example', 'sign_event', 4, '8h');
+      await grantPermission('https://site1.example', ALICE, 'sign_event', 1, 'always');
+      await grantPermission('https://site2.example', ALICE, 'sign_event', 4, '8h');
 
       const all = await getGrantedPermissions();
 
@@ -251,7 +314,7 @@ describe('permission grants', () => {
   describe('caching', () => {
     it('reads storage once until the cache is cleared', async () => {
       seed([
-        { origin: ORIGIN, requestType: 'sign_event', eventKind: 1, granted: true, timestamp: 1 },
+        { origin: ORIGIN, accountPubkey: ALICE, requestType: 'sign_event', eventKind: 1, granted: true, timestamp: 1 },
       ]);
 
       await getGrantedPermissions();


### PR DESCRIPTION
Refs #116. The account dimension on the permission record.

> **Stacked on #165.** Targets that branch and will retarget to `master` when it merges.

## The gap

A grant said which site, which request type and which event kind — but not **which identity it was
given to**. So connecting a second account to a site inherited the first account's permissions: a
user who approved "always" as one identity had already approved it for every identity they hold
there.

## The fix

Grants are keyed by account too, as a **public key rather than an alias**. Aliases are user-editable;
a rename must not orphan a grant or transfer it to a different identity.

The account is resolved **before** the permission check rather than after, so the check runs against
the account that will actually act — the site's bound account from #164. A grant given to one
identity cannot answer for another, even while a different account is active.

Both degenerate cases are closed rather than left permissive:

- `checkPermission` with no account returns false rather than matching any
- `grantPermission` with no account throws

Either fallback would reintroduce exactly the inheritance this removes.

## The migration is stricter than #136's

#136 kept a legacy grant that named a real event kind, because it could only have come from a signing
request. That reasoning does not survive the account dimension: **no pre-#116 record says which
identity the user was granting for**, and a vault with several accounts gives no way to tell. Keeping
one would hand an identity authority another was given.

So every record without an account is discarded and the user is asked again.

**This means upgrading drops all stored grants**, including the ones #136 preserved. Narrowing, never
broadening (SR-6). Combined with #163, a 0.0.32 user re-approves each site once — worth a line in the
0.1.0 release notes.

## Also added

Two accessors the Connected Sites view will need, so it does not have to filter the whole store
itself: grants for one origin whichever account holds them, and revoking every grant an account
holds.

## Verification

The account key is **mutation-checked**: removing it from the scope comparison fails exactly the
three tests that assert non-inheritance — one account not using another's grant, a wildcard staying
with its account, and revocation touching only the named account.

`lint`, `typecheck` and `test:run` pass — 771 tests, up from 768.

## Still open on #116

Bridge events to list and revoke grants (the handlers now exist but nothing calls them), the
Connected Sites view, the "Approved Clients" metric, and the header account switcher slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)