### PR TITLE
fix(bex): route the panel's own actions through the dispatcher

### DIFF
--- a/src-bex/dispatcher.ts
+++ b/src-bex/dispatcher.ts
@@ -20,6 +20,21 @@ import {
   stopAutoLockTimer,
 } from './services/auto-lock';
 import { handleGetPublicKey, handleSignEvent } from './handlers/nip07';
+import {
+  getCurrentRequest,
+  getPendingCount,
+  getRequestContent,
+  listPendingRequests,
+  markPresented,
+  requeuePresented,
+  submitDecision,
+} from './services/request-queue';
+import { getPageOrigin } from './services/page-origin-registry';
+import {
+  countSitesHoldingGrantsFor,
+  disconnectSite,
+  listConnectedSites,
+} from './services/connected-sites';
 import { handleBlossomUpload } from './handlers/blossom-handler';
 import { handleNip04Encrypt, handleNip04Decrypt } from './handlers/nip04';
 import { handleNip44Encrypt, handleNip44Decrypt } from './handlers/nip44';
@@ -151,6 +166,65 @@ export async function dispatchMessage<K extends BridgeAction>(
         } as BridgeResponsePayload<K>;
       }
       return { success: false, error: result.error, code: result.code } as unknown as BridgeResponsePayload<K>;
