### PR TITLE
feat(sidebar): cross-check panel presence against the browser

### DIFF
--- a/src-bex/background.ts
+++ b/src-bex/background.ts
@@ -34,7 +34,11 @@ import {
   requeuePresented,
   submitDecision,
 } from './services/request-queue';
-import { notifyPanelsOfQueueChange, observePanelConnections } from './services/panel-presence';
+import {
+  notifyPanelsOfQueueChange,
+  observePanelConnections,
+  reconcilePanelPresence,
+} from './services/panel-presence';
 import { refreshAttention } from './services/attention-badge';
 import { resolveSigningAccount } from './services/signing-account';
 import {
@@ -463,8 +467,11 @@ onPageOriginChange((_tabId, record) => {
 });
 
 // A closed window takes its tabs with it; ports usually report that first, but not always.
-chrome.windows?.onRemoved?.addListener(() => {
+chrome.windows?.onRemoved?.addListener((windowId) => {
   void refreshAttention();
+  // Firefox can say whether a panel is still open in a window; Chromium cannot and abstains. This
+  // catches a panel that went away without its port disconnecting (#113).
+  void reconcilePanelPresence(windowId);
 });
 
 // Chromium reveals the panel through `openPanelOnActionClick`, so `action.onClicked` never

--- a/src-bex/services/panel-presence.ts
+++ b/src-bex/services/panel-presence.ts
@@ -16,6 +16,7 @@
  */
 
 import { LogLevel, logService } from 'src/services/log-service';
+import { resolvePanelSurface } from './panel-surface';
 import { requeuePresented } from './request-queue';
 
 export const PANEL_PORT_NAME = 'porwr-panel';
@@ -93,6 +94,41 @@ export const notifyPanelsOfQueueChange = (): void => {
     } catch {
       /* the port is closing; onDisconnect removes it */
     }
+  }
+};
+
+/**
+ * Reconcile the port's view of presence against the browser's, where the browser has one.
+ *
+ * The port is the source of truth: it is the only mechanism both browsers support, and it is what
+ * `requeuePresented` and the badge already follow. This does not replace it — it catches the one
+ * case the port cannot see, a panel that went away without its `onDisconnect` firing, which leaves a
+ * request `presented` to nobody.
+ *
+ * Firefox answers through `sidebarAction.isOpen`; Chromium has no equivalent and returns undefined.
+ * Undefined means "no opinion" and is never treated as "closed" — acting on a guess would tear down
+ * a live panel's presence on the browser where most people run this (#113).
+ */
+export const reconcilePanelPresence = async (windowId?: number): Promise<void> => {
+  if (!isPanelPresent()) return;
+
+  const surface = resolvePanelSurface();
+  const browserSaysOpen = await surface.isOpenAccordingToBrowser(windowId);
+  if (browserSaysOpen !== false) return;
+
+  logService.log(LogLevel.WARN, '[Panel] Browser reports no panel while a port is still held', {
+    ports: panels.size,
+  });
+
+  // Drop the stale ports and let the normal path run: presence changes, and the last one going
+  // requeues whatever was presented. Nothing here decides a request.
+  for (const port of [...panels]) {
+    try {
+      port.disconnect();
+    } catch {
+      /* already gone */
+    }
+    handleDisconnect(port);
   }
 };
 

--- a/src-bex/services/panel-surface.ts
+++ b/src-bex/services/panel-surface.ts
@@ -26,6 +26,14 @@ export interface PanelSurface {
   configureToolbarBehaviour(): Promise<void>;
   /** Reveal the panel. Only valid inside a user-gesture handler. */
   openFromUserGesture(windowId?: number): Promise<void>;
+  /**
+   * Whether the browser itself says a panel is open in this window.
+   *
+   * `undefined` where the browser cannot answer, which is every Chromium build — it exposes no
+   * equivalent of Firefox's `sidebarAction.isOpen`. Callers must treat `undefined` as "no opinion"
+   * and never as "closed" (#113).
+   */
+  isOpenAccordingToBrowser(windowId?: number): Promise<boolean | undefined>;
 }
 
 interface ChromiumPanelApi {
@@ -36,6 +44,7 @@ interface ChromiumPanelApi {
 interface FirefoxPanelApi {
   open(): Promise<void>;
   toggle(): Promise<void>;
+  isOpen?(details: { windowId?: number }): Promise<boolean>;
 }
 
 const getChromiumPanelApi = (): ChromiumPanelApi | undefined => {
@@ -55,6 +64,10 @@ const createChromiumPanelSurface = (api: ChromiumPanelApi): PanelSurface => ({
   async configureToolbarBehaviour(): Promise<void> {
     await api.setPanelBehavior({ openPanelOnActionClick: true });
   },
+  isOpenAccordingToBrowser(): Promise<boolean | undefined> {
+    // Chromium has no equivalent. Answering `false` here would be a guess presented as a fact.
+    return Promise.resolve(undefined);
+  },
   async openFromUserGesture(windowId?: number): Promise<void> {
     if (windowId === undefined) return;
     await api.open({ windowId });
@@ -67,6 +80,19 @@ const createFirefoxPanelSurface = (api: FirefoxPanelApi): PanelSurface => ({
     // Firefox reveals the sidebar from the `sidebar_action` manifest key.
     return Promise.resolve();
   },
+  async isOpenAccordingToBrowser(windowId?: number): Promise<boolean | undefined> {
+    if (typeof api.isOpen !== 'function') return undefined;
+
+    try {
+      return await api.isOpen(windowId === undefined ? {} : { windowId });
+    } catch (error: unknown) {
+      // An unavailable answer is not a negative one; the port remains the source of truth.
+      logService.log(LogLevel.DEBUG, '[Panel] Firefox could not report panel state', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
+  },
   async openFromUserGesture(): Promise<void> {
     await api.toggle();
   },
@@ -74,6 +100,9 @@ const createFirefoxPanelSurface = (api: FirefoxPanelApi): PanelSurface => ({
 
 const createUnsupportedPanelSurface = (): PanelSurface => ({
   kind: 'unsupported',
+  isOpenAccordingToBrowser(): Promise<boolean | undefined> {
+    return Promise.resolve(undefined);
+  },
   configureToolbarBehaviour(): Promise<void> {
     return Promise.resolve();
   },

--- a/tests/unit/components/CurrentRequest.test.ts
+++ b/tests/unit/components/CurrentRequest.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import type { ApprovalRequestRecord } from 'app/src-bex/types/background';
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+import CurrentRequest from 'src/components/sidebar/CurrentRequest.vue';
+
+const request = (over: Partial<ApprovalRequestRecord> = {}): ApprovalRequestRecord =>
+  ({
+    id: 'req-1',
+    origin: 'https://example.com',
+    requestType: 'sign_event',
+    eventKind: 1,
+    accountAlias: 'alice',
+    accountPubkey: 'a'.repeat(64),
+    state: 'presented',
+    createdAt: 1,
+    expiresAt: 2,
+    ...over,
+  }) as ApprovalRequestRecord;
+
+const mountRequest = (record: ApprovalRequestRecord) =>
+  mount(CurrentRequest, {
+    props: { request: record, content: { allowRemember: true }, busy: false },
+    global: {
+      stubs: {
+        RequestOriginHeader: true,
+        RequestRiskWarning: true,
+        RequestPreview: { template: '<div class="request-preview" />' },
+        RequestDecisionBar: { template: '<div class="request-decision-bar" />' },
+      },
+    },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+/**
+ * A terminal request must not look actionable (FR-12, S13, S14).
+ *
+ * The background refuses a decision on a terminal id, so approving one cannot succeed — but a panel
+ * that still shows the controls invites the attempt and reads as though the request were live.
+ */
+describe('a request that can no longer be decided', () => {
+  for (const state of ['expired', 'interrupted'] as const) {
+    describe(`when ${state}`, () => {
+      it('offers no approval controls', () => {
+        const wrapper = mountRequest(request({ state }));
+
+        expect(wrapper.find('.request-decision-bar').exists()).toBe(false);
+      });
+
+      it('does not show the event content, which is no longer reviewable', () => {
+        const wrapper = mountRequest(request({ state }));
+
+        expect(wrapper.find('.request-preview').exists()).toBe(false);
+      });
+
+      it('says why, in a live region so it is announced', () => {
+        const wrapper = mountRequest(request({ state }));
+
+        const notice = wrapper.find('[role="status"]');
+        expect(notice.exists()).toBe(true);
+        expect(notice.text()).toBe(`request.states.${state}`);
+      });
+    });
+  }
+
+  it('still shows the controls for a live request', () => {
+    const wrapper = mountRequest(request({ state: 'presented' }));
+
+    expect(wrapper.find('.request-decision-bar').exists()).toBe(true);
+    expect(wrapper.find('.request-preview').exists()).toBe(true);
+    expect(wrapper.find('[role="status"]').exists()).toBe(false);
+  });
+
+  it('still shows the controls for a queued request', () => {
+    const wrapper = mountRequest(request({ state: 'queued' }));
+
+    expect(wrapper.find('.request-decision-bar').exists()).toBe(true);
+  });
+});

--- a/tests/unit/panel-open-gesture.test.ts
+++ b/tests/unit/panel-open-gesture.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Guards the one rule both browsers enforce and neither reports usefully.
+ *
+ * `sidePanel.open()` and `sidebarAction.open()` may only be called from inside a user-gesture
+ * handler. Called anywhere else they reject at runtime, in the background, where nobody is watching
+ * — so the failure is a panel that silently does not open (ADR D4, #113).
+ *
+ * The rule is therefore structural: only the panel-surface port may call them, and only through
+ * `openFromUserGesture`, which the toolbar handler invokes.
+ */
+
+const ROOT = resolve(__dirname, '../..');
+const PORT = 'src-bex/services/panel-surface.ts';
+
+const sourceFiles = (dir: string): string[] => {
+  const entries = readdirSync(join(ROOT, dir));
+  return entries.flatMap((entry) => {
+    const relative = join(dir, entry);
+    if (statSync(join(ROOT, relative)).isDirectory()) return sourceFiles(relative);
+    return /\.(ts|vue)$/.test(entry) && !entry.endsWith('.d.ts') ? [relative] : [];
+  });
+};
+
+/** Any reference to a browser panel API at all, however it is reached. */
+const PANEL_API = /\b(sidePanel|sidebarAction)\b/;
+
+/**
+ * Comments name these APIs when explaining why only the port may call them, and prose is not a
+ * violation. Stripping first keeps the rule about code.
+ */
+const withoutComments = (source: string): string =>
+  source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+describe('opening the panel', () => {
+  const files = [...sourceFiles('src'), ...sourceFiles('src-bex')];
+
+  it('finds the source tree, so this cannot pass by looking at nothing', () => {
+    expect(files.length).toBeGreaterThan(100);
+    expect(files).toContain(PORT);
+  });
+
+  it('touches a browser panel API from the port and nowhere else (D17)', () => {
+    // The port is the only place either API is named. That is what makes the gesture rule
+    // enforceable at all: one method, one caller, one place to read.
+    const offenders = files.filter(
+      (file) => file !== PORT && PANEL_API.test(withoutComments(readFileSync(join(ROOT, file), 'utf8'))),
+    );
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('offers exactly one way to open the panel, and it names the gesture', () => {
+    const port = readFileSync(join(ROOT, PORT), 'utf8');
+
+    const surface = /export interface PanelSurface \{([\s\S]*?)\n\}/.exec(port)?.[1] ?? '';
+    const members = [...surface.matchAll(/^\s{2}(\w+)\s*[(<]/gm)].map(([, name]) => name ?? '');
+
+    expect(members).toContain('openFromUserGesture');
+    // `isOpenAccordingToBrowser` reports state and opens nothing. Anything else with "open" in its
+    // name would be a second opening path, which is what D4 forbids.
+    expect(members.filter((name) => /open/i.test(name)).sort()).toEqual([
+      'isOpenAccordingToBrowser',
+      'openFromUserGesture',
+    ]);
+  });
+});

--- a/tests/unit/services/panel-presence.test.ts
+++ b/tests/unit/services/panel-presence.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const { requeuePresented } = vi.hoisted(() => ({ requeuePresented: vi.fn(async () => undefined) }));
 
 vi.mock('app/src-bex/services/request-queue', () => ({ requeuePresented }));
+vi.mock('app/src-bex/services/panel-surface', () => ({ resolvePanelSurface: vi.fn() }));
 vi.mock('src/services/log-service', () => ({
   LogLevel: { ERROR: 'error' },
   logService: { log: vi.fn() },
@@ -16,7 +17,9 @@ import {
   observePanelConnections,
   notifyPanelsOfQueueChange,
   onPanelPresenceChange,
+  reconcilePanelPresence,
 } from 'app/src-bex/services/panel-presence';
+import { resolvePanelSurface } from 'app/src-bex/services/panel-surface';
 
 type Connect = (port: chrome.runtime.Port) => void;
 
@@ -182,5 +185,71 @@ describe('telling panels the queue moved', () => {
     } as unknown as Partial<chrome.runtime.Port>);
 
     expect(() => notifyPanelsOfQueueChange()).not.toThrow();
+  });
+});
+
+/**
+ * Cross-checking the port against the browser (#113).
+ *
+ * The port is the source of truth because it is the only mechanism both browsers support. Firefox
+ * can additionally say whether a panel is open; Chromium cannot. This catches a panel that went away
+ * without its `onDisconnect` firing, which would otherwise leave a request presented to nobody.
+ */
+describe('reconciling presence with the browser', () => {
+  const isOpenAccordingToBrowser = vi.fn();
+
+  const withSurface = (): void => {
+    vi.mocked(resolvePanelSurface).mockReturnValue({
+      kind: 'firefox',
+      isOpenAccordingToBrowser,
+      configureToolbarBehaviour: vi.fn(),
+      openFromUserGesture: vi.fn(),
+    } as unknown as ReturnType<typeof resolvePanelSurface>);
+  };
+
+  beforeEach(() => {
+    withSurface();
+  });
+
+  it('drops ports the browser says are not there', async () => {
+    const connect = startObserving();
+    openPort(connect);
+    isOpenAccordingToBrowser.mockResolvedValue(false);
+
+    await reconcilePanelPresence(1);
+
+    expect(isPanelPresent()).toBe(false);
+    // The normal teardown path runs, so whatever was presented goes back to the queue.
+    expect(requeuePresented).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves presence alone when the browser says the panel is open', async () => {
+    const connect = startObserving();
+    openPort(connect);
+    isOpenAccordingToBrowser.mockResolvedValue(true);
+
+    await reconcilePanelPresence(1);
+
+    expect(isPanelPresent()).toBe(true);
+    expect(requeuePresented).not.toHaveBeenCalled();
+  });
+
+  it('treats no answer as no opinion, never as closed', async () => {
+    const connect = startObserving();
+    openPort(connect);
+    // Chromium abstains. Acting on that would tear down a live panel on the browser where most
+    // people run this.
+    isOpenAccordingToBrowser.mockResolvedValue(undefined);
+
+    await reconcilePanelPresence(1);
+
+    expect(isPanelPresent()).toBe(true);
+    expect(requeuePresented).not.toHaveBeenCalled();
+  });
+
+  it('does not ask the browser when no port is held', async () => {
+    await reconcilePanelPresence(1);
+
+    expect(isOpenAccordingToBrowser).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Refs #113. The remaining implementation work on that issue.

Most of #113 shipped in #157, #155 and #162; the checkboxes were never ticked, so the issue reads as
though none of it happened. This covers what was genuinely left.

## Firefox cross-check

The port is the only presence mechanism both browsers support, so it stays the source of truth. It
has one blind spot: **a panel that goes away without its `onDisconnect` firing leaves a request
presented to nobody.**

`isOpenAccordingToBrowser` joins the panel-surface port (D17 — no component touches a browser panel
API). Firefox answers through `sidebarAction.isOpen`; Chromium returns `undefined`, having no
equivalent.

**`undefined` means no opinion and is never read as closed.** Treating it as closed would tear down a
live panel's presence on the browser where most people run this — a worse failure than the blind spot
it would close. There is a test asserting exactly that.

Reconciliation runs when a window closes and takes the ordinary teardown path: presence changes, and
the last port going requeues whatever was presented. Nothing here decides a request.

## The gesture rule, made structural

`sidePanel.open()` and `sidebarAction.open()` reject outside a user gesture — in the background,
where nobody is watching. The symptom is a panel that silently does not open, which is why D4 states
the rule and why nothing had been enforcing it.

The guard asserts the invariant rather than the call site: **only the port names either API**, and the
port **offers exactly one way to open**, named for the gesture it requires.

My first version of this test looked for `sidePanel.open(` textually and passed while matching
nothing, because the port calls through a local handle. The second matched my own comment explaining
the rule. It now strips comments and checks the interface.

## Terminal states

`CurrentRequest` already withheld the controls for expired and interrupted requests; nothing asserted
it. The background refuses a decision on a terminal id anyway, so this is not a hole — but a panel
that still shows the controls invites the attempt and reads as though the request were live.

Eight tests: no decision bar, no event preview, and a reason announced in a live region, for both
terminal states, plus the live cases still showing everything.

## Verification

`lint`, `typecheck`, `test:run` — 802 tests, up from 787 — and the coverage gate all pass.

## Still open on #113, and it is a measurement not a decision

Whether a long-lived `runtime.connect` port keeps the Chromium service worker alive, and whether
presence should therefore use a heartbeat with a deliberate idle gap. I am measuring it now against a
real build and will post the result on the issue; it does not block this change either way, since the
port is the source of truth in both outcomes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)