### PR TITLE
refactor(bex): extract the approval flow so it can be tested

### DIFF
--- a/src-bex/background.ts
+++ b/src-bex/background.ts
@@ -21,7 +21,6 @@ import {
 } from './services/auto-lock';
 import { initializePanelSurface, resolvePanelSurface } from './services/panel-surface';
 import {
-  enqueueRequest,
   getCurrentRequest,
   getPendingCount,
   getRequestContent,
@@ -40,7 +39,9 @@ import {
   reconcilePanelPresence,
 } from './services/panel-presence';
 import { refreshAttention } from './services/attention-badge';
-import { resolveSigningAccount } from './services/signing-account';
+import { requestApproval, trimApprovalContentDescription } from './services/approval-flow';
+import type { ApprovalRequestDetails } from './services/approval-flow';
+import { originHostname } from './services/origin';
 import {
   getPageOrigin,
   listPageOrigins,
@@ -48,7 +49,7 @@ import {
   onPageOriginChange,
   restorePageOrigins,
 } from './services/page-origin-registry';
-import type { ApprovalDuration, UnsignedEvent } from './types/background';
+import type { ApprovalDuration } from './types/background';
 import type {
   BridgeResponsePayload,
   VaultData,
@@ -67,8 +68,6 @@ import {
   restoreVaultState,
 } from './handlers/vault-handler';
 import {
-  checkPermission,
-  grantPermission,
 } from './handlers/permission-handler';
 import {
   handleGetPublicKey,
@@ -256,14 +255,6 @@ if (typeof self !== 'undefined') {
 // Auto-lock activity is deliberately not reset by site-initiated requests (ADR D15). A page
 // making periodic requests must not hold the vault unlocked past the user's configured
 // interval; only interaction with a Porwr surface counts as activity.
-const getHostname = (origin: string): string => {
-  try {
-    return new URL(origin).hostname;
-  } catch {
-    return origin;
-  }
-};
-
 bridge.on('nostr.requests.list', () => {
   return listPendingRequests() as unknown as BridgeResponsePayload<'nostr.requests.list'>;
 });
@@ -533,110 +524,6 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   return true;
 });
 
-interface ApprovalRequestDetails {
-  requestType: string;
-  contentDescription?: string;
-  allowRemember?: boolean;
-  skipPermissionCheck?: boolean;
-  /** Full unsigned event, for `sign_event`. Held in memory only, never persisted (D6). */
-  event?: UnsignedEvent;
-  /** Counterparty for encryption and decryption requests. Never the plaintext. */
-  counterpartyPubkey?: string;
-}
-
-const trimApprovalContentDescription = (content?: string): string | undefined => {
-  const normalized = content?.replace(/\s+/g, ' ').trim();
-  if (!normalized) return undefined;
-  return normalized.length > 240 ? `${normalized.slice(0, 237)}...` : normalized;
-};
-
-/**
- * `-1` at these call sites means "this request carries no event kind", never "any kind". The grant
- * store no longer conflates the two, so it is translated to null on the way in (#136).
- */
-const toPermissionKind = (eventKind: number): number | null => (eventKind < 0 ? null : eventKind);
-
-async function requestApproval(
-  origin: string,
-  eventKind: number,
-  details: ApprovalRequestDetails,
-): Promise<boolean> {
-  const permissionKind = toPermissionKind(eventKind);
-
-  // The account that will act for this site, which is the one a grant belongs to. Resolved before
-  // the permission check so a grant given to one identity cannot answer for another (#116).
-  const resolved = await resolveSigningAccount(origin);
-  const actingAccount = 'account' in resolved ? resolved.account : null;
-
-  if (!details.skipPermissionCheck && actingAccount) {
-    const permission = await checkPermission(
-      origin,
-      actingAccount.id,
-      details.requestType,
-      permissionKind,
-    );
-    if (permission.granted) return true;
-  }
-
-  const { record, decision } = await enqueueRequest({
-    origin,
-    requestType: details.requestType,
-    eventKind,
-    accountAlias: actingAccount?.alias ?? null,
-    // The identity the user is deciding for, shown on the approval and recorded on the grant.
-    accountPubkey: actingAccount?.id ?? null,
-  }, {
-    // Reviewable detail stays in worker memory for the life of the request.
-    ...(details.contentDescription !== undefined
-      ? { contentDescription: details.contentDescription }
-      : {}),
-    ...(details.event !== undefined ? { event: details.event } : {}),
-    ...(details.counterpartyPubkey !== undefined
-      ? { counterpartyPubkey: details.counterpartyPubkey }
-      : {}),
-    allowRemember: details.allowRemember !== false,
-  });
-
-  // A locked vault no longer opens its own window: the panel presents the unlock view with the
-  // waiting request, and unlocking still requires an explicit decision afterwards (ADR D14).
-  const outcome = await decision;
-
-  const approved = outcome.approved;
-  const durationLabel: ApprovalDuration = outcome.duration;
-
-  if (
-    approved &&
-    durationLabel !== 'once' &&
-    details.allowRemember !== false &&
-    !details.skipPermissionCheck
-  ) {
-    try {
-      await grantPermission(
-        origin,
-        record.accountPubkey ?? '',
-        details.requestType,
-        permissionKind,
-        durationLabel,
-      );
-    } catch (error: unknown) {
-      logService.log(LogLevel.ERROR, '[BEX] Failed to grant permission', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-  }
-
-  // Logged on the terminal transition rather than when the site asked, so a rejection is not
-  // recorded as an approval.
-  void logService.logApproval(
-    eventKind === -1 ? details.requestType : eventKind,
-    getHostname(origin),
-    record.accountAlias,
-    approved ? 'approved' : 'rejected',
-  );
-
-  return approved;
-}
-
 bridge.on('nostr.getPublicKey', ({ payload: { origin } }) => (
   (async () => {
     const result = await handleGetPublicKey({}, origin);
@@ -647,7 +534,7 @@ bridge.on('nostr.getPublicKey', ({ payload: { origin } }) => (
       );
     }
     const activeStoredKey = await getActiveStoredKey();
-    void logService.logApproval('get_public_key', getHostname(origin), activeStoredKey?.alias);
+    void logService.logApproval('get_public_key', originHostname(origin), activeStoredKey?.alias);
     const approved = await requestApproval(origin, -1, { requestType: 'get_public_key' });
     if (!approved) {
       throw new BackgroundBridgeError('PERMISSION_DENIED', 'User rejected the request');
@@ -659,7 +546,7 @@ bridge.on('nostr.getPublicKey', ({ payload: { origin } }) => (
 bridge.on('nostr.signEvent', ({ payload: { event, origin } }) => (
   (async () => {
     const activeStoredKey = await getActiveStoredKey();
-    void logService.logApproval(event.kind, getHostname(origin), activeStoredKey?.alias);
+    void logService.logApproval(event.kind, originHostname(origin), activeStoredKey?.alias);
     const contentDescription = trimApprovalContentDescription(event.content);
     const approvalDetails: ApprovalRequestDetails = contentDescription
       ? { requestType: 'sign_event', contentDescription, event }
@@ -690,7 +577,7 @@ bridge.on('nostr.signEvent', ({ payload: { event, origin } }) => (
 bridge.on('nostr.getRelays', ({ payload: { origin } }) => (
   (async () => {
     const activeStoredKey = await getActiveStoredKey();
-    void logService.logApproval('get_relays', getHostname(origin), activeStoredKey?.alias);
+    void logService.logApproval('get_relays', originHostname(origin), activeStoredKey?.alias);
     const approved = await requestApproval(origin, -1, { requestType: 'get_relays' });
     if (!approved) {
       const unlockedStatus = await handleVaultIsUnlocked({}, '');
@@ -704,7 +591,7 @@ bridge.on('nostr.getRelays', ({ payload: { origin } }) => (
 bridge.on('nostr.nip04.encrypt', ({ payload }) => (
   (async () => {
     const activeStoredKey = await getActiveStoredKey();
-    void logService.logApproval('nip04_encrypt', getHostname(payload.origin), activeStoredKey?.alias);
+    void logService.logApproval('nip04_encrypt', originHostname(payload.origin), activeStoredKey?.alias);
     const approved = await requestApproval(payload.origin, -1, { requestType: 'nip04_encrypt', counterpartyPubkey: payload.pubkey });
     if (!approved) {
       const unlockedStatus = await handleVaultIsUnlocked({}, '');
@@ -718,7 +605,7 @@ bridge.on('nostr.nip04.encrypt', ({ payload }) => (
 bridge.on('nostr.nip04.decrypt', ({ payload }) => (
   (async () => {
     const activeStoredKey = await getActiveStoredKey();
-    void logService.logApproval('nip04_decrypt', getHostname(payload.origin), activeStoredKey?.alias);
+    void logService.logApproval('nip04_decrypt', originHostname(payload.origin), activeStoredKey?.alias);
     const approved = await requestApproval(payload.origin, -1, { requestType: 'nip04_decrypt', counterpartyPubkey: payload.pubkey });
     if (!approved) {
       const unlockedStatus = await handleVaultIsUnlocked({}, '');
@@ -732,7 +619,7 @@ bridge.on('nostr.nip04.decrypt', ({ payload }) => (
 bridge.on('nostr.nip44.encrypt', ({ payload }) => (
   (async () => {
     const activeStoredKey = await getActiveStoredKey();
-    void logService.logApproval('nip44_encrypt', getHostname(payload.origin), activeStoredKey?.alias);
+    void logService.logApproval('nip44_encrypt', originHostname(payload.origin), activeStoredKey?.alias);
     const approved = await requestApproval(payload.origin, -1, { requestType: 'nip44_encrypt', counterpartyPubkey: payload.pubkey });
     if (!approved) {
       const unlockedStatus = await handleVaultIsUnlocked({}, '');
@@ -746,7 +633,7 @@ bridge.on('nostr.nip44.encrypt', ({ payload }) => (
 bridge.on('nostr.nip44.decrypt', ({ payload }) => (
   (async () => {
     const activeStoredKey = await getActiveStoredKey();
-    void logService.logApproval('nip44_decrypt', getHostname(payload.origin), activeStoredKey?.alias);
+    void logService.logApproval('nip44_decrypt', originHostname(payload.origin), activeStoredKey?.alias);
     const approved = await requestApproval(payload.origin, -1, { requestType: 'nip44_decrypt', counterpartyPubkey: payload.pubkey });
     if (!approved) {
       const unlockedStatus = await handleVaultIsUnlocked({}, '');

--- a/src-bex/services/approval-flow.ts
+++ b/src-bex/services/approval-flow.ts
@@ -1,0 +1,131 @@
+/**
+ * The approval decision for a site-initiated request.
+ *
+ * Extracted from `background.ts` unchanged (#173). It was the security logic in a file nothing could
+ * import — the module registers listeners and calls `initialize()` at load — so none of it was
+ * reachable from a test, and the coverage report skipped the file entirely rather than reporting it
+ * as uncovered.
+ *
+ * What it decides, in order:
+ *
+ * 1. which account acts for the origin, because that is the account a grant belongs to (#116)
+ * 2. whether an existing grant already answers, short-circuiting without asking the user
+ * 3. otherwise, enqueue for the panel and wait for a terminal outcome
+ * 4. on approval with a remembered duration, write the grant against the acting account
+ * 5. log the outcome on the terminal transition, so a rejection is never recorded as an approval
+ */
+
+import { LogLevel, logService } from 'src/services/log-service';
+import { checkPermission, grantPermission } from '../handlers/permission-handler';
+import { enqueueRequest } from './request-queue';
+import { originHostname } from './origin';
+import { resolveSigningAccount } from './signing-account';
+import type { ApprovalDuration, UnsignedEvent } from '../types/background';
+
+export interface ApprovalRequestDetails {
+  requestType: string;
+  contentDescription?: string;
+  allowRemember?: boolean;
+  skipPermissionCheck?: boolean;
+  /** Full unsigned event, for `sign_event`. Held in memory only, never persisted (D6). */
+  event?: UnsignedEvent;
+  /** Counterparty for encryption and decryption requests. Never the plaintext. */
+  counterpartyPubkey?: string;
+}
+
+export const trimApprovalContentDescription = (content?: string): string | undefined => {
+  const normalized = content?.replace(/\s+/g, ' ').trim();
+  if (!normalized) return undefined;
+  return normalized.length > 240 ? `${normalized.slice(0, 237)}...` : normalized;
+};
+
+/**
+ * `-1` at the call sites means "this request carries no event kind", never "any kind". The grant
+ * store no longer conflates the two, so it is translated to null on the way in (#136).
+ */
+export const toPermissionKind = (eventKind: number): number | null =>
+  eventKind < 0 ? null : eventKind;
+
+export async function requestApproval(
+  origin: string,
+  eventKind: number,
+  details: ApprovalRequestDetails,
+): Promise<boolean> {
+  const permissionKind = toPermissionKind(eventKind);
+
+  // The account that will act for this site, which is the one a grant belongs to. Resolved before
+  // the permission check so a grant given to one identity cannot answer for another (#116).
+  const resolved = await resolveSigningAccount(origin);
+  const actingAccount = 'account' in resolved ? resolved.account : null;
+
+  if (!details.skipPermissionCheck && actingAccount) {
+    const permission = await checkPermission(
+      origin,
+      actingAccount.id,
+      details.requestType,
+      permissionKind,
+    );
+    if (permission.granted) return true;
+  }
+
+  const { record, decision } = await enqueueRequest(
+    {
+      origin,
+      requestType: details.requestType,
+      eventKind,
+      accountAlias: actingAccount?.alias ?? null,
+      // The identity the user is deciding for, shown on the approval and recorded on the grant.
+      accountPubkey: actingAccount?.id ?? null,
+    },
+    {
+      // Reviewable detail stays in worker memory for the life of the request.
+      ...(details.contentDescription !== undefined
+        ? { contentDescription: details.contentDescription }
+        : {}),
+      ...(details.event !== undefined ? { event: details.event } : {}),
+      ...(details.counterpartyPubkey !== undefined
+        ? { counterpartyPubkey: details.counterpartyPubkey }
+        : {}),
+      allowRemember: details.allowRemember !== false,
+    },
+  );
+
+  // A locked vault no longer opens its own window: the panel presents the unlock view with the
+  // waiting request, and unlocking still requires an explicit decision afterwards (ADR D14).
+  const outcome = await decision;
+
+  const approved = outcome.approved;
+  const durationLabel: ApprovalDuration = outcome.duration;
+
+  if (
+    approved &&
+    durationLabel !== 'once' &&
+    details.allowRemember !== false &&
+    !details.skipPermissionCheck
+  ) {
+    try {
+      await grantPermission(
+        origin,
+        record.accountPubkey ?? '',
+        details.requestType,
+        permissionKind,
+        durationLabel,
+      );
+    } catch (error: unknown) {
+      logService.log(LogLevel.ERROR, '[BEX] Failed to grant permission', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  // Logged on the terminal transition rather than when the site asked, so a rejection is not
+  // recorded as an approval.
+  void logService.logApproval(
+    eventKind === -1 ? details.requestType : eventKind,
+    originHostname(origin),
+    record.accountAlias,
+    approved ? 'approved' : 'rejected',
+  );
+
+  return approved;
+}

--- a/tests/unit/bridge-action-routing.test.ts
+++ b/tests/unit/bridge-action-routing.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Every declared bridge action must be reachable, by one path or the other.
+ *
+ * There are two: `dispatcher.ts`'s switch, used by the raw `chrome.runtime.onMessage` listener, and
+ * `bridge.on` registrations in `background.ts`, used by the Quasar bridge. An action declared in the
+ * union but wired to neither is a call that silently does nothing — no error, no route, no reply
+ * (#173).
+ *
+ * This reads the source rather than the runtime because `background.ts` cannot be imported: it
+ * registers listeners and calls `initialize()` at load, which is the same reason coverage skips it.
+ */
+
+const ROOT = resolve(__dirname, '../..');
+
+const read = (path: string): string => readFileSync(resolve(ROOT, path), 'utf8');
+
+const declaredActions = (): string[] => {
+  const source = read('src/types/bridge-types.d.ts');
+  const union = /export type BridgeAction =(.*?);/s.exec(source)?.[1] ?? '';
+  return [...union.matchAll(/'([^']+)'/g)].map(([, action]) => action ?? '');
+};
+
+const dispatcherCases = (): string[] =>
+  [...read('src-bex/dispatcher.ts').matchAll(/case '([^']+)'/g)].map(([, action]) => action ?? '');
+
+const bridgeRegistrations = (): string[] =>
+  [...read('src-bex/background.ts').matchAll(/bridge\.on\('([^']+)'/g)].map(([, action]) => action ?? '');
+
+/**
+ * Declared, wired to neither path, and sent by nothing.
+ *
+ * Recorded rather than fixed here: removing an action from the union is a contract change, and one
+ * of these is a permission call, which deserves a deliberate decision rather than a tidy-up.
+ */
+const KNOWN_UNROUTED = ['permission.check', 'permission.grant', 'vault.setData'];
+
+describe('bridge action routing', () => {
+  const actions = declaredActions();
+  const routed = new Set([...dispatcherCases(), ...bridgeRegistrations()]);
+
+  it('parses all three sources, so this cannot pass by reading nothing', () => {
+    expect(actions.length).toBeGreaterThan(40);
+    expect(dispatcherCases().length).toBeGreaterThan(30);
+    expect(bridgeRegistrations().length).toBeGreaterThan(30);
+  });
+
+  it('routes every declared action except the ones known to be unrouted', () => {
+    const unrouted = actions.filter((action) => !routed.has(action));
+
+    expect(unrouted.sort()).toEqual([...KNOWN_UNROUTED].sort());
+  });
+
+  it('has no route for an action that was never declared', () => {
+    // A typo in a `case` or a `bridge.on` name is otherwise invisible: the action simply never
+    // matches, and the caller gets silence.
+    const undeclared = [...routed].filter((action) => !actions.includes(action));
+
+    expect(undeclared).toEqual([]);
+  });
+
+  it('keeps the unrouted list honest', () => {
+    // If one of these gains a route, this fails and the entry should be deleted rather than the
+    // expectation loosened.
+    for (const action of KNOWN_UNROUTED) {
+      expect(actions).toContain(action);
+      expect(routed.has(action)).toBe(false);
+    }
+  });
+});

--- a/tests/unit/services/approval-flow.test.ts
+++ b/tests/unit/services/approval-flow.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  checkPermission: vi.fn(),
+  grantPermission: vi.fn(),
+  enqueueRequest: vi.fn(),
+  resolveSigningAccount: vi.fn(),
+  log: vi.fn(),
+  logApproval: vi.fn(),
+}));
+
+vi.mock('app/src-bex/handlers/permission-handler', () => ({
+  checkPermission: mocks.checkPermission,
+  grantPermission: mocks.grantPermission,
+}));
+vi.mock('app/src-bex/services/request-queue', () => ({ enqueueRequest: mocks.enqueueRequest }));
+vi.mock('app/src-bex/services/signing-account', () => ({
+  resolveSigningAccount: mocks.resolveSigningAccount,
+}));
+vi.mock('src/services/log-service', () => ({
+  LogLevel: { ERROR: 'error' },
+  logService: { log: mocks.log, logApproval: mocks.logApproval },
+}));
+
+import {
+  requestApproval,
+  toPermissionKind,
+  trimApprovalContentDescription,
+} from 'app/src-bex/services/approval-flow';
+
+const ALICE = { id: 'a'.repeat(64), alias: 'alice', account: { privkey: '11'.repeat(32) } };
+const ORIGIN = 'https://example.com';
+
+/** Enqueue returns the stored record plus a promise that settles on the user's decision. */
+const enqueueResolving = (
+  outcome: { approved: boolean; duration: 'once' | '8h' | 'always' },
+  accountPubkey: string | null = ALICE.id,
+): void => {
+  mocks.enqueueRequest.mockResolvedValue({
+    record: { id: 'req-1', accountAlias: 'alice', accountPubkey },
+    decision: Promise.resolve(outcome),
+  });
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.resolveSigningAccount.mockResolvedValue({ account: ALICE });
+  mocks.checkPermission.mockResolvedValue({ granted: false });
+  mocks.grantPermission.mockResolvedValue(undefined);
+  enqueueResolving({ approved: true, duration: 'once' });
+});
+
+describe('deciding a site request', () => {
+  describe('an existing grant', () => {
+    it('answers without asking the user', async () => {
+      mocks.checkPermission.mockResolvedValue({ granted: true });
+
+      await expect(requestApproval(ORIGIN, 1, { requestType: 'sign_event' })).resolves.toBe(true);
+      expect(mocks.enqueueRequest).not.toHaveBeenCalled();
+    });
+
+    it('is checked against the account that will act, not whichever is active (#116)', async () => {
+      mocks.checkPermission.mockResolvedValue({ granted: true });
+
+      await requestApproval(ORIGIN, 1, { requestType: 'sign_event' });
+
+      expect(mocks.checkPermission).toHaveBeenCalledWith(ORIGIN, ALICE.id, 'sign_event', 1);
+    });
+
+    it('is not consulted when the caller says to skip it', async () => {
+      await requestApproval(ORIGIN, 1, { requestType: 'sign_event', skipPermissionCheck: true });
+
+      expect(mocks.checkPermission).not.toHaveBeenCalled();
+      expect(mocks.enqueueRequest).toHaveBeenCalled();
+    });
+
+    it('is not consulted when no account can act, so the user is always asked', async () => {
+      mocks.resolveSigningAccount.mockResolvedValue({ error: 'Vault is locked', code: 'VLT_LOCKED' });
+
+      await requestApproval(ORIGIN, 1, { requestType: 'sign_event' });
+
+      expect(mocks.checkPermission).not.toHaveBeenCalled();
+      expect(mocks.enqueueRequest).toHaveBeenCalled();
+    });
+  });
+
+  describe('the request it enqueues', () => {
+    it('carries the acting account so the panel names the identity being decided for', async () => {
+      await requestApproval(ORIGIN, 1, { requestType: 'sign_event' });
+
+      expect(mocks.enqueueRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ accountAlias: 'alice', accountPubkey: ALICE.id }),
+        expect.anything(),
+      );
+    });
+
+    it('carries no account when none can act', async () => {
+      mocks.resolveSigningAccount.mockResolvedValue({ error: 'No active account', code: 'X' });
+
+      await requestApproval(ORIGIN, 1, { requestType: 'sign_event' });
+
+      expect(mocks.enqueueRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ accountAlias: null, accountPubkey: null }),
+        expect.anything(),
+      );
+    });
+
+    it('omits reviewable detail that was not supplied, rather than sending undefined', async () => {
+      await requestApproval(ORIGIN, 1, { requestType: 'sign_event' });
+
+      const [, content] = mocks.enqueueRequest.mock.calls[0] as [unknown, Record<string, unknown>];
+      expect(content).toEqual({ allowRemember: true });
+    });
+
+    it('passes the event through for a signing request (D6: memory only)', async () => {
+      const event = { kind: 1, content: 'hi', tags: [], created_at: 1 };
+
+      await requestApproval(ORIGIN, 1, { requestType: 'sign_event', event: event as never });
+
+      const [, content] = mocks.enqueueRequest.mock.calls[0] as [unknown, Record<string, unknown>];
+      expect(content.event).toBe(event);
+    });
+  });
+
+  describe('writing the grant', () => {
+    it('writes it against the acting account when a duration is remembered', async () => {
+      enqueueResolving({ approved: true, duration: '8h' });
+
+      await requestApproval(ORIGIN, 1, { requestType: 'sign_event' });
+
+      expect(mocks.grantPermission).toHaveBeenCalledWith(ORIGIN, ALICE.id, 'sign_event', 1, '8h');
+    });
+
+    it('writes nothing for "once"', async () => {
+      enqueueResolving({ approved: true, duration: 'once' });
+
+      await requestApproval(ORIGIN, 1, { requestType: 'sign_event' });
+
+      expect(mocks.grantPermission).not.toHaveBeenCalled();
+    });
+
+    it('writes nothing when the request was rejected', async () => {
+      enqueueResolving({ approved: false, duration: 'always' });
+
+      await expect(requestApproval(ORIGIN, 1, { requestType: 'sign_event' })).resolves.toBe(false);
+      expect(mocks.grantPermission).not.toHaveBeenCalled();
+    });
+
+    it('writes nothing when the request type may not be remembered', async () => {
+      enqueueResolving({ approved: true, duration: 'always' });
+
+      await requestApproval(ORIGIN, 1, { requestType: 'send_zap', allowRemember: false });
+
+      // Payments are one-time whatever else is true (D11).
+      expect(mocks.grantPermission).not.toHaveBeenCalled();
+    });
+
+    it('writes nothing when the permission check was skipped', async () => {
+      enqueueResolving({ approved: true, duration: 'always' });
+
+      await requestApproval(ORIGIN, 1, { requestType: 'sign_event', skipPermissionCheck: true });
+
+      expect(mocks.grantPermission).not.toHaveBeenCalled();
+    });
+
+    it('still approves when the grant cannot be written', async () => {
+      enqueueResolving({ approved: true, duration: 'always' });
+      mocks.grantPermission.mockRejectedValue(new Error('storage gone'));
+
+      // The user approved this request; failing to remember it must not retract that.
+      await expect(requestApproval(ORIGIN, 1, { requestType: 'sign_event' })).resolves.toBe(true);
+      expect(mocks.log).toHaveBeenCalled();
+    });
+  });
+
+  describe('the approvals log', () => {
+    it('records the outcome, not the asking', async () => {
+      enqueueResolving({ approved: false, duration: 'once' });
+
+      await requestApproval(ORIGIN, 1, { requestType: 'sign_event' });
+
+      expect(mocks.logApproval).toHaveBeenCalledWith(1, 'example.com', 'alice', 'rejected');
+    });
+
+    it('names the request type when there is no event kind', async () => {
+      await requestApproval(ORIGIN, -1, { requestType: 'get_public_key' });
+
+      expect(mocks.logApproval).toHaveBeenCalledWith(
+        'get_public_key',
+        'example.com',
+        'alice',
+        'approved',
+      );
+    });
+  });
+});
+
+describe('helpers', () => {
+  describe('toPermissionKind', () => {
+    it('maps "no event kind" to null rather than a wildcard (#136)', () => {
+      expect(toPermissionKind(-1)).toBeNull();
+      expect(toPermissionKind(0)).toBe(0);
+      expect(toPermissionKind(30023)).toBe(30023);
+    });
+  });
+
+  describe('trimApprovalContentDescription', () => {
+    it('collapses whitespace', () => {
+      expect(trimApprovalContentDescription('  a\n\n b  ')).toBe('a b');
+    });
+
+    it('drops content that is only whitespace', () => {
+      expect(trimApprovalContentDescription('   ')).toBeUndefined();
+      expect(trimApprovalContentDescription(undefined)).toBeUndefined();
+    });
+
+    it('truncates visibly rather than silently', () => {
+      const trimmed = trimApprovalContentDescription('x'.repeat(400));
+
+      expect(trimmed).toHaveLength(240);
+      expect(trimmed?.endsWith('...')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Refs #173. First pass of the plan on that issue.

## The problem, restated from measuring rather than guessing

`background.ts` is 870 lines, and **roughly 71% of it is thin `bridge.on` adapters** delegating to
handlers and services that already sit above 80%. Most of the file does not need covering.

The part that does is `requestApproval` — the security logic — and it was unreachable from any test,
because importing the module runs `void initialize()` and registers a dozen listeners. Coverage did
not report it as uncovered; it skipped the file with `Failed to parse`.

## What moved

`requestApproval` and its two helpers to `services/approval-flow.ts`, **unchanged**. It sits directly
on the signing path, so nothing was tidied on the way out.

It now reports **100% statements, 89% branches**, and the file it left drops from 870 lines to 759.

Twenty tests, covering the paths that matter rather than the lines that are easy:

- the permission short-circuit, and that it checks against **the acting account** rather than
  whichever is active (#116)
- no check at all when no account can act, so the user is always asked rather than silently refused
- `once` writes no grant; a rejection writes none; a payment marked not-rememberable writes none
- a grant that **fails to persist does not retract an approval the user already gave**
- the approvals log records the outcome, not the asking, and names the request type when there is no
  event kind

## A duplicate I had left behind

`background.ts` carried its own `getHostname`, while `services/origin.ts` exports `originHostname` —
which I added in #164 and never used anywhere. The local one did not lowercase and did not reject
non-web schemes, and **the approvals log is keyed on it**, so the seven call sites now use the shared
normalisation #116 asked for.

## The routing guard found something

Every declared `BridgeAction` should be reachable by one of the two paths — `dispatcher.ts`'s switch
or a `bridge.on` registration. Three are reachable by neither:

| Action | Dispatcher | `bridge.on` | Sent by anything |
|---|---|---|---|
| `permission.check` | no | no | no |
| `permission.grant` | no | no | no |
| `vault.setData` | no | no | no |

Nothing is broken today, because nothing sends them — but a caller that did would get **silence**, not
an error.

They are recorded in the test rather than removed. Deleting from the union is a contract change, and
two of them are permission calls that deserve a deliberate decision rather than a tidy-up. If one
gains a route, the test fails and the entry should be deleted rather than the expectation loosened.

The guard also catches the inverse — a `case` or `bridge.on` naming an action that was never
declared, which is otherwise invisible: it simply never matches.

## Verification

`lint`, `typecheck`, `test:run` (826 tests, up from 802), the coverage gate, and the Chromium e2e
suite all pass.

Global coverage moved to 59.36% statements / 51.64% branches. The floors from #143 are not raised
here — worth doing once the rest of #173 lands rather than twice.

## Still open on #173

The raw message listener's decision, the queue and page-gone callbacks, and `dispatcher.ts`'s own
17.85%. `background.ts` still reports `Failed to parse`, which the plan predicted: extraction removes
the reason to import it, so the file's own percentage was never the target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)