### PR TITLE
feat(sidebar): push queue state to the panel instead of polling

### DIFF
--- a/src-bex/background.ts
+++ b/src-bex/background.ts
@@ -34,7 +34,7 @@ import {
   requeuePresented,
   submitDecision,
 } from './services/request-queue';
-import { observePanelConnections } from './services/panel-presence';
+import { notifyPanelsOfQueueChange, observePanelConnections } from './services/panel-presence';
 import { refreshAttention } from './services/attention-badge';
 import { resolveSigningAccount } from './services/signing-account';
 import {
@@ -428,6 +428,10 @@ observePanelConnections();
 // leave the queue with no caller involved; watching the write is the only way to catch that.
 onQueueChange(() => {
   void refreshAttention();
+  // The same write that moves the toolbar tells any open panel to re-read (#140). Expiry is
+  // evaluated lazily, so this is also how a request leaving the queue with no caller involved
+  // reaches the panel.
+  notifyPanelsOfQueueChange();
 });
 
 /**

--- a/src-bex/services/panel-presence.ts
+++ b/src-bex/services/panel-presence.ts
@@ -9,12 +9,19 @@
  * Presence is a presentation fact, never a lifecycle one. When the last panel goes away the
  * presented request returns to the queue; nothing is decided, rejected or duplicated, because
  * closing the panel is not a decision (FR-6, S11).
+ *
+ * The same connection carries queue notifications outward (#140). They say only "the queue moved",
+ * never what it moved to: the background stays the single source of truth, and a panel that acts on
+ * a notification does so by re-reading rather than by trusting a payload it was handed.
  */
 
 import { LogLevel, logService } from 'src/services/log-service';
 import { requeuePresented } from './request-queue';
 
 export const PANEL_PORT_NAME = 'porwr-panel';
+
+/** The only message the background sends a panel: re-read the queue. */
+export const QUEUE_CHANGED_MESSAGE = { type: 'queue-changed' } as const;
 
 type PresenceListener = (present: boolean) => void;
 
@@ -66,6 +73,27 @@ export const observePanelConnections = (): void => {
     notify();
     port.onDisconnect.addListener(() => handleDisconnect(port));
   });
