### PR TITLE
fix(sidebar): stop vault actions navigating the panel to the dashboard

### DIFF
--- a/src/composables/useVault.ts
+++ b/src/composables/useVault.ts
@@ -46,6 +46,18 @@ export function useVault() {
     return loginContext === 'extension' ? 'home' : 'dashboard';
   }
 
+  /**
+   * Whether this is running inside the sidebar panel.
+   *
+   * The panel owns a view for every vault state it can be in — setup, unlock, idle, a request — and
+   * renders them itself. Navigating away from `/sidebar` for any of them puts a full-tab management
+   * surface inside a 360px column, which the approved surface map forbids and which is what a user
+   * actually sees: unlocking in the panel used to land them on the dashboard (#116).
+   */
+  function isPanelRoute(): boolean {
+    return route.name === 'sidebar' || route.path === '/sidebar';
+  }
+
   function getCurrentLoginContext(): LoginContext {
     const routeName = route.name;
     if (typeof routeName === 'string' && dashboardRouteNames.has(routeName)) {
@@ -66,6 +78,8 @@ export function useVault() {
     loading.value = false;
     if (result.success) {
       $q.notify({ type: 'positive', message: 'Vault created successfully' });
+      if (isPanelRoute()) return;
+
       await router.push({ name: getPostLoginRouteName() });
     } else {
       loginError.value = formatErrorForUser(result.error, result.errorCode as ErrorCode);
@@ -82,6 +96,10 @@ export function useVault() {
     const result = await vaultStore.unlock(password.value);
     loading.value = false;
     if (result.success) {
+      // The panel re-renders itself from vault state: unlocking reveals the idle view, or the
+      // request that was waiting (S6). There is nowhere to navigate to.
+      if (isPanelRoute()) return;
+
       const redirect = route.query.redirect as string;
       if (redirect) {
         await router.push({ path: redirect, query: route.query });
@@ -100,12 +118,9 @@ export function useVault() {
   async function handleLock() {
     await vaultStore.lock();
 
-    // The panel renders its own unlock view for a locked vault, the same way it already reacts to a
-    // background auto-lock. Routing to the dashboard login page would pull a full-tab surface into
-    // the 360px panel, which the sidebar surface map forbids.
-    if (route.name === 'sidebar') {
-      return;
-    }
+    // Same rule as unlocking: the panel shows its own unlock view for a locked vault, exactly as it
+    // already does when the background auto-locks.
+    if (isPanelRoute()) return;
 
     void router.push({
       name: 'login',

--- a/tests/e2e/vault-and-panel.spec.ts
+++ b/tests/e2e/vault-and-panel.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from './fixtures/extension';
-import { createVault, lockVault } from './fixtures/vault';
+import { createVault, lockVault, VAULT_PASSWORD } from './fixtures/vault';
 
 /**
  * Answers the question that could not be asked before this harness existed: what does the panel
@@ -64,5 +64,43 @@ test.describe('the panel with no vault', () => {
     const page = await openPage('/sidebar');
 
     await expect(page.locator('.sidebar-setup')).toBeVisible();
+  });
+});
+
+/**
+ * The panel must never navigate itself to a dashboard surface (#116).
+ *
+ * Unlocking in the panel used to push to `dashboard`, so the full-tab dashboard rendered inside a
+ * 360px column. Asserted end to end because it is a router behaviour in a real extension page, and
+ * because it is the failure a user actually sees.
+ */
+test.describe('the panel keeps itself', () => {
+  test('stays on the panel after unlocking, and shows the panel again', async ({ openPage }) => {
+    const page = await openPage('/login');
+    await createVault(page);
+    await lockVault(page);
+
+    await page.goto(page.url().replace(/#.*$/, '#/sidebar'));
+    await page.locator('.sidebar-unlock').waitFor({ state: 'visible' });
+
+    await page.getByLabel('Password', { exact: true }).fill(VAULT_PASSWORD);
+    await page.getByRole('button', { name: 'Unlock', exact: true }).click();
+
+    // The panel re-renders from vault state rather than navigating anywhere.
+    await expect(page.locator('.sidebar-root')).toBeVisible();
+    await expect(page.locator('.sidebar-unlock')).toHaveCount(0);
+    expect(page.url()).toContain('#/sidebar');
+  });
+
+  test('never renders a dashboard surface inside the panel', async ({ openPage }) => {
+    const page = await openPage('/login');
+    await createVault(page);
+    await page.goto(page.url().replace(/#.*$/, '#/sidebar'));
+    await page.locator('.sidebar-root').waitFor({ state: 'visible' });
+
+    // The dashboard's own chrome. Any of it here means a full-tab surface reached the panel.
+    await expect(page.locator('.dashboard-page-shell')).toHaveCount(0);
+    await expect(page.locator('.dashboard-topbar')).toHaveCount(0);
+    await expect(page.locator('.main-navigation')).toHaveCount(0);
   });
 });

--- a/tests/unit/composables/useVault.test.ts
+++ b/tests/unit/composables/useVault.test.ts
@@ -200,4 +200,66 @@ describe('useVault', () => {
       expect(testState.pushMock).not.toHaveBeenCalled();
     });
   });
+
+  /**
+   * The panel owns a view for every vault state it can be in, so no vault action may navigate it.
+   *
+   * Unlocking used to push to `dashboard`, which put the full-tab dashboard inside a 360px panel —
+   * the failure users actually saw, and a break of S6, where unlocking with a request waiting should
+   * present that request (#116).
+   */
+  describe('inside the panel', () => {
+    beforeEach(() => {
+      testState.route.name = 'sidebar';
+    });
+
+    it('does not navigate after unlocking', async () => {
+      testState.vaultStore.unlock.mockResolvedValue({ success: true });
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+      vm.password = 'a-password';
+
+      await vm.handleUnlock();
+
+      expect(testState.vaultStore.unlock).toHaveBeenCalled();
+      expect(testState.pushMock).not.toHaveBeenCalled();
+    });
+
+    it('does not navigate after unlocking even when a redirect is queued', async () => {
+      // A redirect query belongs to the full-tab login flow and must not drag the panel with it.
+      testState.route.query = { redirect: '/settings' };
+      testState.vaultStore.unlock.mockResolvedValue({ success: true });
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+      vm.password = 'a-password';
+
+      await vm.handleUnlock();
+
+      expect(testState.pushMock).not.toHaveBeenCalled();
+    });
+
+    it('does not navigate after creating a vault', async () => {
+      testState.vaultStore.create.mockResolvedValue({ success: true });
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+      vm.password = 'a-password';
+      vm.confirmPassword = 'a-password';
+
+      await vm.handleCreate();
+
+      expect(testState.pushMock).not.toHaveBeenCalled();
+    });
+
+    it('still reports a failed unlock rather than swallowing it', async () => {
+      testState.vaultStore.unlock.mockResolvedValue({ success: false, error: 'Wrong password' });
+      const wrapper = mount(TestHarness);
+      const vm = wrapper.vm as unknown as HarnessVm;
+      vm.password = 'wrong';
+
+      await vm.handleUnlock();
+
+      expect(vm.loginError).toBeTruthy();
+      expect(testState.pushMock).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
Fixes the sidebar showing dashboard pages.

## What was happening

`handleUnlock` pushed to `getPostLoginRouteName()` on success. From `#/sidebar` there is no
`loginContext` query, so that resolves to **`dashboard`** — and the panel navigated itself to the
full-tab dashboard, rendered inside a 360px column.

It also broke **S6**: unlocking with a request waiting should present that request. Instead the
request was left behind on a route the panel had navigated away from.

`handleCreate` had the same fault. `handleLock` was fixed for the panel in #147 — and I did not check
the function directly beside it, which is why this survived.

## The fix

All three share one guard. The panel owns a view for every vault state it can be in — setup, unlock,
idle, a request — and renders them itself, so **no vault action navigates it anywhere**.

A queued `redirect` query is ignored in the panel too: that belongs to the full-tab login flow and
must not drag the panel along with it.

## Swept for others

Every `router.push` and `router.replace` in `src/`, checked for reachability from the panel:

| | |
|---|---|
| `VaultLogin.vue` | only reached at `/login`, which the panel never routes to |
| `useAccounts.ts` | not in the panel's component tree, and already exempts `/sidebar` from its management-path redirect |
| `App.vue` remaining watchers | fire only for `/` and `home` |
| dashboard pages and components | not in the panel's tree |

`useVault` was the only one.

## Verification

Two end-to-end tests, because this is router behaviour in a real extension page and a unit test alone
would not have caught it:

- unlocking in the panel stays on `#/sidebar` and shows the panel, not the dashboard
- **no dashboard chrome renders inside the panel at all** — `.dashboard-page-shell`,
  `.dashboard-topbar`, `.main-navigation`

**I built the extension from the unfixed source and confirmed the first test fails against it**, so
it is a regression test rather than an assertion that happens to pass.

Unit tests cover the same rule at the composable, mutation-checked: removing the guard fails exactly
the tests asserting it.

`lint`, `typecheck`, `test:run` (894), the coverage gate and the full Chromium e2e suite pass.

## Why the existing guard missed it

`tests/unit/sidebar-surface-boundary.test.ts` asserts no route *definition* mounts a dashboard layout
under `/sidebar`. That is still true and still worth having — but the panel and the dashboard share
one router, so a dashboard surface reaches the panel by **navigation at runtime**, which a
route-table assertion cannot see. The new end-to-end tests cover the gap the unit guard structurally
cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)