### PR TITLE
chore(bex): remove manifest keys the build discards

### DIFF
--- a/src-bex/manifest.json
+++ b/src-bex/manifest.json
@@ -1,7 +1,4 @@
 {
-  "name": "Diogel",
-  "description": "Privacy focused nostr account & signer extension",
-  "version": "0.0.1.0",
   "all": {
     "manifest_version": 3,
     "icons": {

--- a/tests/unit/bex-manifest.test.ts
+++ b/tests/unit/bex-manifest.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Guards the source manifest against keys the build silently discards.
+ *
+ * `createManifest` in `@quasar/app-vite` merges only `all`, `chrome` and `firefox`. Anything else at
+ * the top level is dropped, and the emitted `name`, `description` and `version` come from
+ * `package.json` instead. A key here that looks authoritative and is not is worse than no key at
+ * all: the file declared `"version": "0.0.1.0"` while every build shipped the package version
+ * (#144).
+ */
+
+const ROOT = resolve(__dirname, '../..');
+
+const read = (path: string): Record<string, unknown> =>
+  JSON.parse(readFileSync(resolve(ROOT, path), 'utf8')) as Record<string, unknown>;
+
+describe('the BEX source manifest', () => {
+  const manifest = read('src-bex/manifest.json');
+
+  it('declares only the sections the build merges', () => {
+    expect(Object.keys(manifest).sort()).toEqual(['all', 'chrome', 'firefox']);
+  });
+
+  it('claims no extension version, because the build takes it from package.json', () => {
+    expect(manifest).not.toHaveProperty('version');
+    expect(read('package.json')).toHaveProperty('version');
+  });
+
+  it('keeps the target-specific keys where the build expects them', () => {
+    // A regression here would emit a manifest missing the panel entirely, which no unit test of
+    // the panel itself would notice.
+    expect(manifest.chrome).toHaveProperty('side_panel');
+    expect(manifest.firefox).toHaveProperty('sidebar_action');
+  });
+});


### PR DESCRIPTION
Fixes #144.

## What was dead

`createManifest` in `@quasar/app-vite` merges only `all`, `chrome` and `firefox`. The three
top-level keys were discarded on every build:

| Key | In `src-bex/manifest.json` | Actually shipped |
|---|---|---|
| `version` | `0.0.1.0` | `0.0.32` |
| `description` | "Privacy focused nostr **account & signer** extension" | "Privacy focused nostr extension" |
| `name` | `Diogel` | `Diogel` |

The version is the one that matters — a key that looks authoritative and is not is worse than no key,
particularly the version of a signing extension. The description is the one that *proves* the point:
the two texts differ, so the source value demonstrably never reached a build.

## Verified, not assumed

Both targets built before and after the change. The emitted manifests are **byte-identical** —
`cmp` clean for Chromium and Firefox, which is the issue's acceptance criterion.

## Guard

Nothing else would catch these coming back, so `tests/unit/bex-manifest.test.ts` asserts the source
manifest declares only the three merged sections and claims no version.

It also pins `side_panel` and `sidebar_action` to their target sections. That is not strictly #144's
scope, but a regression there would emit a manifest with **no panel at all**, and no test of the
panel itself would notice — the panel is reached as an extension page in the e2e suite precisely
because no automation can open the real one.

## One thing for you, not changed here

The source description — "Privacy focused nostr **account & signer** extension" — has never shipped.
The store listing says "Privacy focused nostr extension".

The longer wording is more accurate now that the product is a signer, but the description is store
copy, so changing what ships is a product decision rather than a cleanup. If you want it, it belongs
in `package.json`; say the word and it is a one-line follow-up.

`lint`, `typecheck` and `test:run` pass — 784 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)