### PR TITLE
feat(sidebar): show the footer as icons with the label on hover and focus

### DIFF
--- a/src/components/sidebar/SidebarFooterLinks.vue
+++ b/src/components/sidebar/SidebarFooterLinks.vue
@@ -1,9 +1,19 @@
 <script lang="ts" setup>
+import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 defineOptions({ name: 'SidebarFooterLinks' });
 
 const { t } = useI18n();
+
+/**
+ * Which button is focused, so the tooltip can follow focus as well as hover.
+ *
+ * Quasar's QTooltip shows on hover only — verified in the built panel, where focusing a footer
+ * button rendered no tooltip at all. That would leave the label as a pointer-only affordance, which
+ * NFR-1 forbids, so focus drives it explicitly.
+ */
+const focused = ref<string | null>(null);
 
 /**
  * Management surfaces stay full-tab; the panel links out to them rather than hosting them.
@@ -27,12 +37,34 @@ const links = [
       :key="link.id"
       flat
       dense
-      no-caps
       class="sidebar-footer__link"
       :icon="link.icon"
-      :label="t(link.labelKey)"
+      :aria-label="t(link.labelKey)"
+      :title="t(link.labelKey)"
       @click="openInTab(link.path)"
-    />
+      @focus="focused = link.id"
+      @blur="focused = null"
+      @keydown.esc="focused = null"
+    >
+      <!--
+        The name lives on `aria-label`, not here. A tooltip is a pointer affordance, and NFR-1 says
+        no interaction may depend on one — so this is what a sighted user sees, while assistive
+        technology reads the label whether or not anything is hovered.
+
+        Escape dismisses it and it follows the button's own hover, with focus driven explicitly
+        above because Quasar does not do that itself (WCAG 1.4.13, NFR-1).
+      -->
+      <q-tooltip
+        class="sidebar-footer__tooltip"
+        anchor="top middle"
+        self="bottom middle"
+        :offset="[0, 6]"
+        :delay="300"
+        :model-value="focused === link.id ? true : null"
+      >
+        {{ t(link.labelKey) }}
+      </q-tooltip>
+    </q-btn>
   </nav>
 </template>
 
@@ -47,9 +79,13 @@ const links = [
   flex-shrink: 0;
 }
 
+/*
+ * Icon-only, so the target must be held open deliberately: a dense q-btn shrinks to its content and
+ * WCAG 2.2 AA wants 24px (NFR-7). 36px leaves room without crowding a 320px-floor row.
+ */
 .sidebar-footer__link {
   flex: 1 1 auto;
-  min-width: 0;
-  font-size: 0.75rem;
+  min-width: 36px;
+  min-height: 36px;
 }
 </style>

--- a/tests/unit/components/SidebarFooterLinks.test.ts
+++ b/tests/unit/components/SidebarFooterLinks.test.ts
@@ -11,7 +11,13 @@ const mountFooter = () =>
   mount(SidebarFooterLinks, {
     global: {
       stubs: {
-        'q-btn': { template: '<button>{{ label }}</button>', props: ['label', 'icon'] },
+        // Mirrors the real q-btn closely enough for the assertions: the accessible name comes
+        // from `aria-label`, and the tooltip renders inside the button.
+        'q-btn': {
+          template: '<button :aria-label="ariaLabel" :title="title"><slot /></button>',
+          props: ['label', 'icon', 'ariaLabel', 'title'],
+        },
+        'q-tooltip': { template: '<span class="tooltip"><slot /></span>' },
       },
     },
   });
@@ -38,10 +44,47 @@ describe('the sidebar footer', () => {
     expect(wrapper.findAll('button')).toHaveLength(3);
   });
 
-  it('offers Dashboard, Keys and Settings, and nothing else', () => {
+  /**
+   * Asserted on the accessible name, not on rendered text.
+   *
+   * The footer shows icons only (#184), so there is no visible label to assert against — and the
+   * name is what a screen-reader user actually receives. If this ever fails because the label was
+   * dropped, the fix is to restore the label, never to assert on something weaker.
+   */
+  it('names Dashboard, Keys and Settings, and nothing else', () => {
     const wrapper = mountFooter();
 
-    expect(wrapper.findAll('button').map((button) => button.text())).toEqual([
+    expect(wrapper.findAll('button').map((button) => button.attributes('aria-label'))).toEqual([
+      'sidebar.links.dashboard',
+      'sidebar.links.keys',
+      'sidebar.links.settings',
+    ]);
+  });
+
+  it('carries no visible text, which is the point of the change', () => {
+    const wrapper = mountFooter();
+
+    // The tooltip is rendered inside the button, so its text is excluded deliberately: what must
+    // be absent is a permanently visible label beside the icon.
+    for (const button of wrapper.findAll('button')) {
+      expect(button.element.childElementCount).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('names each button for assistive technology whether or not anything is hovered', () => {
+    const wrapper = mountFooter();
+
+    // NFR-1: no interaction may depend on a pointer affordance, and a tooltip is one.
+    for (const button of wrapper.findAll('button')) {
+      expect(button.attributes('aria-label')).toBeTruthy();
+      expect(button.attributes('title')).toBe(button.attributes('aria-label'));
+    }
+  });
+
+  it('offers a tooltip for sighted users beside that name', () => {
+    const wrapper = mountFooter();
+
+    expect(wrapper.findAll('.tooltip').map((tip) => tip.text())).toEqual([
       'sidebar.links.dashboard',
       'sidebar.links.keys',
       'sidebar.links.settings',


### PR DESCRIPTION
Fixes #184. Paired with diogel-io/workspace#8, which now carries both footer decisions — #182's three
links and this one — in the same §3 amendment rather than two competing ones.

## The change

Icons only. Labelled buttons crowd a 320px-floor column that needs the width for the request being
reviewed.

## The label does not move into the tooltip

Removing visible text removes the button's **name**, and the name is what everything except a sighted
mouse user relies on. Each control keeps an `aria-label` and a `title`, present whether or not
anything is pointing at it.

**Quasar's tooltip shows on hover only.** I verified this in the built panel: focusing a footer
button rendered no tooltip at all. That would have left the label as a pointer-only affordance, and
NFR-1 forbids exactly that — so focus drives it explicitly, with blur and Escape dismissing it
(WCAG 1.4.13).

An icon-only `dense` button also shrinks to its content, so a minimum size holds the target clear of
the 24px floor (NFR-7).

## Measured, not assumed

In the real panel, constrained to the 320px floor:

| | |
|---|---|
| Target size | **96 × 36** — clear of 24 × 24 |
| Horizontal overflow | none |
| Tooltip on focus | shows, reads "Dashboard" |
| Tooltip on hover | shows, reads "Settings" |
| Dismissal on blur | confirmed |

The first measurement I took was at 460px, because the panel opened as a tab fills the viewport —
worth knowing for anyone measuring the panel this way, since it silently gives you the wrong number.

## The test now asserts the accessible name

`SidebarFooterLinks.test.ts` asserted the three destinations by rendered text, which no longer
exists. It asserts `aria-label` instead — a stronger assertion, and the one that matches what a
screen-reader user actually receives.

It says so in a comment, because the failure mode is subtle: if the label were ever dropped, this
test fails for the right reason and could be "fixed" by asserting on something weaker.

## Verification

`lint`, `typecheck`, `test:run` (902), the coverage gate, and all 13 Chromium e2e tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)