### PR TITLE
fix(porwr): key permission grants on the normalised origin

### DIFF
--- a/src-bex/handlers/permission-handler.ts
+++ b/src-bex/handlers/permission-handler.ts
@@ -11,10 +11,16 @@
  * The account is part of the key because a grant belongs to the identity the user was looking at
  * when they gave it. Without it, connecting a second account to a site inherited the first
  * account's permissions (#116).
+ *
+ * Origins are normalised on the way in and on the way out. The binding store already did this and
+ * the grant store did not, so the two keyed the same site differently — and `disconnectSite`
+ * normalises before filtering grants, which meant a grant stored under an unnormalised origin would
+ * have survived the user disconnecting that site.
  */
 
 import { PERMISSIONS_KEY, storageService } from 'src/services/storage-service';
 import { LogLevel, logService } from 'src/services/log-service';
+import { normalizeOrigin } from '../services/origin';
 import type { PermissionEventKind, PermissionGrant } from '../types/background';
 
 const SIGN_EVENT = 'sign_event';
@@ -55,12 +61,21 @@ const migrateGrants = (
   let discarded = 0;
 
   for (const grant of stored) {
-    if (isMigrated(grant)) {
-      grants.push(grant);
+    if (!isMigrated(grant)) {
+      discarded += 1;
       continue;
     }
 
-    discarded += 1;
+    // Records written before the store normalised are re-keyed onto the canonical origin, so they
+    // match the bindings and so `disconnectSite` can find them. One that names no web origin is
+    // discarded on the same reasoning as an unattributable one: it cannot be honoured safely.
+    const origin = normalizeOrigin(grant.origin);
+    if (!origin) {
+      discarded += 1;
+      continue;
+    }
+
+    grants.push(origin === grant.origin ? grant : { ...grant, origin });
   }
 
   return { grants, discarded };
@@ -76,9 +91,12 @@ async function loadPermissions(): Promise<PermissionGrant[]> {
     [];
   const { grants, discarded } = migrateGrants(stored);
 
-  if (discarded > 0 || grants.length !== stored.length) {
-    logService.log(LogLevel.WARN, '[Permissions] Discarded grants that name no account', {
+  const rekeyed = grants.some((grant, index) => grant !== stored[index]);
+
+  if (discarded > 0 || rekeyed || grants.length !== stored.length) {
+    logService.log(LogLevel.WARN, '[Permissions] Rewrote stored grants on load', {
       discarded,
+      rekeyed,
     });
     permissionCache = grants;
     await storageService.set(PERMISSIONS_KEY, grants);
@@ -110,7 +128,7 @@ const sameScope = (
   grant.eventKind === eventKind;
 
 export async function checkPermission(
-  origin: string,
+  rawOrigin: string,
   accountPubkey: string,
   requestType: string,
   eventKind: PermissionEventKind,
@@ -118,6 +136,10 @@ export async function checkPermission(
   // No account means nothing to check against. Matching "any account" here would reintroduce the
   // inheritance this dimension removes.
   if (!accountPubkey) return { granted: false };
+
+  // An origin we will not store a grant for is an origin we will not honour one for either.
+  const origin = normalizeOrigin(rawOrigin);
+  if (!origin) return { granted: false };
 
   const permissions = await loadPermissions();
   const now = Date.now();
@@ -144,7 +166,7 @@ export async function checkPermission(
 }
 
 export async function grantPermission(
-  origin: string,
+  rawOrigin: string,
   accountPubkey: string,
   requestType: string,
   // Deliberately narrower than PermissionEventKind: a wildcard must be asked for explicitly on a
@@ -158,6 +180,11 @@ export async function grantPermission(
 
   if (!accountPubkey) {
     throw new Error('A permission grant must name the account it was given to');
+  }
+
+  const origin = normalizeOrigin(rawOrigin);
+  if (!origin) {
+    throw new Error(`A permission grant must name a web origin, not ${JSON.stringify(rawOrigin)}`);
   }
 
   const permissions = await loadPermissions();
@@ -179,11 +206,12 @@ export async function grantPermission(
 }
 
 export async function revokePermission(
-  origin: string,
+  rawOrigin: string,
   accountPubkey: string,
   requestType: string,
   eventKind: PermissionEventKind,
 ): Promise<void> {
+  const origin = normalizeOrigin(rawOrigin) ?? rawOrigin;
   const permissions = await loadPermissions();
   await savePermissions(
     permissions.filter((grant) => !sameScope(grant, origin, accountPubkey, requestType, eventKind)),
@@ -191,7 +219,10 @@ export async function revokePermission(
 }
 
 /** Every grant for one origin, whichever account holds it. For the Connected Sites view. */
-export async function getGrantsForOrigin(origin: string): Promise<PermissionGrant[]> {
+export async function getGrantsForOrigin(rawOrigin: string): Promise<PermissionGrant[]> {
+  const origin = normalizeOrigin(rawOrigin);
+  if (!origin) return [];
+
   const permissions = await loadPermissions();
   return permissions.filter((grant) => grant.origin === origin);
 }

--- a/tests/unit/handlers/permission-handler.test.ts
+++ b/tests/unit/handlers/permission-handler.test.ts
@@ -327,3 +327,102 @@ describe('permission grants', () => {
     });
   });
 });
+
+/**
+ * Origin normalisation (#116).
+ *
+ * The binding store normalised origins and the grant store matched raw strings, so the two keyed
+ * the same site differently. That inconsistency is what the acceptance criterion rules out: storage,
+ * UI, and enforcement have to agree on what "the same site" is.
+ */
+describe('origin normalisation', () => {
+  const grantFor = (origin: string): Promise<void> =>
+    grantPermission(origin, ALICE, 'sign_event', 1, 'always');
+
+  it('stores the canonical origin, not the string the caller passed', async () => {
+    await grantFor('https://Example.COM:443/some/path?q=1');
+
+    const [record] = await getGrantedPermissions();
+    expect(record?.origin).toBe('https://example.com');
+  });
+
+  it('honours a grant when the same site arrives spelled differently', async () => {
+    await grantFor(ORIGIN);
+
+    const result = await checkPermission(
+      'https://EXAMPLE.com/login',
+      ALICE,
+      'sign_event',
+      1,
+    );
+
+    expect(result.granted).toBe(true);
+  });
+
+  it('does not let two spellings of one site become two grants', async () => {
+    await grantFor('https://example.com');
+    await grantFor('https://Example.com:443');
+
+    expect(await getGrantedPermissions()).toHaveLength(1);
+  });
+
+  it('revokes a grant given under a different spelling', async () => {
+    await grantFor('https://Example.com');
+
+    await revokePermission(ORIGIN, ALICE, 'sign_event', 1);
+
+    expect(await getGrantedPermissions()).toHaveLength(0);
+  });
+
+  it('re-keys stored grants onto the canonical origin on load', async () => {
+    seed([
+      {
+        origin: 'https://Example.com/path',
+        accountPubkey: ALICE,
+        requestType: 'sign_event',
+        eventKind: 1,
+        granted: true,
+        timestamp: Date.now(),
+      },
+    ]);
+
+    // A grant left under its raw spelling is invisible to `disconnectSite`, which normalises before
+    // filtering: the user disconnects the site and the grant quietly survives.
+    const [record] = await getGrantedPermissions();
+    expect(record?.origin).toBe('https://example.com');
+    expect(stored[0]?.origin).toBe('https://example.com');
+  });
+
+  it('refuses to grant for a non-web origin', async () => {
+    await expect(grantPermission('file:///etc/passwd', ALICE, 'sign_event', 1, 'always')).rejects.toThrow(
+      /web origin/,
+    );
+  });
+
+  it('never reports a grant for a non-web origin', async () => {
+    seed([
+      {
+        origin: 'chrome-extension://abc',
+        accountPubkey: ALICE,
+        requestType: 'sign_event',
+        eventKind: 1,
+        granted: true,
+        timestamp: Date.now(),
+      },
+    ]);
+
+    expect(await checkPermission('chrome-extension://abc', ALICE, 'sign_event', 1)).toEqual({
+      granted: false,
+    });
+    expect(await getGrantedPermissions()).toHaveLength(0);
+  });
+
+  it('still separates genuinely different sites', async () => {
+    await grantFor('https://example.com');
+
+    expect((await checkPermission('https://evil.example.com', ALICE, 'sign_event', 1)).granted).toBe(
+      false,
+    );
+    expect((await checkPermission('http://example.com', ALICE, 'sign_event', 1)).granted).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes the last open acceptance criterion on #116: *origin normalisation and matching are consistent across storage, UI, and enforcement.*

## The gap

`normalizeOrigin` landed with the site-binding store, and the binding store uses it. The **grant** store never did — it matched `grant.origin === origin` on whatever string the caller passed and stored the same.

That leaves the two stores keying the same site differently, and it has a concrete consequence. `disconnectSite` normalises first and then filters grants by the normalised origin:

```ts
const normalized = normalizeOrigin(origin);
const held = grants.filter((grant) => grant.origin === normalized);
```

A grant stored under an unnormalised origin does not match, so it is **not revoked** — the user disconnects a site and the grant quietly survives.

## The fix

Grants are normalised on write, on check, on revoke, and on read, and stored records are re-keyed onto the canonical origin when loaded. An origin naming no web scheme is refused on write and never honoured on read — the same reasoning that already discards a grant naming no account: it cannot be attributed, so it cannot be honoured.

Normalisation is `URL.origin` on http/https only, so it collapses case, default ports, and paths, and nothing else. `https://evil.example.com` and `http://example.com` remain distinct sites, and there is a test holding that line.

## Verification

- 8 new tests; **7 of 8 fail** with the normalisation removed. The 8th is the over-normalisation guard, which passes either way by design.
- 910 unit tests pass; typecheck and lint clean; coverage gate passes at 60.47/52.56/52.66/60.65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)