### PR TITLE
refactor(bex): extract the routing and reconciliation decisions

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -104,10 +104,10 @@ actually stands, so a genuine regression fails and ordinary noise does not:
 
 | | Floor | Actual (2026-08-21) |
 |---|---|---|
-| Statements | 58% | 58.84% |
-| Branches | 50% | 50.94% |
-| Functions | 50% | 50.73% |
-| Lines | 59% | 59.12% |
+| Statements | 59% | 59.77% |
+| Branches | 52% | 52.05% |
+| Functions | 51% | 51.39% |
+| Lines | 60% | 60.02% |
 
 **The target is 75%** across the board. The floors are raised toward it as coverage rises, and are
 never lowered: if a change cannot meet the current floor, the answer is a test, not a smaller number.
@@ -131,11 +131,14 @@ it did not touch: adding an uncovered file to a well-covered directory is exactl
 Branches are the furthest from target and matter most. In a signing extension the untested branch is
 the one that fails open.
 
-`src-bex/background.ts` is not covered at all, and is not even measured: the coverage provider
-reports `Failed to parse ... background.ts. Excluding it from coverage.` because no test imports it,
-so it is read from disk rather than through the Vite transform. At 862 lines it is the largest file
-in the extension and it wires together approvals, permissions, the queue, the badge and the page
-registry. It does not appear in any figure above, in either direction.
+`src-bex/background.ts` is still not measured — the provider reports `Failed to parse ...
+background.ts. Excluding it from coverage.` because nothing imports it, so it is read from disk
+rather than through the Vite transform. It appears in no figure above, in either direction.
+
+That matters less than it did. #173 moved what it decided into modules that are measured: the
+approval flow, the raw message routing decision and the page reconciliation, all now covered. What
+remains in the file is the `bridge.on` registrations and startup ordering — wiring, which the
+end-to-end suite exercises against a real extension rather than a mock.
 
 The Vue component layer has no threshold. #123 deliberately left component structure alone, and a
 floor there would measure work nobody has agreed to do.