+    }
+
+    /**
+     * The panel's own actions.
+     *
+     * These were registered only on the Quasar bridge, which `sendBexMessage` looks for at
+     * `window.bridge` or `$q.bex` and does not find in an extension page — so every call fell back
+     * to this dispatcher, hit no case, and returned null. The panel silently showed no requests at
+     * all while the queue held them and the toolbar badge counted them (#177).
+     */
+    case 'nostr.requests.list':
+      return (await listPendingRequests()) as BridgeResponsePayload<K>;
+
+    case 'nostr.requests.current':
+      return (await getCurrentRequest()) as BridgeResponsePayload<K>;
+
+    case 'nostr.requests.count':
+      return (await getPendingCount()) as BridgeResponsePayload<K>;
+
+    case 'nostr.requests.content': {
+      const contentPayload = payload as BridgeRequestMap['nostr.requests.content'];
+      return getRequestContent(contentPayload.requestId) as BridgeResponsePayload<K>;
+    }
+
+    case 'nostr.requests.present': {
+      const presentPayload = payload as BridgeRequestMap['nostr.requests.present'];
+      return (await markPresented(presentPayload.requestId)) as BridgeResponsePayload<K>;
+    }
+
+    case 'nostr.requests.respond': {
+      const respondPayload = payload as BridgeRequestMap['nostr.requests.respond'];
+      return (await submitDecision(respondPayload.requestId, {
+        approved: respondPayload.approved,
+        duration: respondPayload.duration,
+      })) as BridgeResponsePayload<K>;
+    }
+
+    case 'nostr.requests.requeuePresented':
+      await requeuePresented();
+      return null;
+
+    case 'pages.originForTab': {
+      const tabPayload = payload as BridgeRequestMap['pages.originForTab'];
+      return (getPageOrigin(tabPayload.tabId) ?? null) as BridgeResponsePayload<K>;
+    }
+
+    case 'sites.list':
+      return (await listConnectedSites()) as BridgeResponsePayload<K>;
+
+    case 'sites.revoke': {
+      const revokePayload = payload as BridgeRequestMap['sites.revoke'];
+      return (await disconnectSite(revokePayload.origin)) as BridgeResponsePayload<K>;
+    }
+
+    case 'sites.countForAccount': {
+      const countPayload = payload as BridgeRequestMap['sites.countForAccount'];
+      return (await countSitesHoldingGrantsFor(
+        countPayload.accountPubkey,
+      )) as BridgeResponsePayload<K>;
     }
 
     case 'vault.getData': {

--- a/tests/e2e/badge-attention.spec.ts
+++ b/tests/e2e/badge-attention.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from './fixtures/extension';
+import {
+  TEST_ACCOUNT,
+  createVault,
+  requestSignatureFromPage,
+  seedAccount,
+} from './fixtures/vault';
+
+/**
+ * The closed-panel attention path (#177, #113's last acceptance criterion).
+ *
+ * While the panel is closed the toolbar badge and title are the *only* thing telling a user that
+ * something is waiting (D4). Unit tests cover the formatting; nothing covered the whole path —
+ * request arrives, queue writes, `chrome.action` is called — in a real browser.
+ */
+test.describe('the toolbar while a request waits', () => {
+  test('shows the pending count and says what is waiting', async ({
+    openPage,
+    background,
+    context,
+  }) => {
+    const extensionPage = await openPage('/login');
+    await createVault(extensionPage);
+    await seedAccount(extensionPage);
+
+    const site = await context.newPage();
+    await site.goto('https://example.com');
+    await requestSignatureFromPage(site);
+
+    // The badge is written after the queue write, so this polls rather than reading once — an
+    // immediate read would pass or fail on machine speed.
+    await expect
+      .poll(() => background.evaluate(() => chrome.action.getBadgeText({})), { timeout: 15_000 })
+      .toBe('1');
+
+    const title = await background.evaluate(() => chrome.action.getTitle({}));
+    expect(title).toMatch(/1 request waiting/);
+
+    await site.close();
+  });
+
+  test('clears once the request is decided', async ({ openPage, background, context }) => {
+    const extensionPage = await openPage('/login');
+    await createVault(extensionPage);
+    await seedAccount(extensionPage);
+
+    const site = await context.newPage();
+    await site.goto('https://example.com');
+    await requestSignatureFromPage(site);
+
+    await expect
+      .poll(() => background.evaluate(() => chrome.action.getBadgeText({})), { timeout: 15_000 })
+      .toBe('1');
+
+    // Decided through the panel, so the assertion covers the path a user actually takes.
+    await extensionPage.goto(extensionPage.url().replace(/#.*$/, '#/sidebar'));
+    await extensionPage.locator('.current-request').waitFor({ state: 'visible', timeout: 15_000 });
+    await extensionPage.getByRole('button', { name: /reject/i }).first().click();
+
+    await expect
+      .poll(() => background.evaluate(() => chrome.action.getBadgeText({})), { timeout: 15_000 })
+      .toBe('');
+
+    await site.close();
+  });
+
+  test('presents the request in the panel, signed for the seeded identity', async ({
+    openPage,
+    context,
+  }) => {
+    const extensionPage = await openPage('/login');
+    await createVault(extensionPage);
+    await seedAccount(extensionPage);
+
+    const site = await context.newPage();
+    await site.goto('https://example.com');
+    await requestSignatureFromPage(site);
+
+    await extensionPage.goto(extensionPage.url().replace(/#.*$/, '#/sidebar'));
+    await extensionPage.locator('.current-request').waitFor({ state: 'visible', timeout: 15_000 });
+
+    // The origin is the site's own, not the tab the user happens to be looking at (D2, S8), and the
+    // identity it will be signed by is named beside it. Both render in `.request-origin__value`.
+    const origin = extensionPage.locator('.request-origin__value').first();
+    await expect(origin).toHaveText('https://example.com');
+    await expect(extensionPage.locator('.request-origin')).toContainText(TEST_ACCOUNT.alias);
+
+    await site.close();
+  });
+});

--- a/tests/e2e/fixtures/vault.ts
+++ b/tests/e2e/fixtures/vault.ts
@@ -66,3 +66,71 @@ export async function unlockVault(page: Page, password = VAULT_PASSWORD): Promis
 export async function lockVault(page: Page): Promise<void> {
   await page.evaluate(() => chrome.runtime.sendMessage({ type: 'vault.lock' }));
 }
+
+/**
+ * A fixed test identity.
+ *
+ * Deliberately not generated: a failure that only reproduces with the key that produced it is not
+ * a failure anyone can act on.
+ */
+export const TEST_ACCOUNT = {
+  alias: 'e2e',
+  privkey: '1'.repeat(64),
+  // The public key for that private key, computed once with nostr-tools and pinned here so the
+  // fixture needs no crypto. A wrong value here would seed an account whose id does not match what
+  // it signs with, which is exactly the kind of mismatch these tests exist to catch.
+  pubkey: '4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa',
+};
+
+/**
+ * Puts one account into an unlocked vault, without driving the key-generation UI.
+ *
+ * `vault.updateData` is routed through the dispatcher, so an extension page can send it directly.
+ * The active account lives in `chrome.storage.local` under `nostr:active`, which is what
+ * `resolveSigningAccount` reads when a site has no binding yet.
+ */
+export async function seedAccount(page: Page): Promise<void> {
+  const seeded = await page.evaluate(async (account) => {
+    const result = (await chrome.runtime.sendMessage({
+      type: 'vault.updateData',
+      payload: {
+        vaultData: {
+          accounts: [
+            {
+              id: account.pubkey,
+              alias: account.alias,
+              account: { privkey: account.privkey },
+              createdAt: new Date().toISOString(),
+            },
+          ],
+        },
+      },
+    })) as { success?: boolean } | undefined;
+
+    await chrome.storage.local.set({ 'nostr:active': account.alias });
+    return result;
+  }, TEST_ACCOUNT);
+
+  if (!seeded || seeded.success === false) {
+    throw new Error(`Could not seed the test account: ${JSON.stringify(seeded)}`);
+  }
+}
+
+/**
+ * Asks the extension to sign, from a real page, through the injected provider.
+ *
+ * Deliberately does not await the result. The promise settles only when the request is decided, and
+ * the interval while it is pending is the thing under test.
+ */
+export async function requestSignatureFromPage(sitePage: Page): Promise<void> {
+  await sitePage.evaluate(() => {
+    const provider = (window as unknown as { nostr?: { signEvent: (event: unknown) => Promise<unknown> } })
+      .nostr;
+    if (!provider) throw new Error('window.nostr was not injected into the page');
+
+    // Held so the promise is not garbage, and so a later test can inspect it if needed.
+    (window as unknown as { __signing?: unknown }).__signing = provider
+      .signEvent({ kind: 1, content: 'e2e', tags: [], created_at: Math.floor(Date.now() / 1000) })
+      .catch((error: unknown) => ({ error: String(error) }));
+  });
+}

--- a/tests/unit/bridge-action-routing.test.ts
+++ b/tests/unit/bridge-action-routing.test.ts
@@ -39,6 +39,29 @@ const bridgeRegistrations = (): string[] =>
  */
 const KNOWN_UNROUTED = ['permission.check', 'permission.grant', 'vault.setData'];
 
+/**
+ * Actions the extension's own surfaces send, which must reach the dispatcher.
+ *
+ * `sendBexMessage` prefers the Quasar bridge and falls back to `chrome.runtime.sendMessage`. It
+ * looks for the bridge at `window.bridge` or `$q.bex`, neither of which exists in an extension
+ * page — so the fallback is the *only* path a panel or dashboard call ever takes. An action
+ * registered on the bridge alone silently returns null there, which is how the panel came to show
+ * no requests while the queue held them (#177).
+ */
+const SURFACE_ACTIONS = [
+  'nostr.requests.list',
+  'nostr.requests.current',
+  'nostr.requests.count',
+  'nostr.requests.content',
+  'nostr.requests.present',
+  'nostr.requests.respond',
+  'nostr.requests.requeuePresented',
+  'pages.originForTab',
+  'sites.list',
+  'sites.revoke',
+  'sites.countForAccount',
+];
+
 describe('bridge action routing', () => {
   const actions = declaredActions();
   const routed = new Set([...dispatcherCases(), ...bridgeRegistrations()]);
@@ -69,6 +92,20 @@ describe('bridge action routing', () => {
     for (const action of KNOWN_UNROUTED) {
       expect(actions).toContain(action);
       expect(routed.has(action)).toBe(false);
+    }
+  });
+
+  it('routes every action an extension surface sends through the dispatcher', () => {
+    const cases = new Set(dispatcherCases());
+    const unreachable = SURFACE_ACTIONS.filter((action) => !cases.has(action));
+
+    expect(unreachable).toEqual([]);
+  });
+
+  it('keeps that list honest against the declared union', () => {
+    // A typo here would make the assertion above vacuous.
+    for (const action of SURFACE_ACTIONS) {
+      expect(actions).toContain(action);
     }
   });
 });


### PR DESCRIPTION
Fixes #177, and fixes the bug that writing #177's tests uncovered.

## The panel could not see the request queue

A site asks for a signature. The queue holds the request. The toolbar badge counts it. **The panel
says "No requests waiting."**

`sendBexMessage` prefers the Quasar bridge and falls back to `chrome.runtime.sendMessage`. It looks
for the bridge at `window.bridge` or `$q.bex` — and **neither exists in an extension page**. I
checked: both are `false` in the panel. So the fallback is the *only* path a panel or dashboard call
ever takes.

Eleven actions were registered with `bridge.on` and had **no dispatcher case**, so every one returned
`null` down that path:

```
nostr.requests.list · current · count · content · present · respond · requeuePresented
pages.originForTab
sites.list · sites.revoke · sites.countForAccount
```

That is the entire request queue, the page-origin lookup behind the panel's current-site line, and
all three Connected Sites actions added this week.

Vault actions were routed in *both* places, which is why the panel looked alive — unlocked, showing
the account, the profile, the footer — while being unable to read a single request.

## Evidence

With a real signing request pending, before the fix:

```
queue states = ["queued"]    badge = "1"    panel .current-request count = 0
```

## The fix, and a guard

The eleven actions are routed. The routing test now asserts that **every action an extension surface
sends reaches the dispatcher**, and separately that the list naming them matches the declared union,
so the assertion cannot quietly go vacuous.

The earlier version of that test recorded three actions as unrouted and reachable by neither path.
It was right about those and blind to these, because it only asked whether an action was reachable
*somehow* — not whether it was reachable by the path its caller actually uses.

## The tests that found it

The capability #177 said was missing turned out to be a fixture, not a mechanism:

- a `StoredKey` is four fields and `vault.updateData` is routable, so an account can be seeded
  without driving any UI
- the provider is already injected into every page, so a real signing request is one `evaluate` away

Three tests: the badge shows the count and the title says what is waiting while the panel is closed;
the badge clears when the request is decided **through the panel**; and the panel presents the
request with the site's own origin and the identity that will sign it.

**Mutation-checked**, and the result is the point: with the `current` route returning null, the badge
test still passes — it reads the background directly — and both panel tests fail. That is exactly the
shape of the bug, and exactly why a badge-only assertion would not have caught it.

## Verification

`lint`, `typecheck`, `test:run` (899), the coverage gate, and all 13 Chromium e2e tests pass.

## Follow-up

#113's sixth acceptance criterion — closed-panel behaviour covered end to end — is now met. Worth
noting on that issue, which was closed with it recorded as the one outstanding gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)