### PR TITLE
fix(sidebar): reduce the footer to Dashboard, Keys and Settings

### DIFF
--- a/src/components/sidebar/SidebarFooterLinks.vue
+++ b/src/components/sidebar/SidebarFooterLinks.vue
@@ -16,7 +16,6 @@ function openInTab(path: string): void {
 const links = [
   { id: 'dashboard', icon: 'dashboard', labelKey: 'sidebar.links.dashboard', path: '/dashboard' },
   { id: 'keys', icon: 'key', labelKey: 'sidebar.links.keys', path: '/keys' },
-  { id: 'event-history', icon: 'history', labelKey: 'sidebar.links.eventHistory', path: '/event-history' },
   { id: 'settings', icon: 'settings', labelKey: 'sidebar.links.settings', path: '/settings' },
 ] as const;
 </script>

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -595,7 +595,6 @@ export default {
       ariaLabel: 'Porwr management surfaces',
       dashboard: 'Dashboard',
       keys: 'Keys',
-      eventHistory: 'History',
       settings: 'Settings',
     },
     setup: {

--- a/tests/unit/components/SidebarFooterLinks.test.ts
+++ b/tests/unit/components/SidebarFooterLinks.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }));
+
+import SidebarFooterLinks from 'src/components/sidebar/SidebarFooterLinks.vue';
+
+const createTab = vi.fn();
+
+const mountFooter = () =>
+  mount(SidebarFooterLinks, {
+    global: {
+      stubs: {
+        'q-btn': { template: '<button>{{ label }}</button>', props: ['label', 'icon'] },
+      },
+    },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal('chrome', {
+    runtime: { getURL: (path: string) => `chrome-extension://id/${path}` },
+    tabs: { create: createTab },
+  });
+});
+
+/**
+ * The footer offers exactly three destinations (#182).
+ *
+ * It carried a fourth, Event History, which the panel does not need: the panel is where signing is
+ * decided, and reviewing what was signed belongs to the dashboard the first link reaches. The
+ * approved specification named a different three again, and was amended to match this.
+ */
+describe('the sidebar footer', () => {
+  it('offers exactly three links', () => {
+    const wrapper = mountFooter();
+
+    expect(wrapper.findAll('button')).toHaveLength(3);
+  });
+
+  it('offers Dashboard, Keys and Settings, and nothing else', () => {
+    const wrapper = mountFooter();
+
+    expect(wrapper.findAll('button').map((button) => button.text())).toEqual([
+      'sidebar.links.dashboard',
+      'sidebar.links.keys',
+      'sidebar.links.settings',
+    ]);
+  });
+
+  it('opens each in a full tab rather than routing the panel', async () => {
+    const wrapper = mountFooter();
+
+    for (const button of wrapper.findAll('button')) {
+      await button.trigger('click');
+    }
+
+    // Management stays full-tab; a panel that navigated to one would be a 360px dashboard.
+    expect(createTab).toHaveBeenCalledTimes(3);
+    for (const [{ url }] of createTab.mock.calls as Array<[{ url: string }]>) {
+      expect(url).toMatch(/^chrome-extension:\/\/id\/www\/index\.html#\//);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #182. Paired with diogel-io/workspace#8, which amends the specification to match.

## What changed

The footer carried four links. It now carries the three defined on the issue:

```
dashboard · keys · settings
```

Event History goes. The panel is where signing is decided; reviewing what was already signed belongs
to the dashboard the first link reaches. Its i18n string had no other consumer and goes with it.

## The specification disagreed too, in the other direction

§3 named **Event History, Settings and Key Management** — no Dashboard. So the build and the contract
each had something the other lacked, rather than one having drifted from the other.

diogel-io/workspace#8 amends §3 to the settled three, and records *why* three rather than just which
three, so the next request for a fourth link starts from the reason.

## Pinned by name, not by count

The test asserts the three destinations rather than that there are three of them — a fourth cannot
return unnoticed by replacing one. It also asserts each still opens a full tab, because a footer link
that routed the panel would put a dashboard surface inside 360px, which is the failure #181 just
fixed elsewhere.

## Verification

Checked in the real panel, not only in tests: three links rendered, no horizontal overflow at panel
width.

`lint`, `typecheck`, `test:run` (897), the coverage gate and the Chromium e2e suite pass.

## Also corrected

diogel-io/workspace#8 fixes a note I wrote during #145 claiming the footer and the specification
agreed. They never did — I had checked in one direction only, and the original observation it
replaced was pointing at this exact discrepancy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)