+};
+
+/**
+ * Tell every open panel that the queue moved.
+ *
+ * Deliberately carries no state. A payload would have to be built per panel and could arrive out of
+ * order behind a decision the background has already applied, which is how a panel ends up showing
+ * a resolved request as actionable. A bare notification cannot go stale — the panel re-reads, and
+ * the background answers with what is true now.
+ *
+ * A panel that has gone without its disconnect having been processed yet will throw here; that is
+ * expected and not worth logging, since `onDisconnect` cleans it up immediately afterwards.
+ */
+export const notifyPanelsOfQueueChange = (): void => {
+  for (const port of panels) {
+    try {
+      port.postMessage(QUEUE_CHANGED_MESSAGE);
+    } catch {
+      /* the port is closing; onDisconnect removes it */
+    }
+  }
 };
 
 export const __resetPanelPresenceForTests = (): void => {

--- a/src/composables/useApprovalQueue.ts
+++ b/src/composables/useApprovalQueue.ts
@@ -17,12 +17,14 @@ import type {
  * caches authoritative state: every decision is followed by a refresh from the background, so a
  * request that expired or was interrupted meanwhile cannot linger on screen as actionable.
  *
- * State is module-scoped so every consumer in the panel observes one queue behind one poller. The
- * header shows the pending count while the page shows the request itself; per-caller state would
- * mean two pollers racing each other and a count that could disagree with what is on screen.
+ * State is module-scoped so every consumer in the panel observes one queue. The header shows the
+ * pending count while the page shows the request itself; per-caller state would mean two readers
+ * racing each other and a count that could disagree with what is on screen.
+ *
+ * Nothing polls. The background pushes a bare "the queue moved" notification over the panel port
+ * and this re-reads (#140). A push carries no state, so it cannot be stale or arrive behind a
+ * decision the background has already applied; the answer always comes from a fresh read.
  */
-
-const POLL_INTERVAL_MS = 1000;
 
 export interface UseApprovalQueueResult {
   pending: Ref<ApprovalRequestRecord[]>;
@@ -40,7 +42,6 @@ const content = ref<ApprovalRequestContent | null>(null);
 const loading = ref(true);
 const pendingCount = computed(() => pending.value.length);
 
-let timer: ReturnType<typeof setInterval> | undefined;
 let consumers = 0;
 let panelPort: PanelPortHandle | undefined;
 
@@ -99,8 +100,6 @@ const decide = async (
  * Exported so a suite can start from a known queue rather than inheriting the previous test's.
  */
 export function resetApprovalQueue(): void {
-  if (timer !== undefined) clearInterval(timer);
-  timer = undefined;
   panelPort?.disconnect();
   panelPort = undefined;
   consumers = 0;
@@ -114,13 +113,6 @@ export function useApprovalQueue(): UseApprovalQueueResult {
   onMounted(() => {
     consumers += 1;
 
-    // The poller belongs to the queue, not to whichever component mounted first.
-    if (timer === undefined) {
-      timer = setInterval(() => {
-        void refresh();
-      }, POLL_INTERVAL_MS);
-    }
-
     // One presence port per panel, not per consumer: the background counts connections, so a
     // second port would make a single panel look like two.
     panelPort ??= connectPanelPort({
@@ -129,17 +121,19 @@ export function useApprovalQueue(): UseApprovalQueueResult {
       onReconnect: () => {
         void refresh();
       },
+      onQueueChanged: () => {
+        void refresh();
+      },
     });
 
+    // The one read that is not driven by a notification: what is already waiting when the panel
+    // opens. Everything after this arrives as a push.
     void refresh();
   });
 
   onUnmounted(() => {
     consumers -= 1;
     if (consumers > 0) return;
-
-    if (timer !== undefined) clearInterval(timer);
-    timer = undefined;
 
     panelPort?.disconnect();
     panelPort = undefined;

--- a/src/services/panel-port.ts
+++ b/src/services/panel-port.ts
@@ -6,7 +6,11 @@
  * signal that works on both browsers (#113).
  *
  * The port carries no requests and no decisions. Those stay on the existing request/response
- * bridge, where the background remains the authority. #140 adds pushes over this same connection.
+ * bridge, where the background remains the authority.
+ *
+ * What it does carry is a bare "the queue moved" notification (#140). It says nothing about what
+ * changed, so it cannot be stale or arrive out of order behind a decision already applied — the
+ * panel re-reads and the background answers with what is true now.
  *
  * A Chromium service worker can be suspended while the panel stays open, which disconnects the
  * port without the panel having gone anywhere. Reconnecting is therefore normal operation rather
@@ -28,6 +32,8 @@ export interface PanelPortHandle {
 export interface PanelPortOptions {
   /** Called after every reconnect, never on the first connect. */
   onReconnect?: () => void;
+  /** Called when the background says the queue moved. Re-read; do not trust a payload. */
+  onQueueChanged?: () => void;
 }
 
 export function connectPanelPort(options: PanelPortOptions = {}): PanelPortHandle {
@@ -58,6 +64,13 @@ export function connectPanelPort(options: PanelPortOptions = {}): PanelPortHandl
 
     if (hasConnected) options.onReconnect?.();
     hasConnected = true;
+
+    port.onMessage.addListener((message: unknown) => {
+      // One message type today. Anything else is from a newer background than this panel, and
+      // ignoring it is safer than guessing at it.
+      if ((message as { type?: string } | null)?.type !== 'queue-changed') return;
+      options.onQueueChanged?.();
+    });
 
     port.onDisconnect.addListener(() => {
       port = undefined;

--- a/tests/unit/composables/useApprovalQueue.test.ts
+++ b/tests/unit/composables/useApprovalQueue.test.ts
@@ -2,9 +2,18 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { defineComponent } from 'vue';
 
-const { sendBexMessage } = vi.hoisted(() => ({ sendBexMessage: vi.fn() }));
+const { sendBexMessage, connectPanelPort, disconnect, portOptions } = vi.hoisted(() => ({
+  sendBexMessage: vi.fn(),
+  connectPanelPort: vi.fn(),
+  disconnect: vi.fn(),
+  portOptions: { current: undefined as { onQueueChanged?: () => void; onReconnect?: () => void } | undefined },
+}));
 
 vi.mock('src/services/bridge-client', () => ({ sendBexMessage }));
+vi.mock('src/services/panel-port', () => ({
+  PANEL_PORT_NAME: 'porwr-panel',
+  connectPanelPort,
+}));
 vi.mock('src/services/log-service', () => ({
   LogLevel: { DEBUG: 'debug' },
   logService: { log: vi.fn() },
@@ -30,6 +39,11 @@ describe('useApprovalQueue', () => {
     vi.clearAllMocks();
     resetApprovalQueue();
     sendBexMessage.mockResolvedValue([]);
+    portOptions.current = undefined;
+    connectPanelPort.mockImplementation((options: { onQueueChanged?: () => void }) => {
+      portOptions.current = options;
+      return { disconnect };
+    });
   });
 
   afterEach(() => {
@@ -38,16 +52,27 @@ describe('useApprovalQueue', () => {
   });
 
   describe('shared state', () => {
-    it('runs one poller however many consumers are mounted', async () => {
+    it('drives nothing from a timer (#140)', () => {
       vi.useFakeTimers();
       const setInterval = vi.spyOn(globalThis, 'setInterval');
 
       const header = mount(Consumer);
       const page = mount(Consumer);
 
-      // The header shows the count while the page shows the request. Two pollers would race and
-      // could disagree about what is waiting.
-      expect(setInterval).toHaveBeenCalledTimes(1);
+      // The background pushes; the panel re-reads. A poll interval is both a delay before a
+      // request appears and a second source of truth about when to look.
+      expect(setInterval).not.toHaveBeenCalled();
+
+      header.unmount();
+      page.unmount();
+    });
+
+    it('opens one port however many consumers are mounted', () => {
+      const header = mount(Consumer);
+      const page = mount(Consumer);
+
+      // The background counts connections, so a second port would make one panel look like two.
+      expect(connectPanelPort).toHaveBeenCalledTimes(1);
 
       header.unmount();
       page.unmount();
@@ -66,18 +91,15 @@ describe('useApprovalQueue', () => {
   });
 
   describe('teardown', () => {
-    it('keeps polling while any consumer remains', async () => {
-      vi.useFakeTimers();
-      const clearInterval = vi.spyOn(globalThis, 'clearInterval');
-
+    it('keeps the port open while any consumer remains', () => {
       const header = mount(Consumer);
       const page = mount(Consumer);
 
       header.unmount();
-      expect(clearInterval).not.toHaveBeenCalled();
+      expect(disconnect).not.toHaveBeenCalled();
 
       page.unmount();
-      expect(clearInterval).toHaveBeenCalled();
+      expect(disconnect).toHaveBeenCalled();
     });
 
     it('requeues the presented request only once the last consumer has gone', () => {
@@ -90,6 +112,31 @@ describe('useApprovalQueue', () => {
       page.unmount();
       // Closing the panel is never a decision (FR-6); navigating within it is not either.
       expect(sendBexMessage).toHaveBeenCalledWith('nostr.requests.requeuePresented');
+    });
+  });
+
+  describe('push notifications (#140)', () => {
+    it('re-reads when the background says the queue moved', async () => {
+      const wrapper = mount(Consumer);
+      await vi.waitFor(() => expect(sendBexMessage).toHaveBeenCalled());
+      sendBexMessage.mockClear();
+
+      portOptions.current?.onQueueChanged?.();
+
+      // The notification carries no state, so the answer has to come from a fresh read.
+      await vi.waitFor(() => expect(sendBexMessage).toHaveBeenCalledWith('nostr.requests.list'));
+      wrapper.unmount();
+    });
+
+    it('re-reads on reconnect, since the worker may have reconciled while it was gone', async () => {
+      const wrapper = mount(Consumer);
+      await vi.waitFor(() => expect(sendBexMessage).toHaveBeenCalled());
+      sendBexMessage.mockClear();
+
+      portOptions.current?.onReconnect?.();
+
+      await vi.waitFor(() => expect(sendBexMessage).toHaveBeenCalledWith('nostr.requests.list'));
+      wrapper.unmount();
     });
   });
 

--- a/tests/unit/services/panel-port.test.ts
+++ b/tests/unit/services/panel-port.test.ts
@@ -12,13 +12,16 @@ const disconnect = vi.fn();
 
 const makePort = () => {
   const handlers: Array<() => void> = [];
+  const messageHandlers: Array<(message: unknown) => void> = [];
   return {
     port: {
       name: PANEL_PORT_NAME,
       disconnect,
       onDisconnect: { addListener: (fn: () => void) => handlers.push(fn) },
+      onMessage: { addListener: (fn: (message: unknown) => void) => messageHandlers.push(fn) },
     },
     drop: () => handlers.forEach((fn) => fn()),
+    send: (message: unknown) => messageHandlers.forEach((fn) => fn(message)),
   };
 };
 
@@ -83,6 +86,47 @@ describe('panel presence port', () => {
 
     vi.advanceTimersByTime(500);
     expect(connect).toHaveBeenCalledTimes(2);
+  });
+
+  describe('queue notifications (#140)', () => {
+    it('tells the caller to re-read when the background says the queue moved', () => {
+      const first = makePort();
+      connect.mockReturnValue(first.port);
+      const onQueueChanged = vi.fn();
+
+      connectPanelPort({ onQueueChanged });
+      first.send({ type: 'queue-changed' });
+
+      expect(onQueueChanged).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores a message it does not recognise', () => {
+      const first = makePort();
+      connect.mockReturnValue(first.port);
+      const onQueueChanged = vi.fn();
+
+      connectPanelPort({ onQueueChanged });
+      // From a newer background than this panel. Ignoring beats guessing.
+      first.send({ type: 'something-else' });
+      first.send(null);
+      first.send('queue-changed');
+
+      expect(onQueueChanged).not.toHaveBeenCalled();
+    });
+
+    it('keeps notifying after a reconnect', () => {
+      const first = makePort();
+      const second = makePort();
+      connect.mockReturnValueOnce(first.port).mockReturnValue(second.port);
+      const onQueueChanged = vi.fn();
+
+      connectPanelPort({ onQueueChanged });
+      first.drop();
+      vi.advanceTimersByTime(500);
+
+      second.send({ type: 'queue-changed' });
+      expect(onQueueChanged).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('gives up quietly where there is no extension API to connect to', () => {

--- a/tests/unit/services/panel-presence.test.ts
+++ b/tests/unit/services/panel-presence.test.ts
@@ -14,6 +14,7 @@ import {
   getPanelCount,
   isPanelPresent,
   observePanelConnections,
+  notifyPanelsOfQueueChange,
   onPanelPresenceChange,
 } from 'app/src-bex/services/panel-presence';
 
@@ -117,5 +118,69 @@ describe('panel presence', () => {
     panel.disconnect();
 
     expect(seen).toEqual([true, false]);
+  });
+});
+
+/**
+ * Queue notifications (#140).
+ *
+ * The panel used to poll every second. The background now says "the queue moved" over the same
+ * connection presence already uses, and the panel re-reads.
+ */
+describe('telling panels the queue moved', () => {
+  const postMessage = vi.fn();
+
+  const openMessagePort = (connect: Connect, over: Partial<chrome.runtime.Port> = {}) => {
+    const handlers: Array<() => void> = [];
+    const port = {
+      name: PANEL_PORT_NAME,
+      postMessage,
+      onDisconnect: { addListener: (fn: () => void) => handlers.push(fn) },
+      ...over,
+    } as unknown as chrome.runtime.Port;
+    connect(port);
+    return { port, disconnect: () => handlers.forEach((fn) => fn()) };
+  };
+
+  it('notifies every open panel', () => {
+    const connect = startObserving();
+    openMessagePort(connect);
+    openMessagePort(connect);
+
+    notifyPanelsOfQueueChange();
+
+    expect(postMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it('carries no state, only that the queue moved', () => {
+    const connect = startObserving();
+    openMessagePort(connect);
+
+    notifyPanelsOfQueueChange();
+
+    // A payload could arrive behind a decision already applied, which is how a panel ends up
+    // showing a resolved request as actionable.
+    expect(postMessage).toHaveBeenCalledWith({ type: 'queue-changed' });
+  });
+
+  it('does not notify a panel that has gone', () => {
+    const connect = startObserving();
+    const panel = openMessagePort(connect);
+    panel.disconnect();
+
+    notifyPanelsOfQueueChange();
+
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it('survives a port that is closing but not yet disconnected', () => {
+    const connect = startObserving();
+    openMessagePort(connect, {
+      postMessage: vi.fn(() => {
+        throw new Error('Attempting to use a disconnected port object');
+      }),
+    } as unknown as Partial<chrome.runtime.Port>);
+
+    expect(() => notifyPanelsOfQueueChange()).not.toThrow();
   });
 });


### PR DESCRIPTION
Fixes #140.

## Why

The panel re-read the queue every second. That is both a delay before an arriving request appears and
a second opinion about when to look — #115 accepted it as a placeholder until panel presence existed.

Presence exists now (#157), so the same connection carries the notification. The background already
emits a change on every queue write, which is how a lazily-evaluated expiry reaches the toolbar; that
hook now tells every open panel too.

## The push carries no state, deliberately

#140 allowed either a notification to re-read **or** a state payload. It is a notification.

A payload would have to be built per panel and could arrive out of order behind a decision the
background has already applied — which is precisely how a panel ends up showing a resolved request as
actionable, the thing the issue's fourth criterion asks us to prevent. A bare "the queue moved"
cannot go stale: the panel re-reads, and the background answers with what is true now.

## What still reads

Two reads remain, both deliberate:

- when the panel opens, for whatever is already waiting
- on reconnect, because a restarted worker may have reconciled the queue while it was gone

A message the panel does not recognise is ignored rather than guessed at. That can only come from a
newer background than the panel, which happens when the extension updates underneath an open panel.

## Against the acceptance criteria

| Criterion | Where |
|---|---|
| No timer drives queue state | `useApprovalQueue` starts no interval; asserted directly |
| A request arriving appears without a poll interval's delay | the write that changes the queue notifies in the same tick |
| Dropping the connection and reconnecting restores correct state | reconnect re-reads; covered in the port and composable suites |
| A decision against changed state is still refused | unchanged — the background refuses by request id, and the push carries no state to decide from |

`lint`, `typecheck` and `test:run` pass — 781 tests, up from 771. The Chromium e2e suite passes.

The broadcast is **mutation-checked**: silencing it fails the two tests asserting panels are told, and
told without state.

## One thing I did not land

I wrote an end-to-end spec asserting the message actually crosses a real port, and dropped it.

The first version passed **vacuously** — it instrumented `setInterval` and asserted 1000 was absent,
but the instrumentation captured nothing at all, so an empty list satisfied it. I only noticed
because I added a guard that the list was non-empty. The replacement, connecting a second port from
the page, kept closing the page context and I stopped rather than keep digging.

So the crossing itself is covered by unit tests on both sides — the background broadcasting, the port
forwarding, the composable re-reading — but not by an end-to-end assertion. Worth adding when the
harness grows a way to drive a real signing request, which needs the vault work #141 flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)