### PR TITLE
feat(sidebar): add the account switcher and fix the approved-clients count

### DIFF
--- a/src-bex/background.ts
+++ b/src-bex/background.ts
@@ -43,7 +43,11 @@ import type { ApprovalRequestDetails } from './services/approval-flow';
 import { originHostname } from './services/origin';
 import { decideRouting, type RawMessage } from './services/message-routing';
 import { reconcileAbandonedRequests } from './services/page-reconciliation';
-import { disconnectSite, listConnectedSites } from './services/connected-sites';
+import {
+  countSitesHoldingGrantsFor,
+  disconnectSite,
+  listConnectedSites,
+} from './services/connected-sites';
 import {
   getPageOrigin,
   observePageConnections,
@@ -154,6 +158,10 @@ declare module '@quasar/app-vite' {
     'pages.originForTab': [{ tabId: number }, BridgeResponsePayload<'pages.originForTab'>];
     'sites.list': [undefined, BridgeResponsePayload<'sites.list'>];
     'sites.revoke': [{ origin: string }, BridgeResponsePayload<'sites.revoke'>];
+    'sites.countForAccount': [
+      { accountPubkey: string },
+      BridgeResponsePayload<'sites.countForAccount'>,
+    ];
     'nostr.requests.present': [{ requestId: string }, BridgeResponsePayload<'nostr.requests.present'>];
     'nostr.requests.respond': [
       { requestId: string; approved: boolean; duration: ApprovalDuration },
@@ -287,6 +295,12 @@ bridge.on('sites.list', () => {
 
 bridge.on('sites.revoke', ({ payload }) => {
   return disconnectSite(payload.origin) as unknown as BridgeResponsePayload<'sites.revoke'>;
+});
+
+bridge.on('sites.countForAccount', ({ payload }) => {
+  return countSitesHoldingGrantsFor(
+    payload.accountPubkey,
+  ) as unknown as BridgeResponsePayload<'sites.countForAccount'>;
 });
 
 bridge.on('nostr.requests.present', ({ payload }) => {

--- a/src-bex/services/connected-sites.ts
+++ b/src-bex/services/connected-sites.ts
@@ -15,6 +15,13 @@ import { normalizeOrigin } from './origin';
 import type { PermissionEventKind } from '../types/background';
 
 export interface ConnectedSiteGrant {
+  /**
+   * The account this grant belongs to.
+   *
+   * A site can hold grants for more than one identity — each was given while that account was the
+   * one acting — so a grant list that did not say which would be ambiguous exactly where it matters.
+   */
+  accountPubkey: string;
   requestType: string;
   eventKind: PermissionEventKind;
   /** Absent for a grant that does not expire. */
@@ -60,6 +67,7 @@ export const listConnectedSites = async (): Promise<ConnectedSite[]> => {
     if (!grant.granted) continue;
 
     siteFor(grant.origin).grants.push({
+      accountPubkey: grant.accountPubkey,
       requestType: grant.requestType,
       eventKind: grant.eventKind,
       grantedAt: grant.timestamp,
@@ -78,6 +86,22 @@ export const listConnectedSites = async (): Promise<ConnectedSite[]> => {
  * means to anyone reading it. Removing the binding lets the next request bind afresh, and the user
  * is asked again for everything.
  */
+/**
+ * How many sites hold at least one standing permission for an account.
+ *
+ * The dashboard's "Approved Clients" figure used to count distinct hostnames in the approvals log,
+ * which answers a different question: it counted sites that *asked*, including ones the user
+ * rejected, and kept counting them after a grant was revoked (#116).
+ */
+export const countSitesHoldingGrantsFor = async (accountPubkey: string): Promise<number> => {
+  if (!accountPubkey) return 0;
+
+  const sites = await listConnectedSites();
+  return sites.filter((site) =>
+    site.grants.some((grant) => grant.accountPubkey === accountPubkey),
+  ).length;
+};
+
 export const disconnectSite = async (origin: string): Promise<boolean> => {
   const normalized = normalizeOrigin(origin);
   if (!normalized) return false;

--- a/src/components/sidebar/AccountSwitcher.vue
+++ b/src/components/sidebar/AccountSwitcher.vue
@@ -1,0 +1,132 @@
+<script lang="ts" setup>
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import useAccountStore from 'src/stores/account-store';
+import type { StoredKey } from 'src/types';
+
+defineOptions({ name: 'AccountSwitcher' });
+
+/**
+ * Chooses the identity a site binds to on first contact.
+ *
+ * It cannot change what an already-connected site signs as: a site keeps the account it was bound
+ * to, and a pending request keeps the account captured when it was created (#116, S10, FR-13). The
+ * control says so rather than leaving the user to infer a scope they cannot see — a switcher that
+ * looked like it re-pointed existing sessions would be misleading about which key signs what.
+ */
+const { t } = useI18n();
+const accountStore = useAccountStore();
+
+const accounts = computed<StoredKey[]>(() => Array.from(accountStore.storedKeys));
+
+const activeAlias = computed(() => accountStore.activeKey);
+
+const hasChoice = computed(() => accounts.value.length > 1);
+
+const emit = defineEmits<{ (event: 'switched', alias: string): void }>();
+
+async function choose(alias: string): Promise<void> {
+  if (alias === activeAlias.value) return;
+
+  await accountStore.setActiveKey(alias);
+  emit('switched', alias);
+}
+
+function openKeys(): void {
+  const url = chrome.runtime.getURL('www/index.html#/keys');
+  void chrome.tabs.create({ url });
+}
+</script>
+
+<template>
+  <q-btn
+    flat
+    dense
+    no-caps
+    class="account-switcher"
+    :aria-label="t('sidebar.accountSwitcher.ariaLabel')"
+    :title="t('sidebar.accountSwitcher.ariaLabel')"
+  >
+    <span class="account-switcher__alias">
+      {{ activeAlias ?? t('sidebar.accountSwitcher.none') }}
+    </span>
+    <q-icon name="expand_more" size="xs" />
+
+    <q-menu class="account-switcher__menu">
+      <div class="account-switcher__heading">
+        {{ t('sidebar.accountSwitcher.current') }}
+      </div>
+
+      <q-list dense>
+        <q-item
+          v-for="account in accounts"
+          :key="account.id"
+          v-close-popup
+          clickable
+          :active="account.alias === activeAlias"
+          @click="choose(account.alias)"
+        >
+          <q-item-section>{{ account.alias }}</q-item-section>
+          <q-item-section v-if="account.alias === activeAlias" side>
+            <q-icon name="check" size="xs" />
+          </q-item-section>
+        </q-item>
+
+        <q-item v-if="accounts.length === 0" dense>
+          <q-item-section class="text-grey-6">
+            {{ t('sidebar.accountSwitcher.none') }}
+          </q-item-section>
+        </q-item>
+      </q-list>
+
+      <!--
+        Stated whenever there is a choice to make. Without it the control reads as "sign as this
+        account", which is not what it does.
+      -->
+      <p v-if="hasChoice" class="account-switcher__scope">
+        {{ t('sidebar.accountSwitcher.scope') }}
+      </p>
+
+      <q-separator />
+
+      <q-list dense>
+        <q-item v-close-popup clickable @click="openKeys">
+          <q-item-section>{{ t('sidebar.accountSwitcher.manage') }}</q-item-section>
+        </q-item>
+      </q-list>
+    </q-menu>
+  </q-btn>
+</template>
+
+<style scoped>
+.account-switcher {
+  max-width: 40%;
+  min-width: 0;
+}
+
+/* An alias can be anything the user typed; it must not push the lock action off the header. */
+.account-switcher__alias {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.account-switcher__heading {
+  padding: 8px 12px 4px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted, #888);
+}
+
+.account-switcher__scope {
+  margin: 4px 0 8px;
+  padding: 0 12px;
+  max-width: 260px;
+  font-size: 0.75rem;
+  color: var(--text-muted, #888);
+}
+</style>

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -603,6 +603,16 @@ export default {
       body: 'Create your encrypted vault to start signing Nostr events from this panel.',
       action: 'Create vault',
     },
+    accountSwitcher: {
+      ariaLabel: 'Signing identity for new sites',
+      current: 'New sites will use',
+      // The scope has to be stated. Switching cannot re-target a site that is already bound, and a
+      // control that implied otherwise would mislead about which key signs what (#116, S10).
+      scope: 'Sites already connected keep the identity they were given.',
+      none: 'No account configured',
+      manage: 'Manage keys',
+      switched: 'New sites will use {alias}',
+    },
     header: {
       ariaLabel: 'Porwr panel',
       pending: {

--- a/src/layouts/SidebarLayout.vue
+++ b/src/layouts/SidebarLayout.vue
@@ -1,9 +1,10 @@
 <script lang="ts" setup>
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import DiogelLogo from 'components/DiogelLogo/Index.vue';
 import SidebarFooterLinks from 'components/sidebar/SidebarFooterLinks.vue';
+import AccountSwitcher from 'components/sidebar/AccountSwitcher.vue';
 import { useApprovalQueue } from 'src/composables/useApprovalQueue';
 import { useVault } from 'src/composables/useVault';
 import useVaultStore from 'src/stores/vault-store';
@@ -20,6 +21,16 @@ const hasPending = computed(() => pendingCount.value > 0);
 /**
  * The badge carries the number visually; this is what a screen reader announces instead (NFR-4).
  */
+const switchedAlias = ref<string | null>(null);
+
+/**
+ * Announced rather than shown as a toast: the panel is 360px and the change is deliberately
+ * undramatic, but a screen-reader user needs to know the choice took effect.
+ */
+function onAccountSwitched(alias: string): void {
+  switchedAlias.value = alias;
+}
+
 const pendingLabel = computed(() =>
   t('sidebar.header.pending.ariaLabel', { count: pendingCount.value }, pendingCount.value),
 );
@@ -35,10 +46,10 @@ const pendingLabel = computed(() =>
 
       <div class="sidebar-header__actions">
         <!--
-          The account switcher named in specification §3 belongs here. It is deferred to #116,
-          which owns site-to-account binding and therefore decides what switching means for an
-          origin that is already bound to an account.
+          Specification §3's account switcher. It chooses the identity a *new* site binds to; it
+          cannot re-target one already connected, and says so (#116).
         -->
+        <AccountSwitcher v-if="vaultStore.isUnlocked" @switched="onAccountSwitched" />
 
         <q-badge
           v-if="hasPending"
@@ -55,6 +66,9 @@ const pendingLabel = computed(() =>
         -->
         <span class="sidebar-header__sr-only" role="status" aria-live="polite">
           {{ pendingLabel }}
+          <template v-if="switchedAlias">
+            {{ t('sidebar.accountSwitcher.switched', { alias: switchedAlias }) }}
+          </template>
         </span>
 
         <q-btn

--- a/src/services/connected-sites-service.ts
+++ b/src/services/connected-sites-service.ts
@@ -15,3 +15,7 @@ export const listConnectedSites = async (): Promise<ConnectedSite[]> =>
 
 export const disconnectSite = async (origin: string): Promise<boolean> =>
   (await sendBexMessage('sites.revoke', { origin })) ?? false;
+
+/** How many sites hold a standing permission for an account. */
+export const countSitesHoldingGrantsFor = async (accountPubkey: string): Promise<number> =>
+  (await sendBexMessage('sites.countForAccount', { accountPubkey })) ?? 0;

--- a/src/services/dashboard-service.ts
+++ b/src/services/dashboard-service.ts
@@ -8,7 +8,7 @@ import useSettingsStore from 'src/stores/settings-store';
 import type { Event } from 'nostr-tools';
 import { isVaultUnlocked } from './vault-service';
 import { useEventService } from 'src/composables/useEventService';
-import { db } from './database';
+import { countSitesHoldingGrantsFor } from './connected-sites-service';
 import type { DashboardActivityType, DashboardSummary } from 'src/types';
 
 export type DashboardActivityStatus = 'approved' | 'exception' | 'rejected' | 'signed';
@@ -73,10 +73,15 @@ export async function getActiveKeyCount(): Promise<number> {
 }
 
 /**
- * Returns the number of distinct hostnames that have approval log entries
- * for the active Diogel account on this local install.
+ * Returns the number of sites that currently hold a standing permission for the active account.
  *
- * This metric is deterministic, stable, and does not query Nostr relays.
+ * This counted distinct hostnames in the approvals log, which answers a different question in two
+ * ways that both overstate it (#116): the log records rejections as well as approvals and the query
+ * never filtered on outcome, so a site the user *refused* was counted as an approved client — and a
+ * grant that had since expired or been revoked went on being counted for as long as its log entry
+ * survived.
+ *
+ * It now reads the grant store, so the figure answers what its label claims.
  */
 export async function getApprovedClientCountForActiveKey(): Promise<number> {
   const unlocked = await isVaultUnlocked();
@@ -84,20 +89,19 @@ export async function getApprovedClientCountForActiveKey(): Promise<number> {
     return 0;
   }
 
-  const activeAccount = await getActiveAccountAlias();
-  if (!activeAccount) {
+  const alias = await getActiveAccountAlias();
+  if (!alias) {
     return 0;
   }
 
-  const approvals = await db.approvals.where('account').equals(activeAccount).toArray();
+  // Grants are keyed by public key, never alias, because an alias is user-editable.
+  const keys = await get();
+  const activePubkey = keys[alias]?.id;
+  if (!activePubkey) {
+    return 0;
+  }
 
-  const hostnames = new Set(
-    approvals
-      .map((approval) => approval.hostname.trim().toLowerCase())
-      .filter((hostname) => hostname.length > 0),
-  );
-
-  return hostnames.size;
+  return countSitesHoldingGrantsFor(activePubkey);
 }
 
 export async function getConnectedRelayCountForActiveKey(): Promise<number> {

--- a/src/types/bridge-types.d.ts
+++ b/src/types/bridge-types.d.ts
@@ -119,6 +119,7 @@ export type BridgeAction =
   | 'pages.originForTab'
   | 'sites.list'
   | 'sites.revoke'
+  | 'sites.countForAccount'
   | 'relay.browser.list'
   | 'relay.browser.getStatus'
   | 'relay.browser.refresh'
@@ -305,6 +306,11 @@ export interface BridgeRequestMap {
     action: 'sites.revoke';
     origin: string;
   };
+  'sites.countForAccount': {
+    id: string;
+    action: 'sites.countForAccount';
+    accountPubkey: string;
+  };
   'nostr.requests.requeuePresented': {
     id: string;
     action: 'nostr.requests.requeuePresented';
@@ -416,6 +422,7 @@ export interface BridgeResponseMap {
   'pages.originForTab': string | null;
   'sites.list': ConnectedSite[];
   'sites.revoke': boolean;
+  'sites.countForAccount': number;
   'nostr.requests.present': ApprovalRequestRecord | null;
   'nostr.requests.respond': DecisionResult;
   'nostr.requests.content': ApprovalRequestContent | null;

--- a/tests/unit/components/AccountSwitcher.test.ts
+++ b/tests/unit/components/AccountSwitcher.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+const state = vi.hoisted(() => ({
+  activeKey: 'alice' as string | undefined,
+  storedKeys: [] as Array<{ id: string; alias: string }>,
+  setActiveKey: vi.fn(),
+}));
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, string>) =>
+      params ? `${key}:${Object.values(params).join(',')}` : key,
+  }),
+}));
+
+vi.mock('src/stores/account-store', () => ({
+  default: () => ({
+    get activeKey() {
+      return state.activeKey;
+    },
+    get storedKeys() {
+      return new Set(state.storedKeys);
+    },
+    setActiveKey: state.setActiveKey,
+  }),
+}));
+
+import AccountSwitcher from 'src/components/sidebar/AccountSwitcher.vue';
+
+const createTab = vi.fn();
+
+const mountSwitcher = () =>
+  mount(AccountSwitcher, {
+    global: {
+      stubs: {
+        'q-btn': { template: '<button><slot /></button>' },
+        'q-icon': true,
+        'q-menu': { template: '<div><slot /></div>' },
+        'q-list': { template: '<ul><slot /></ul>' },
+        'q-separator': true,
+        'q-item': {
+          template: '<li :class="{ active }" @click="$emit(\'click\')"><slot /></li>',
+          props: ['clickable', 'active'],
+        },
+        'q-item-section': { template: '<span><slot /></span>' },
+      },
+      directives: { 'close-popup': {} },
+    },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.activeKey = 'alice';
+  state.storedKeys = [
+    { id: 'a'.repeat(64), alias: 'alice' },
+    { id: 'b'.repeat(64), alias: 'bob' },
+  ];
+  vi.stubGlobal('chrome', {
+    runtime: { getURL: (path: string) => `chrome-extension://id/${path}` },
+    tabs: { create: createTab },
+  });
+});
+
+describe('choosing the identity new sites bind to', () => {
+  it('shows the current account', () => {
+    const wrapper = mountSwitcher();
+
+    expect(wrapper.text()).toContain('alice');
+  });
+
+  it('lists every account to choose from', () => {
+    const wrapper = mountSwitcher();
+
+    expect(wrapper.text()).toContain('alice');
+    expect(wrapper.text()).toContain('bob');
+  });
+
+  it('switches when another account is chosen', async () => {
+    const wrapper = mountSwitcher();
+
+    await wrapper.findAll('li')[1]?.trigger('click');
+    await flushPromises();
+
+    expect(state.setActiveKey).toHaveBeenCalledWith('bob');
+  });
+
+  it('does nothing when the current account is chosen again', async () => {
+    const wrapper = mountSwitcher();
+
+    await wrapper.findAll('li')[0]?.trigger('click');
+    await flushPromises();
+
+    expect(state.setActiveKey).not.toHaveBeenCalled();
+  });
+
+  it('announces the switch so it is not a silent change', async () => {
+    const wrapper = mountSwitcher();
+
+    await wrapper.findAll('li')[1]?.trigger('click');
+    await flushPromises();
+
+    expect(wrapper.emitted('switched')?.[0]).toEqual(['bob']);
+  });
+
+  /**
+   * The scope is the point. Switching cannot re-target a site that is already bound, and a control
+   * implying otherwise would mislead about which key signs what (#116, S10).
+   */
+  describe('what it says about its own scope', () => {
+    it('states that connected sites keep their identity', () => {
+      const wrapper = mountSwitcher();
+
+      expect(wrapper.text()).toContain('sidebar.accountSwitcher.scope');
+    });
+
+    it('omits the caveat when there is no choice to make', () => {
+      state.storedKeys = [{ id: 'a'.repeat(64), alias: 'alice' }];
+
+      const wrapper = mountSwitcher();
+
+      expect(wrapper.text()).not.toContain('sidebar.accountSwitcher.scope');
+    });
+  });
+
+  describe('with no account configured', () => {
+    it('says so rather than showing an empty control', () => {
+      state.activeKey = undefined;
+      state.storedKeys = [];
+
+      const wrapper = mountSwitcher();
+
+      expect(wrapper.text()).toContain('sidebar.accountSwitcher.none');
+    });
+  });
+
+  it('links out to key management in a full tab', async () => {
+    const wrapper = mountSwitcher();
+
+    await wrapper.findAll('li').at(-1)?.trigger('click');
+
+    // Management stays full-tab; the panel links out rather than hosting it.
+    expect(createTab).toHaveBeenCalledWith({
+      url: 'chrome-extension://id/www/index.html#/keys',
+    });
+  });
+});

--- a/tests/unit/layouts/SidebarLayout.test.ts
+++ b/tests/unit/layouts/SidebarLayout.test.ts
@@ -45,6 +45,7 @@ const mountLayout = async () => {
       stubs: {
         DiogelLogo: true,
         SidebarFooterLinks: true,
+        AccountSwitcher: { template: '<div class="account-switcher-stub" />' },
         'router-view': true,
         'q-layout': { template: '<div><slot /></div>' },
         'q-page-container': { template: '<div><slot /></div>' },

--- a/tests/unit/services/connected-sites.test.ts
+++ b/tests/unit/services/connected-sites.test.ts
@@ -16,7 +16,11 @@ vi.mock('app/src-bex/services/site-binding-store', () => ({
   removeBinding: mocks.removeBinding,
 }));
 
-import { disconnectSite, listConnectedSites } from 'app/src-bex/services/connected-sites';
+import {
+  countSitesHoldingGrantsFor,
+  disconnectSite,
+  listConnectedSites,
+} from 'app/src-bex/services/connected-sites';
 
 const ALICE = 'a'.repeat(64);
 const BOB = 'b'.repeat(64);
@@ -52,7 +56,9 @@ describe('what a site holds', () => {
       origin: 'https://example.com',
       boundPubkey: ALICE,
       boundAt: 500,
-      grants: [{ requestType: 'sign_event', eventKind: 1, grantedAt: 1000 }],
+      grants: [
+        { accountPubkey: ALICE, requestType: 'sign_event', eventKind: 1, grantedAt: 1000 },
+      ],
     });
   });
 
@@ -170,5 +176,45 @@ describe('disconnecting a site', () => {
     await expect(disconnectSite('https://example.com')).resolves.toBe(true);
 
     expect(mocks.removeBinding).toHaveBeenCalledWith('https://example.com');
+  });
+});
+
+/**
+ * The dashboard's "Approved Clients" figure.
+ *
+ * It counted distinct hostnames in the approvals log, which overstates it twice over: the log
+ * records rejections and the query never filtered on outcome, and an entry outlives the grant it
+ * describes (#116).
+ */
+describe('counting sites that hold a standing permission', () => {
+  it('counts a site once however many grants it holds', async () => {
+    mocks.getGrantedPermissions.mockResolvedValue([grant(), grant({ eventKind: 5 })]);
+
+    await expect(countSitesHoldingGrantsFor(ALICE)).resolves.toBe(1);
+  });
+
+  it('counts only grants belonging to that account', async () => {
+    mocks.getGrantedPermissions.mockResolvedValue([
+      grant(),
+      grant({ origin: 'https://other.example', accountPubkey: BOB }),
+    ]);
+
+    await expect(countSitesHoldingGrantsFor(ALICE)).resolves.toBe(1);
+    await expect(countSitesHoldingGrantsFor(BOB)).resolves.toBe(1);
+  });
+
+  it('does not count a site that is merely bound', async () => {
+    // A bound site with no standing permission asks every time, so it holds nothing.
+    mocks.listBindings.mockResolvedValue([
+      { origin: 'https://example.com', pubkey: ALICE, boundAt: 1 },
+    ]);
+
+    await expect(countSitesHoldingGrantsFor(ALICE)).resolves.toBe(0);
+  });
+
+  it('counts nothing without an account', async () => {
+    mocks.getGrantedPermissions.mockResolvedValue([grant()]);
+
+    await expect(countSitesHoldingGrantsFor('')).resolves.toBe(0);
   });
 });

--- a/tests/unit/services/dashboard-service.test.ts
+++ b/tests/unit/services/dashboard-service.test.ts
@@ -5,6 +5,14 @@ import type * as DexieStorage from 'src/services/dexie-storage';
 import type * as VaultService from 'src/services/vault-service';
 import { useEventService } from 'src/composables/useEventService';
 
+const { countSitesHoldingGrantsFor } = vi.hoisted(() => ({
+  countSitesHoldingGrantsFor: vi.fn(),
+}));
+
+vi.mock('src/services/connected-sites-service', () => ({ countSitesHoldingGrantsFor }));
+
+const ALICE = 'a'.repeat(64);
+
 vi.mock('src/services/dexie-storage', () => ({
   get: vi.fn(),
   getActive: vi.fn(),
@@ -152,47 +160,54 @@ describe('dashboard-service', () => {
     await expect(dashboardService.getApprovedClientCountForActiveKey()).resolves.toBe(0);
   });
 
-  it('counts unique approved hostnames for active account', async () => {
+  /**
+   * Repointed at the grant store (#116).
+   *
+   * This counted distinct hostnames in the approvals log, which overstates the figure in two ways:
+   * the log records rejections and the query never filtered on outcome, and an entry survives long
+   * after the grant it describes has expired or been revoked.
+   */
+  it('counts the sites that hold a standing permission for the active account', async () => {
     vi.mocked(dexieStorage.getActive).mockResolvedValue('alpha');
-    approvalsToArrayMock.mockResolvedValue([
-      { id: 1, dateTime: '2026-01-01', eventKind: 1, hostname: 'example.com', account: 'alpha' },
-      { id: 2, dateTime: '2026-01-02', eventKind: 1, hostname: 'example.com', account: 'alpha' },
-      { id: 3, dateTime: '2026-01-03', eventKind: 1, hostname: 'app.example.com', account: 'alpha' },
-    ]);
+    vi.mocked(dexieStorage.get).mockResolvedValue({
+      alpha: { id: ALICE, alias: 'alpha' },
+    } as never);
+    countSitesHoldingGrantsFor.mockResolvedValue(2);
 
     await expect(dashboardService.getApprovedClientCountForActiveKey()).resolves.toBe(2);
   });
 
-  it('normalizes hostname case and whitespace', async () => {
+  it('asks by public key, not alias', async () => {
     vi.mocked(dexieStorage.getActive).mockResolvedValue('alpha');
-    approvalsToArrayMock.mockResolvedValue([
-      { id: 1, dateTime: '2026-01-01', eventKind: 1, hostname: 'Example.com', account: 'alpha' },
-      { id: 2, dateTime: '2026-01-02', eventKind: 1, hostname: ' example.com ', account: 'alpha' },
-    ]);
+    vi.mocked(dexieStorage.get).mockResolvedValue({
+      alpha: { id: ALICE, alias: 'alpha' },
+    } as never);
+    countSitesHoldingGrantsFor.mockResolvedValue(1);
 
-    await expect(dashboardService.getApprovedClientCountForActiveKey()).resolves.toBe(1);
+    await dashboardService.getApprovedClientCountForActiveKey();
+
+    // An alias is user-editable; a rename must not change what the figure counts.
+    expect(countSitesHoldingGrantsFor).toHaveBeenCalledWith(ALICE);
   });
 
-  it('ignores blank hostnames', async () => {
+  it('no longer reads the approvals log for this figure', async () => {
     vi.mocked(dexieStorage.getActive).mockResolvedValue('alpha');
-    approvalsToArrayMock.mockResolvedValue([
-      { id: 1, dateTime: '2026-01-01', eventKind: 1, hostname: '', account: 'alpha' },
-      { id: 2, dateTime: '2026-01-02', eventKind: 1, hostname: '   ', account: 'alpha' },
-      { id: 3, dateTime: '2026-01-03', eventKind: 1, hostname: 'client.example', account: 'alpha' },
-    ]);
+    vi.mocked(dexieStorage.get).mockResolvedValue({
+      alpha: { id: ALICE, alias: 'alpha' },
+    } as never);
+    countSitesHoldingGrantsFor.mockResolvedValue(0);
 
-    await expect(dashboardService.getApprovedClientCountForActiveKey()).resolves.toBe(1);
+    await dashboardService.getApprovedClientCountForActiveKey();
+
+    expect(approvalsToArrayMock).not.toHaveBeenCalled();
   });
 
-  it('scopes approved clients by active account', async () => {
-    vi.mocked(dexieStorage.getActive).mockResolvedValue('alpha');
-    approvalsToArrayMock.mockResolvedValue([
-      { id: 1, dateTime: '2026-01-01', eventKind: 1, hostname: 'only-alpha.com', account: 'alpha' },
-    ]);
+  it('counts nothing when the active alias names no stored key', async () => {
+    vi.mocked(dexieStorage.getActive).mockResolvedValue('ghost');
+    vi.mocked(dexieStorage.get).mockResolvedValue({} as never);
 
-    await expect(dashboardService.getApprovedClientCountForActiveKey()).resolves.toBe(1);
-    expect(approvalsWhereMock).toHaveBeenCalledWith('account');
-    expect(approvalsEqualsMock).toHaveBeenCalledWith('alpha');
+    await expect(dashboardService.getApprovedClientCountForActiveKey()).resolves.toBe(0);
+    expect(countSitesHoldingGrantsFor).not.toHaveBeenCalled();
   });
 
   it('does not call relay event service for approved client metric', async () => {
@@ -225,9 +240,8 @@ describe('dashboard-service', () => {
       },
     });
 
-    approvalsToArrayMock.mockResolvedValue([
-      { id: 1, dateTime: '2026-01-01', eventKind: 1, hostname: 'client.example', account: 'alpha' },
-    ]);
+    // The figure now comes from the grant store, not the approvals log.
+    countSitesHoldingGrantsFor.mockResolvedValue(1);
     fetchAccountRelayListEventMock.mockResolvedValue(null);
     getEventsMock.mockResolvedValue([]);
 


### PR DESCRIPTION
Refs #116. The last two pieces, both about telling the user the truth about which identity is doing
what.

## The account switcher

Fills the header slot #147 left for it. It chooses the identity a **new** site binds to — and it says
so.

A site keeps the account it was bound to, and a pending request keeps the account captured when it
was created (S10, FR-13), so switching cannot re-target either. **A control that looked like it
re-pointed existing sessions would mislead about which key signs what** — the confusion this whole
issue exists to remove.

So the menu states its own scope: *"Sites already connected keep the identity they were given."*
Shown whenever there is a choice to make, omitted when there is one account and nothing to be
confused about.

The switch is announced through the header's existing live region rather than a toast — the panel is
360px, the change is deliberately undramatic, but a screen-reader user still needs to know it took
effect.

## "Approved Clients" was counting the wrong thing, twice

It counted distinct hostnames in the approvals log. Two problems, and the first is worse than #116
described:

| | |
|---|---|
| The log records **rejections** as well as approvals, and the query never filtered on outcome | a site the user **refused** counted as an approved client |
| A log entry outlives the grant it describes | a revoked or expired grant went on being counted |

It now reads the grant store and counts sites holding a live grant for the active account — **keyed by
public key, not alias**, because an alias is user-editable and a rename must not change what the
figure counts.

## A grant now names its account

A site can hold grants for more than one identity, each given while that account was acting. The
Connected Sites list did not say which, which is ambiguous exactly where it matters. It does now, and
the count above is built on it.

## Verification

`lint`, `typecheck`, `test:run` — **890 tests**, up from 877 — the coverage gate, and the Chromium
e2e suite all pass.

The ratchet caught an uncovered function on the way through (`src-bex/services` functions at 80.68%
against an 81% floor). Second time today it has caught something that would otherwise have slipped in
behind passing tests. Covered rather than lowered.

## #116 after this

Every outcome and acceptance criterion is now delivered. Worth a read-through before closing, and
worth noting for #117's release notes that the migration drops every stored grant, so the
"Approved Clients" figure will read zero on first launch after upgrade — correctly, and for the first
time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)