--- a/src-bex/background.ts
+++ b/src-bex/background.ts
@@ -27,7 +27,6 @@ import {
   listPendingRequests,
   markPresented,
   pruneResolvedRequests,
-  interruptRequestsForOrigin,
   onQueueChange,
   reconcileInterruptedRequests,
   requeuePresented,
@@ -42,15 +41,18 @@ import { refreshAttention } from './services/attention-badge';
 import { requestApproval, trimApprovalContentDescription } from './services/approval-flow';
 import type { ApprovalRequestDetails } from './services/approval-flow';
 import { originHostname } from './services/origin';
+import { decideRouting, type RawMessage } from './services/message-routing';
+import { reconcileAbandonedRequests } from './services/page-reconciliation';
 import {
   getPageOrigin,
-  listPageOrigins,
   observePageConnections,
   onPageOriginChange,
   restorePageOrigins,
 } from './services/page-origin-registry';
 import type { ApprovalDuration } from './types/background';
 import type {
+  BridgeAction,
+  BridgeRequestMap,
   BridgeResponsePayload,
   VaultData,
   GetPublicKeyRequest,
@@ -437,24 +439,10 @@ onQueueChange(() => {
  * until no tab holds the origin at all before interrupting anything (D7).
  */
 onPageOriginChange((_tabId, record) => {
+  // Only a page going away can strand a request; one arriving cannot.
   if (record) return;
 
-  const goneOrigins = new Set<string>();
-  for (const [, remaining] of listPageOrigins()) goneOrigins.add(remaining.origin);
-
-  void (async () => {
-    const origins = new Set<string>();
-    for (const request of (await listPendingRequests()) ?? []) origins.add(request.origin);
-
-    for (const origin of origins) {
-      if (goneOrigins.has(origin)) continue;
-      await interruptRequestsForOrigin(origin);
-    }
-  })().catch((error: unknown) => {
-    logService.log(LogLevel.ERROR, '[Pages] Failed to reconcile requests for a closed page', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-  });
+  void reconcileAbandonedRequests();
 });
 
 // A closed window takes its tabs with it; ports usually report that first, but not always.
@@ -483,33 +471,22 @@ chrome.action?.onClicked?.addListener((tab) => {
 // permission checks. This raw listener has no reliable origin of its own, so
 // these actions must carry a non-empty `payload.origin` rather than falling
 // back to '' (which could otherwise match a permission record with no origin).
-const ORIGIN_SCOPED_ACTIONS = new Set([
-  'nostr.getPublicKey',
-  'nostr.signEvent',
-  'nostr.getRelays',
-  'nostr.nip04.encrypt',
-  'nostr.nip04.decrypt',
-  'nostr.nip44.encrypt',
-  'nostr.nip44.decrypt',
-  'nip57.getCapabilities',
-  'nip57.sendZap',
-  'webln.enable',
-  'webln.getInfo',
-  'webln.sendPayment',
-]);
-
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-  const payload = (message.payload || {}) as { origin?: unknown };
+  const decision = decideRouting(message as RawMessage);
 
-  if (ORIGIN_SCOPED_ACTIONS.has(message.type) && !payload.origin) {
-    sendResponse({
-      success: false,
-      error: 'Missing origin for origin-scoped action',
-    });
+  if (!decision.dispatch) {
+    sendResponse({ success: false, error: decision.error });
     return true;
   }
 
-  void dispatchMessage(message.type, message.payload || {}, typeof payload.origin === 'string' ? payload.origin : '')
+  // The untyped boundary. A raw runtime message is whatever the sender put on the wire, so the
+  // payload is asserted into the dispatcher's shape here and nowhere deeper — the dispatcher's
+  // switch is what actually decides whether the action is one we serve.
+  void dispatchMessage(
+    decision.type as BridgeAction,
+    decision.payload as BridgeRequestMap[BridgeAction],
+    decision.origin,
+  )
     .then((response) => {
       if (response !== null) {
         sendResponse(response);

--- a/src-bex/services/message-routing.ts
+++ b/src-bex/services/message-routing.ts
@@ -1,0 +1,62 @@
+/**
+ * The decision the raw message listener makes before dispatching.
+ *
+ * Extracted from `background.ts` (#173). The listener itself stays there — it is wiring — but the
+ * branching it wraps was unreachable from any test, because importing that module runs
+ * `initialize()` and registers a dozen listeners.
+ *
+ * What it decides is small and worth being sure of: an action scoped to an origin must not be
+ * dispatched without one. `checkPermission` and every signing handler key on the origin, so an empty
+ * one would be a request from nowhere being answered as though it came from somewhere.
+ */
+
+/**
+ * Actions that mean nothing without a requesting origin.
+ *
+ * Every one of them either signs, encrypts, decrypts, pays, or reveals an identity on a site's
+ * behalf. The panel and vault actions are deliberately absent: they come from the extension's own
+ * surfaces, which have no site origin to give.
+ */
+export const ORIGIN_SCOPED_ACTIONS: ReadonlySet<string> = new Set([
+  'nostr.getPublicKey',
+  'nostr.signEvent',
+  'nostr.getRelays',
+  'nostr.nip04.encrypt',
+  'nostr.nip04.decrypt',
+  'nostr.nip44.encrypt',
+  'nostr.nip44.decrypt',
+  'nip57.getCapabilities',
+  'nip57.sendZap',
+  'webln.enable',
+  'webln.getInfo',
+  'webln.sendPayment',
+]);
+
+export interface RawMessage {
+  type?: unknown;
+  payload?: unknown;
+}
+
+export type RoutingDecision =
+  | { dispatch: true; type: string; payload: Record<string, unknown>; origin: string }
+  | { dispatch: false; error: string };
+
+/**
+ * Whether a raw message may be dispatched, and with what.
+ *
+ * Returns the origin as a string rather than leaving it `unknown`: a non-string origin on an
+ * origin-scoped action is the same failure as a missing one, and collapsing both here means the
+ * dispatcher never has to wonder.
+ */
+export const decideRouting = (message: RawMessage): RoutingDecision => {
+  const type = typeof message.type === 'string' ? message.type : '';
+  const payload = (message.payload ?? {}) as Record<string, unknown>;
+  const rawOrigin = payload.origin;
+  const origin = typeof rawOrigin === 'string' ? rawOrigin : '';
+
+  if (ORIGIN_SCOPED_ACTIONS.has(type) && !origin) {
+    return { dispatch: false, error: 'Missing origin for origin-scoped action' };
+  }
+
+  return { dispatch: true, type, payload, origin };
+};

--- a/src-bex/services/page-reconciliation.ts
+++ b/src-bex/services/page-reconciliation.ts
@@ -1,0 +1,56 @@
+/**
+ * Deciding which origins have gone, when a page disappears.
+ *
+ * Extracted from `background.ts` (#173). The listener stays there; this is the part with a decision
+ * in it, and it was unreachable from any test.
+ *
+ * A request record names an origin and no tab, so two tabs on the same origin are indistinguishable
+ * here. The rule is therefore conservative by construction: an origin has only gone when *no* tab
+ * still holds it. Anything less would interrupt a request another live tab is still waiting on.
+ */
+
+import { LogLevel, logService } from 'src/services/log-service';
+import { listPageOrigins } from './page-origin-registry';
+import { interruptRequestsForOrigin, listPendingRequests } from './request-queue';
+
+/**
+ * Origins that have pending requests but are no longer held by any tab.
+ *
+ * Pure, so the rule can be read and tested without a browser: given what is pending and what is
+ * still open, which origins can no longer be signed for.
+ */
+export const findAbandonedOrigins = (
+  pendingOrigins: readonly string[],
+  heldOrigins: ReadonlySet<string>,
+): string[] => [...new Set(pendingOrigins)].filter((origin) => !heldOrigins.has(origin));
+
+/**
+ * Interrupt every request whose origin no longer has a tab.
+ *
+ * Called when the page origin registry reports a tab gone. Failure is logged rather than thrown:
+ * this runs from a browser event with no caller to return to, and a request left pending is still
+ * bounded by its own expiry (D8).
+ */
+export const reconcileAbandonedRequests = async (): Promise<string[]> => {
+  try {
+    const heldOrigins = new Set<string>();
+    for (const [, record] of listPageOrigins()) heldOrigins.add(record.origin);
+
+    const pending = (await listPendingRequests()) ?? [];
+    const abandoned = findAbandonedOrigins(
+      pending.map((request) => request.origin),
+      heldOrigins,
+    );
+
+    for (const origin of abandoned) {
+      await interruptRequestsForOrigin(origin);
+    }
+
+    return abandoned;
+  } catch (error: unknown) {
+    logService.log(LogLevel.ERROR, '[Pages] Failed to reconcile requests for a closed page', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  }
+};

--- a/tests/unit/dispatcher.test.ts
+++ b/tests/unit/dispatcher.test.ts
@@ -4,6 +4,8 @@ import { handleRelayBrowserList, handleRelayBrowserGetStatus } from 'app/src-bex
 import { handleVaultUnlock } from 'app/src-bex/handlers/vault-handler';
 import { handleBlossomUpload } from 'app/src-bex/handlers/blossom-handler';
 import { handleNip44Encrypt, handleNip44Decrypt } from 'app/src-bex/handlers/nip44';
+import { handleNip04Encrypt, handleNip04Decrypt } from 'app/src-bex/handlers/nip04';
+import { handleGetPublicKey, handleSignEvent } from 'app/src-bex/handlers/nip07';
 import type { RelayCatalogEntry, RelayDiscoveryState } from 'src/types/relay';
 import { createBridgeRequest } from 'src/types/bridge';
 import type { VaultData } from 'src/types/bridge';
@@ -228,5 +230,70 @@ describe('Dispatcher', () => {
       expect.objectContaining({ pubkey: 'sender-pubkey', ciphertext: 'nip44-ciphertext' }),
       'https://app.example',
     );
+  });
+
+  /**
+   * Every action that acts on a site's behalf must reach its handler with the origin intact (#173).
+   *
+   * `message-routing` refuses to dispatch these without an origin; this is the other half — that the
+   * dispatcher then passes the one it was given through rather than dropping it. A handler that
+   * received an empty origin would check permissions for nowhere and sign for anyone.
+   */
+  describe('origin pass-through', () => {
+    const ORIGIN = 'https://example.com';
+
+    const cases = [
+      { action: 'nostr.getPublicKey', handler: () => handleGetPublicKey },
+      { action: 'nostr.signEvent', handler: () => handleSignEvent },
+      { action: 'nostr.nip04.encrypt', handler: () => handleNip04Encrypt },
+      { action: 'nostr.nip04.decrypt', handler: () => handleNip04Decrypt },
+      { action: 'nostr.nip44.encrypt', handler: () => handleNip44Encrypt },
+      { action: 'nostr.nip44.decrypt', handler: () => handleNip44Decrypt },
+    ] as const;
+
+    for (const { action, handler } of cases) {
+      it(`passes the origin to ${action}`, async () => {
+        vi.mocked(handler()).mockResolvedValue({ success: true, data: 'ok' } as never);
+
+        await dispatchMessage(
+          action as 'nostr.getPublicKey',
+          createBridgeRequest(action as 'nostr.getPublicKey', {
+            pubkey: 'p',
+            plaintext: 't',
+            ciphertext: 'c',
+            event: { kind: 1, content: '', tags: [], created_at: 0 },
+          } as never),
+          ORIGIN,
+        );
+
+        expect(handler()).toHaveBeenCalledWith(expect.anything(), ORIGIN);
+      });
+    }
+
+    it('rejects with the handler error rather than swallowing it', async () => {
+      vi.mocked(handleNip04Encrypt).mockResolvedValue({
+        success: false,
+        error: 'Vault is locked',
+      } as never);
+
+      await expect(
+        dispatchMessage(
+          'nostr.nip04.encrypt',
+          createBridgeRequest('nostr.nip04.encrypt', {
+            pubkey: 'p',
+            plaintext: 't',
+          } as never),
+          ORIGIN,
+        ),
+      ).rejects.toThrow('Vault is locked');
+    });
+
+    it('returns null for an action it does not serve', async () => {
+      // An unknown action falls through the switch. That is where "we do not serve that" belongs,
+      // and it must not throw — the caller gets no response rather than an error page.
+      await expect(
+        dispatchMessage('not.an.action' as 'ping', {} as never, ORIGIN),
+      ).resolves.toBeNull();
+    });
   });
 });

--- a/tests/unit/services/message-routing.test.ts
+++ b/tests/unit/services/message-routing.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  ORIGIN_SCOPED_ACTIONS,
+  decideRouting,
+} from 'app/src-bex/services/message-routing';
+
+/**
+ * An action scoped to an origin must never be dispatched without one.
+ *
+ * `checkPermission` and every signing handler key on the origin, so an empty one would be a request
+ * from nowhere answered as though it came from somewhere (#173).
+ */
+describe('routing a raw runtime message', () => {
+  describe('origin-scoped actions', () => {
+    it('refuses one with no origin', () => {
+      const decision = decideRouting({ type: 'nostr.signEvent', payload: {} });
+
+      expect(decision).toEqual({
+        dispatch: false,
+        error: 'Missing origin for origin-scoped action',
+      });
+    });
+
+    it('refuses one with no payload at all', () => {
+      expect(decideRouting({ type: 'nostr.signEvent' }).dispatch).toBe(false);
+    });
+
+    it('refuses one whose origin is not a string', () => {
+      // A non-string origin is the same failure as a missing one, and collapsing both here means
+      // the dispatcher never has to wonder.
+      expect(decideRouting({ type: 'nostr.signEvent', payload: { origin: 42 } }).dispatch).toBe(
+        false,
+      );
+      expect(decideRouting({ type: 'nostr.signEvent', payload: { origin: null } }).dispatch).toBe(
+        false,
+      );
+    });
+
+    it('refuses one whose origin is empty', () => {
+      expect(decideRouting({ type: 'nostr.signEvent', payload: { origin: '' } }).dispatch).toBe(
+        false,
+      );
+    });
+
+    it('dispatches one that carries an origin', () => {
+      const decision = decideRouting({
+        type: 'nostr.signEvent',
+        payload: { origin: 'https://example.com', event: { kind: 1 } },
+      });
+
+      expect(decision).toEqual({
+        dispatch: true,
+        type: 'nostr.signEvent',
+        payload: { origin: 'https://example.com', event: { kind: 1 } },
+        origin: 'https://example.com',
+      });
+    });
+
+    it('covers every action that acts on a site’s behalf', () => {
+      // Signing, encryption, decryption, payment and identity disclosure. If one is added to the
+      // provider and not to this set, it would dispatch with an empty origin.
+      for (const action of [
+        'nostr.getPublicKey',
+        'nostr.signEvent',
+        'nostr.nip04.encrypt',
+        'nostr.nip04.decrypt',
+        'nostr.nip44.encrypt',
+        'nostr.nip44.decrypt',
+        'nip57.sendZap',
+        'webln.sendPayment',
+      ]) {
+        expect(ORIGIN_SCOPED_ACTIONS.has(action)).toBe(true);
+      }
+    });
+  });
+
+  describe('everything else', () => {
+    it('dispatches an extension-surface action with no origin', () => {
+      // Panel and vault actions come from Porwr's own surfaces, which have no site origin to give.
+      const decision = decideRouting({ type: 'vault.lock', payload: {} });
+
+      expect(decision.dispatch).toBe(true);
+      if (decision.dispatch) expect(decision.origin).toBe('');
+    });
+
+    it('normalises a missing payload to an empty object', () => {
+      const decision = decideRouting({ type: 'vault.lock' });
+
+      expect(decision.dispatch).toBe(true);
+      if (decision.dispatch) expect(decision.payload).toEqual({});
+    });
+
+    it('normalises a missing type to an empty string rather than throwing', () => {
+      // An unknown action reaches the dispatcher and falls through its switch, which is where
+      // "we do not serve that" belongs.
+      const decision = decideRouting({});
+
+      expect(decision.dispatch).toBe(true);
+      if (decision.dispatch) expect(decision.type).toBe('');
+    });
+  });
+});

--- a/tests/unit/services/page-reconciliation.test.ts
+++ b/tests/unit/services/page-reconciliation.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  listPageOrigins: vi.fn(),
+  listPendingRequests: vi.fn(),
+  interruptRequestsForOrigin: vi.fn(),
+  log: vi.fn(),
+}));
+
+vi.mock('app/src-bex/services/page-origin-registry', () => ({
+  listPageOrigins: mocks.listPageOrigins,
+}));
+vi.mock('app/src-bex/services/request-queue', () => ({
+  listPendingRequests: mocks.listPendingRequests,
+  interruptRequestsForOrigin: mocks.interruptRequestsForOrigin,
+}));
+vi.mock('src/services/log-service', () => ({
+  LogLevel: { ERROR: 'error' },
+  logService: { log: mocks.log },
+}));
+
+import {
+  findAbandonedOrigins,
+  reconcileAbandonedRequests,
+} from 'app/src-bex/services/page-reconciliation';
+
+const held = (...origins: string[]): Map<number, { origin: string; windowId: number }> =>
+  new Map(origins.map((origin, index) => [index, { origin, windowId: 1 }]));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.listPageOrigins.mockReturnValue(held());
+  mocks.listPendingRequests.mockResolvedValue([]);
+  mocks.interruptRequestsForOrigin.mockResolvedValue([]);
+});
+
+describe('which origins have gone', () => {
+  it('names one with a pending request and no tab', () => {
+    expect(findAbandonedOrigins(['https://gone.example'], new Set())).toEqual([
+      'https://gone.example',
+    ]);
+  });
+
+  it('spares one that any tab still holds', () => {
+    // A request record names an origin and no tab, so two tabs on the same origin are
+    // indistinguishable. Interrupting while one is still open would strand a live page.
+    expect(
+      findAbandonedOrigins(['https://example.com'], new Set(['https://example.com'])),
+    ).toEqual([]);
+  });
+
+  it('reports each origin once however many requests it has', () => {
+    expect(
+      findAbandonedOrigins(['https://a.example', 'https://a.example'], new Set()),
+    ).toEqual(['https://a.example']);
+  });
+
+  it('says nothing when nothing is pending', () => {
+    expect(findAbandonedOrigins([], new Set(['https://example.com']))).toEqual([]);
+  });
+});
+
+describe('reconciling after a page goes', () => {
+  it('interrupts requests for an origin no tab holds any more', async () => {
+    mocks.listPageOrigins.mockReturnValue(held('https://still-open.example'));
+    mocks.listPendingRequests.mockResolvedValue([
+      { origin: 'https://gone.example' },
+      { origin: 'https://still-open.example' },
+    ]);
+
+    const abandoned = await reconcileAbandonedRequests();
+
+    expect(abandoned).toEqual(['https://gone.example']);
+    expect(mocks.interruptRequestsForOrigin).toHaveBeenCalledExactlyOnceWith(
+      'https://gone.example',
+    );
+  });
+
+  it('interrupts nothing when every pending origin is still open', async () => {
+    mocks.listPageOrigins.mockReturnValue(held('https://example.com'));
+    mocks.listPendingRequests.mockResolvedValue([{ origin: 'https://example.com' }]);
+
+    await reconcileAbandonedRequests();
+
+    expect(mocks.interruptRequestsForOrigin).not.toHaveBeenCalled();
+  });
+
+  it('survives the queue being unreadable', async () => {
+    // Runs from a browser event with no caller to return to, and a request left pending is still
+    // bounded by its own expiry (D8).
+    mocks.listPendingRequests.mockRejectedValue(new Error('storage gone'));
+
+    await expect(reconcileAbandonedRequests()).resolves.toEqual([]);
+    expect(mocks.log).toHaveBeenCalled();
+  });
+
+  it('treats a missing queue as nothing pending', async () => {
+    mocks.listPendingRequests.mockResolvedValue(null);
+
+    await expect(reconcileAbandonedRequests()).resolves.toEqual([]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -51,14 +51,16 @@ export default defineConfig({
        * the one that fails open, and closing that gap is test-writing work rather than a threshold
        * decision — see the follow-up on #143.
        *
-       * Measured on 2026-08-21 at 787 tests: statements 58.84, branches 50.94, functions 50.73,
-       * lines 59.12.
+       * Raised 2026-08-21 after #173 extracted the approval flow, the routing decision and the
+       * page reconciliation out of `background.ts`, where nothing could reach them.
+       *
+       * Measured at 846 tests: statements 59.77, branches 52.05, functions 51.39, lines 60.02.
        */
       thresholds: {
-        statements: 58,
-        branches: 50,
-        functions: 50,
-        lines: 59,
+        statements: 59,
+        branches: 52,
+        functions: 51,
+        lines: 60,
 
         /**
          * The layers that decide authority are already past the 75% target, so they are held there
@@ -69,7 +71,7 @@ export default defineConfig({
         'src/composables/**': { statements: 85, branches: 70, functions: 80, lines: 85 },
         'src/utils/**': { statements: 95, branches: 80, functions: 95, lines: 95 },
         'src-bex/handlers/**': { statements: 80, branches: 58, functions: 88, lines: 82 },
-        'src-bex/services/**': { statements: 82, branches: 68, functions: 78, lines: 84 },
+        'src-bex/services/**': { statements: 86, branches: 73, functions: 81, lines: 87 },
       },
     },
   },


### PR DESCRIPTION
Refs #173, and finishes it. **Stacked on #175** — targets that branch and will retarget to `master`
when it merges.

## What moved

The rest of what `background.ts` *decided*, out of a file nothing can import.

**The routing decision.** The raw message listener refuses an origin-scoped action carrying no
origin. That branch is why `checkPermission` and every signing handler can trust the origin they are
given, and nothing exercised it. `decideRouting` makes the decision; the listener stays wiring.

It also **tightens one case**: a non-string origin previously passed the emptiness check and was then
coerced to `''` on the way to the dispatcher — a request from nowhere, answered as though it came
from somewhere. It is now the same refusal as a missing origin.

**The page reconciliation.** The only real logic among the callbacks: which origins still have a tab,
and which pending requests can therefore never be answered. `findAbandonedOrigins` states it as a
pure function, so the conservative rule — an origin has gone only when *no* tab holds it — can be
read and tested without a browser.

Both are at 100% statements.

## dispatcher.ts: 17.85% → 26.19%

A table over the actions that act on a site's behalf, asserting each reaches its handler **with the
origin intact**. That is the other half of the routing decision: refusing to dispatch without an
origin is worth little if the dispatcher then drops the one it was given.

Also covered: a handler error propagating rather than being swallowed, and an unknown action
returning `null` rather than throwing.

## Where #173 ends up

| | Start | Now |
|---|---|---|
| `background.ts` | 870 lines | **733** |
| `dispatcher.ts` | 17.85% | **26.19%** |
| Global statements | 59.14% | **59.77%** |
| Global lines | 59.38% | **60.02%** |
| Tests | 802 | **851** |

Ratchet turned per #143: global floors to 59/52/51/60, `src-bex/services` to 86/73/81/87.

## The thing the plan predicted, confirmed

`background.ts` still reports `Failed to parse` and is still not measured. Extraction removed the
reason to import it, so its own percentage was never the target — and it matters less now, because
what it decided lives in modules that *are* measured. What remains is `bridge.on` registrations and
startup ordering: wiring, which the end-to-end suite exercises against a real extension rather than a
mock. `DEVELOPING.md` says so rather than leaving the earlier warning standing.

## Verification

`lint`, `typecheck`, `test:run` (851), the coverage gate at the **new** floors, and the Chromium e2e
suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)