### PR TITLE
fix(sidebar): stop the header squeezing the account identity

### DIFF
--- a/src/components/sidebar/AccountSwitcher.vue
+++ b/src/components/sidebar/AccountSwitcher.vue
@@ -100,9 +100,18 @@ function openKeys(): void {
 </template>
 
 <style scoped>
+/*
+ * Sized to its content, capped, and never squeezed below legibility.
+ *
+ * This carried `max-width: 40%`, which resolved against the header's actions block rather than the
+ * header — and that block is sized by its own contents, so the constraint was circular and left the
+ * alias rendering at 14px (#188). A fixed width would only trade one arbitrary number for another
+ * and break differently on a long alias.
+ */
 .account-switcher {
-  max-width: 40%;
+  flex: 0 1 auto;
   min-width: 0;
+  max-width: 11rem;
 }
 
 /* An alias can be anything the user typed; it must not push the lock action off the header. */
@@ -112,6 +121,8 @@ function openKeys(): void {
   white-space: nowrap;
   font-size: 0.8rem;
   font-weight: 600;
+  /* Enough for several characters before the ellipsis; an alias truncated to nothing names no one. */
+  min-width: 4.5rem;
 }
 
 .account-switcher__heading {

--- a/src/layouts/SidebarLayout.vue
+++ b/src/layouts/SidebarLayout.vue
@@ -113,17 +113,26 @@ const pendingLabel = computed(() =>
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  padding: 12px 16px;
+  /* Trimmed from 12px: the header was 67px tall before any request content appeared (#188). */
+  padding: 8px 12px;
   background: var(--header-bg);
   border-bottom: 1px solid var(--header-border);
   flex-shrink: 0;
 }
 
+/*
+ * The brand gives way first.
+ *
+ * It is decoration; the account switcher beside it names the identity new sites will bind to. When
+ * the header runs short of room the ornamental element should yield, not the functional one (#188).
+ */
 .sidebar-brand {
   display: flex;
   align-items: center;
   gap: 10px;
   min-width: 0;
+  flex: 0 1 auto;
+  overflow: hidden;
 }
 
 .sidebar-brand__name {
@@ -131,14 +140,29 @@ const pendingLabel = computed(() =>
   font-size: 1rem;
   color: var(--text-color);
   letter-spacing: -0.0125em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Below this the wordmark is dropped entirely; the logo still identifies the panel. */
+@media (max-width: 360px) {
+  .sidebar-brand__name {
+    display: none;
+  }
 }
 
 /* Actions keep their width so the brand is what gives way when the panel is narrow. */
+/*
+ * Allowed to shrink now, but only after the brand has: the switcher's own minimum holds the alias
+ * legible, so shrinking here reduces slack rather than squeezing the identity.
+ */
 .sidebar-header__actions {
   display: flex;
   align-items: center;
   gap: 8px;
-  flex-shrink: 0;
+  flex: 0 1 auto;
+  min-width: 0;
 }
 
 /* Theme-aware: a dark pill on light chrome, an amber pill on dark chrome (#153). */

--- a/tests/e2e/panel-header-layout.spec.ts
+++ b/tests/e2e/panel-header-layout.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test } from './fixtures/extension';
+import { createVault, seedAccount } from './fixtures/vault';
+
+/**
+ * The header must keep the identity legible at panel widths (#188).
+ *
+ * Asserted on rendered width, not on the element existing. Every check that existed before passed
+ * while the account alias rendered at 14 pixels — an ellipsis and nothing else — because nothing
+ * overflowed and the element was present. Presence was never the question.
+ */
+
+/** Wide enough that a truncated alias is obvious rather than arguable. */
+const LEGIBLE_ALIAS_PX = 48;
+
+const renameActiveAccount = async (page: import('@playwright/test').Page, alias: string) => {
+  await page.evaluate(async (name) => {
+    const data = await new Promise((resolve) =>
+      chrome.runtime.sendMessage({ type: 'vault.getData', payload: {} }, resolve),
+    );
+    const vaultData = (data as { vaultData?: { accounts: Array<{ alias: string }> } }).vaultData;
+    if (!vaultData) throw new Error('no vault data');
+    vaultData.accounts[0]!.alias = name;
+    await new Promise((r) =>
+      chrome.runtime.sendMessage({ type: 'vault.updateData', payload: { vaultData } }, r),
+    );
+    await chrome.storage.local.set({ 'nostr:active': name });
+  }, alias);
+  await page.reload();
+  await page.locator('.sidebar-root').waitFor({ state: 'visible', timeout: 20_000 });
+};
+
+const measure = (page: import('@playwright/test').Page) =>
+  page.evaluate(() => {
+    const width = (selector: string): number => {
+      const el = document.querySelector(selector);
+      return el ? Math.round(el.getBoundingClientRect().width) : 0;
+    };
+    const header = document.querySelector('.sidebar-header');
+    return {
+      alias: width('.account-switcher__alias'),
+      aliasText: (document.querySelector('.account-switcher__alias') as HTMLElement | null)?.innerText ?? '',
+      brandName: width('.sidebar-brand__name'),
+      overflows: header ? header.scrollWidth > header.clientWidth : true,
+    };
+  });
+
+test.describe('the panel header', () => {
+  for (const width of [320, 400]) {
+    test(`keeps the account alias legible at ${width}px`, async ({ openPage }) => {
+      const page = await openPage('/login');
+      await createVault(page);
+      await seedAccount(page);
+      await page.goto(page.url().replace(/#.*$/, '#/sidebar'));
+      await page.locator('.sidebar-root').waitFor({ state: 'visible', timeout: 20_000 });
+      await page.setViewportSize({ width, height: 700 });
+
+      const header = await measure(page);
+
+      expect(header.alias).toBeGreaterThan(LEGIBLE_ALIAS_PX);
+      expect(header.overflows).toBe(false);
+    });
+  }
+
+  test('shows a long alias without overflowing or collapsing', async ({ openPage }) => {
+    const page = await openPage('/login');
+    await createVault(page);
+    await seedAccount(page);
+    await page.goto(page.url().replace(/#.*$/, '#/sidebar'));
+    await page.locator('.sidebar-root').waitFor({ state: 'visible', timeout: 20_000 });
+
+    // Aliases are user-supplied and unbounded; a three-character one proves nothing about layout.
+    await renameActiveAccount(page, 'a-very-long-account-alias');
+    await page.setViewportSize({ width: 320, height: 700 });
+
+    const header = await measure(page);
+
+    expect(header.aliasText).toContain('a-very-long');
+    expect(header.alias).toBeGreaterThan(LEGIBLE_ALIAS_PX);
+    expect(header.overflows).toBe(false);
+  });
+
+  test('drops the wordmark before squeezing the identity', async ({ openPage }) => {
+    const page = await openPage('/login');
+    await createVault(page);
+    await seedAccount(page);
+    await page.goto(page.url().replace(/#.*$/, '#/sidebar'));
+    await page.locator('.sidebar-root').waitFor({ state: 'visible', timeout: 20_000 });
+
+    await page.setViewportSize({ width: 400, height: 700 });
+    const roomy = await measure(page);
+    expect(roomy.brandName).toBeGreaterThan(0);
+
+    await page.setViewportSize({ width: 320, height: 700 });
+    const tight = await measure(page);
+
+    // The brand is decoration; the switcher names the identity new sites bind to. The ornamental
+    // element yields first.
+    expect(tight.brandName).toBe(0);
+    expect(tight.alias).toBeGreaterThan(LEGIBLE_ALIAS_PX);
+  });
+});


### PR DESCRIPTION
Fixes #188.

## What was happening

The account alias rendered at **14 pixels** — an ellipsis and nothing else.

`max-width: 40%` on the switcher resolved against `.sidebar-header__actions`, not the header. That
block is sized by its own contents, so the constraint was circular: the actions block measured 115px,
and the switcher measured 46 — exactly 40% of it. With `min-width: 0` beside it, nothing stopped the
collapse.

**It hurt short aliases worst**, which is why it looked arbitrary rather than systematic: a long
alias inflates the actions block, which inflates 40% of it, so the alias needing the most room was
the one that got it. The mutation check below shows this — with the old CSS restored, the long-alias
test still passes while the short-alias ones fail.

The wrong element was also giving way. The actions block was `flex-shrink: 0`, so the brand kept its
full 93px while the switcher was squeezed. **The brand is decoration; the switcher names the identity
new sites will bind to.**

## The fix

The ornamental element yields first: the brand truncates, and the wordmark drops entirely below
360px where the logo alone still identifies the panel. The switcher sizes to its content with a cap,
and the alias keeps a minimum so it never truncates to nothing.

A fixed width would have traded one arbitrary number for another and broken differently on a long
alias, so it sizes to content instead.

Header padding trimmed while the layout was open — 67px of header before any request content is a lot
in a panel whose job is showing one request.

## Measured, against a real viewport

Short alias and a 25-character alias, at 320 and 400:

| | Before | After |
|---|---|---|
| Alias width | 14px | **72px** short, **144px** long |
| Header height | 67px | **53px** |
| Wordmark | always shown | hidden at 320, shown at 400 |
| Overflow | none | none |

Worth noting for anyone measuring the panel: my first pass resized the *document*, not the viewport,
and the media query silently did not fire. Only `setViewportSize` gives the real answer.

## The test asserts legibility, not presence

`panel-header-layout.spec.ts` asserts the alias's **rendered width**. Every check that existed before
passed while it rendered at 14px, because nothing overflowed and the element was present — presence
was never the question.

**Mutation-checked:** with the original CSS restored, three of the four fail.

## Verification

`lint`, `typecheck`, `test:run` (902), the coverage gate, and all 17 Chromium e2e tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)