### PR TITLE
test(e2e): cover the fail-closed approval paths in both browsers

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -77,13 +77,34 @@ does not name its own cause:
    line, so the fixture starts geckodriver itself rather than letting selenium start one.
 
 Firefox coverage is deliberately thinner than Chromium's. Chromium is where `side_panel` and the MV3
-service worker live, so it carries the deeper suite; Firefox asserts parity on the panel facts that
-NFR-17 says must be equivalent.
+service worker live, so it carries the deeper suite; Firefox asserts parity on the facts NFR-17 says
+must be equivalent — the panel shell, and the vault lifecycle including unlocking **from inside the
+panel**, which is the path #147 and #181 both regressed.
+
+## Fail-closed paths
+
+`fail-closed.spec.ts` covers expiry, a decision on stale state, and interruption by a worker
+restart. Two techniques there are worth knowing before changing it:
+
+- **Expiry is reached by ageing the stored record, not by waiting.** The floor on
+  `REQUEST_EXPIRY_MINUTES` is one minute, and a suite that waits a minute per case stops being run.
+  Only `expiresAt` is moved; `state` is left alone so the real `applyExpiry` is still what changes
+  it. The test asserts it aged exactly one record, so it cannot pass having aged nothing.
+- **The service worker is stopped over CDP.** Playwright has no API for it; the route is
+  `ServiceWorker.enable` then `ServiceWorker.stopAllWorkers`, and any runtime message revives the
+  worker afterwards. The test writes a canary into `chrome.storage.session` first, because "the
+  queue is empty after the restart" only means reconciliation ran if session storage survived —
+  otherwise the record would be gone because the browser dropped it, and the test would prove
+  nothing. Session storage does survive; the canary keeps that honest.
+
+What these assert is not that the queue record reaches a particular state — the unit suite covers
+that — but that **the page never receives a signature** it should not have.
 
 ## Known gaps
 
 - The real side panel is never opened, in either browser — see above. The manifest keys are asserted
   instead (`side_panel` on Chromium, `sidebar_action` on Firefox); that the toolbar reveals the panel
   is manual.
-- Firefox has no vault-lifecycle coverage yet. The Chromium suite creates, locks and unlocks a vault;
-  the Firefox project asserts panel parity only.
+- The approval path itself is Chromium-only. Firefox covers the panel shell and the vault
+  lifecycle; driving a page request through the provider there needs content-script injection the
+  WebDriver fixture does not yet do.

--- a/tests/e2e/fail-closed.spec.ts
+++ b/tests/e2e/fail-closed.spec.ts
@@ -1,0 +1,250 @@
+import { expect, test } from './fixtures/extension';
+import { createVault, requestSignatureFromPage, seedAccount } from './fixtures/vault';
+
+/**
+ * The fail-closed approval paths (#141).
+ *
+ * `request-queue.ts` is unit tested against these, and until now nothing exercised them in a real
+ * browser. They are the paths where a regression fails *open*: a request that outlives its expiry,
+ * or a decision applied to a request that has already moved on. What matters is not that the queue
+ * record changes state — that is the unit test's job — but that the **page never receives a
+ * signature** it should not have.
+ *
+ * Expiry is reached by ageing the stored record rather than by waiting. The floor on
+ * `REQUEST_EXPIRY_MINUTES` is one minute, and a suite that waits a minute per case is a suite that
+ * stops being run. Ageing exercises the real `applyExpiry` on the real load path; only the clock
+ * is shortcut.
+ */
+
+const QUEUE_KEY = 'nostr:request-queue';
+
+/** A signed Nostr event carries `sig`. Anything without one is not a signature. */
+const isSignature = (value: unknown): boolean =>
+  typeof value === 'object' && value !== null && typeof (value as { sig?: unknown }).sig === 'string';
+
+test.describe('a request that expires', () => {
+  test('is refused at the page rather than left signable', async ({ openPage, background, context }) => {
+    const extensionPage = await openPage('/login');
+    await createVault(extensionPage);
+    await seedAccount(extensionPage);
+
+    const site = await context.newPage();
+    await site.goto('https://example.com');
+    await requestSignatureFromPage(site);
+
+    await expect
+      .poll(() => background.evaluate(() => chrome.action.getBadgeText({})), { timeout: 15_000 })
+      .toBe('1');
+
+    // Age every queued record past its expiry. This is the clock moving, not the queue being
+    // rewritten into a terminal state: `state` is left alone so `applyExpiry` is what changes it.
+    const aged = await background.evaluate(async (key) => {
+      const stored = (await chrome.storage.session.get(key)) as Record<string, unknown>;
+      const records = stored[key] as Array<{ expiresAt: number; state: string }> | undefined;
+      if (!records?.length) return 0;
+      await chrome.storage.session.set({
+        [key]: records.map((record) => ({ ...record, expiresAt: Date.now() - 1_000 })),
+      });
+      return records.length;
+    }, QUEUE_KEY);
+
+    // Without this the test could pass having aged nothing at all.
+    expect(aged).toBe(1);
+
+    // Any read of the queue applies expiry. This is the one the panel itself makes.
+    await extensionPage.evaluate(() => chrome.runtime.sendMessage({ type: 'nostr.requests.count' }));
+
+    await expect
+      .poll(() => background.evaluate(() => chrome.action.getBadgeText({})), { timeout: 15_000 })
+      .toBe('');
+
+    // The guarantee that matters: the site's promise settles, and not with a signature.
+    const outcome = await site.evaluate(() => (window as unknown as { __signing: Promise<unknown> }).__signing);
+    expect(isSignature(outcome)).toBe(false);
+
+    await site.close();
+  });
+
+  test('cannot then be approved from a stale panel', async ({ openPage, background, context }) => {
+    const extensionPage = await openPage('/login');
+    await createVault(extensionPage);
+    await seedAccount(extensionPage);
+
+    const site = await context.newPage();
+    await site.goto('https://example.com');
+    await requestSignatureFromPage(site);
+
+    await expect
+      .poll(() => background.evaluate(() => chrome.action.getBadgeText({})), { timeout: 15_000 })
+      .toBe('1');
+
+    // Read the id before ageing, the way a panel that rendered before the expiry would hold it.
+    const requestId = await background.evaluate(async (key) => {
+      const stored = (await chrome.storage.session.get(key)) as Record<string, unknown>;
+      const records = stored[key] as Array<{ id: string }> | undefined;
+      return records?.[0]?.id ?? null;
+    }, QUEUE_KEY);
+
+    expect(requestId).not.toBeNull();
+
+    await background.evaluate(async (key) => {
+      const stored = (await chrome.storage.session.get(key)) as Record<string, unknown>;
+      const records = stored[key] as Array<{ expiresAt: number }>;
+      await chrome.storage.session.set({
+        [key]: records.map((record) => ({ ...record, expiresAt: Date.now() - 1_000 })),
+      });
+    }, QUEUE_KEY);
+
+    // The decision a stale panel would submit: approve, for a request that is already gone.
+    const result = await extensionPage.evaluate(
+      (id) =>
+        chrome.runtime.sendMessage({
+          type: 'nostr.requests.respond',
+          payload: { requestId: id, approved: true, duration: 'once' },
+        }),
+      requestId,
+    );
+
+    expect(result).toMatchObject({ applied: false, reason: 'expired' });
+
+    const outcome = await site.evaluate(() => (window as unknown as { __signing: Promise<unknown> }).__signing);
+    expect(isSignature(outcome)).toBe(false);
+
+    await site.close();
+  });
+});
+
+test.describe('a request that is already decided', () => {
+  test('refuses a second decision rather than applying it', async ({ openPage, background, context }) => {
+    const extensionPage = await openPage('/login');
+    await createVault(extensionPage);
+    await seedAccount(extensionPage);
+
+    const site = await context.newPage();
+    await site.goto('https://example.com');
+    await requestSignatureFromPage(site);
+
+    await expect
+      .poll(() => background.evaluate(() => chrome.action.getBadgeText({})), { timeout: 15_000 })
+      .toBe('1');
+
+    const requestId = await background.evaluate(async (key) => {
+      const stored = (await chrome.storage.session.get(key)) as Record<string, unknown>;
+      const records = stored[key] as Array<{ id: string }> | undefined;
+      return records?.[0]?.id ?? null;
+    }, QUEUE_KEY);
+
+    // Rejected through the panel, the way a user does it.
+    await extensionPage.goto(extensionPage.url().replace(/#.*$/, '#/sidebar'));
+    await extensionPage.locator('.current-request').waitFor({ state: 'visible', timeout: 15_000 });
+    await extensionPage.getByRole('button', { name: /reject/i }).first().click();
+
+    await expect
+      .poll(() => background.evaluate(() => chrome.action.getBadgeText({})), { timeout: 15_000 })
+      .toBe('');
+
+    // A second panel, or a replayed message, approving what was already rejected.
+    const result = await extensionPage.evaluate(
+      (id) =>
+        chrome.runtime.sendMessage({
+          type: 'nostr.requests.respond',
+          payload: { requestId: id, approved: true, duration: 'once' },
+        }),
+      requestId,
+    );
+
+    expect(result).toMatchObject({ applied: false, reason: 'already-resolved' });
+
+    const outcome = await site.evaluate(() => (window as unknown as { __signing: Promise<unknown> }).__signing);
+    expect(isSignature(outcome)).toBe(false);
+
+    await site.close();
+  });
+});
+
+test.describe('a request interrupted by a worker restart', () => {
+  test('is not left approvable, and the page gets no signature', async ({
+    openPage,
+    background,
+    context,
+  }) => {
+    const extensionPage = await openPage('/login');
+    await createVault(extensionPage);
+    await seedAccount(extensionPage);
+
+    const site = await context.newPage();
+    await site.goto('https://example.com');
+    await requestSignatureFromPage(site);
+
+    await expect
+      .poll(() => background.evaluate(() => chrome.action.getBadgeText({})), { timeout: 15_000 })
+      .toBe('1');
+
+    const requestId = await background.evaluate(async (key) => {
+      const stored = (await chrome.storage.session.get(key)) as Record<string, unknown>;
+      const records = stored[key] as Array<{ id: string }> | undefined;
+      return records?.[0]?.id ?? null;
+    }, QUEUE_KEY);
+
+    expect(requestId).not.toBeNull();
+
+    /*
+     * A canary the extension never reads.
+     *
+     * The queue is empty after the restart, and that is only evidence of anything if session
+     * storage survived it — otherwise the record would be gone because the browser dropped it and
+     * this test would prove nothing about reconciliation. The canary is what separates those two.
+     */
+    await extensionPage.evaluate(() => chrome.storage.session.set({ 'e2e:canary': 'alive' }));
+
+    // Playwright cannot stop an MV3 worker; CDP can.
+    const client = await context.newCDPSession(extensionPage);
+    await client.send('ServiceWorker.enable');
+    await client.send('ServiceWorker.stopAllWorkers');
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+
+    // Any message revives the worker, which is what runs the startup reconciliation.
+    await extensionPage.evaluate(() => chrome.runtime.sendMessage({ type: 'ping' }));
+
+    const canary = await extensionPage.evaluate(async () => {
+      const stored = await chrome.storage.session.get('e2e:canary');
+      return stored['e2e:canary'] ?? null;
+    });
+    expect(canary).toBe('alive');
+
+    // The live callback died with the worker, so the request can never be honoured (D7).
+    const result = await extensionPage.evaluate(
+      (id) =>
+        chrome.runtime.sendMessage({
+          type: 'nostr.requests.respond',
+          payload: { requestId: id, approved: true, duration: 'once' },
+        }),
+      requestId,
+    );
+
+    expect(result).toMatchObject({ applied: false });
+
+    await expect
+      .poll(() => background.evaluate(() => chrome.action.getBadgeText({})), { timeout: 15_000 })
+      .toBe('');
+
+    /*
+     * Raced against a timeout rather than awaited.
+     *
+     * The worker died holding this promise's resolver, so it may never settle at all. A request
+     * left pending forever is not the failure this guards against — a signature arriving for a
+     * request nobody can approve is — so the assertion is that no signature appears, not that the
+     * promise settles.
+     */
+    const outcome = await site.evaluate(
+      () =>
+        Promise.race([
+          (window as unknown as { __signing: Promise<unknown> }).__signing,
+          new Promise((resolve) => setTimeout(() => resolve({ stillPending: true }), 3_000)),
+        ]),
+    );
+    expect(isSignature(outcome)).toBe(false);
+
+    await site.close();
+  });
+});

--- a/tests/e2e/firefox/vault.spec.ts
+++ b/tests/e2e/firefox/vault.spec.ts
@@ -1,0 +1,91 @@
+import { VAULT_PASSWORD, expect, test, until } from '../fixtures/firefox';
+
+/**
+ * Vault lifecycle in Firefox (#141).
+ *
+ * The Chromium suite creates, locks and unlocks a vault; the Firefox project asserted panel parity
+ * only, which left the surface a user actually meets first — the vault — covered in one browser.
+ *
+ * NFR-17 asks for equivalent core behaviour across both, and the panel's vault states are core: a
+ * locked panel must render its own unlock view rather than routing to the full-tab login page,
+ * which is the regression #147 and #181 both produced in Chromium.
+ */
+test.describe('the vault in Firefox', () => {
+  test('creates a vault and settles on the panel, not a dashboard surface', async ({
+    driver,
+    createVault,
+    openExtensionPage,
+  }) => {
+    await createVault();
+    await openExtensionPage('/sidebar');
+
+    await driver.wait(until.elementLocated({ css: '.sidebar-root' }), 30_000, 'the panel never rendered');
+
+    // The panel and the management surfaces share one bundle, so nothing structural keeps a
+    // dashboard layout out of a 360px panel (D2, S9).
+    const dashboards = await driver.findElements({ css: '.dashboard-layout, .dashboard-navigation' });
+    expect(dashboards).toHaveLength(0);
+  });
+
+  test('renders its own unlock view in the panel when locked, never the full-tab login page', async ({
+    driver,
+    createVault,
+    lockVault,
+    openExtensionPage,
+  }) => {
+    await createVault();
+    await lockVault();
+
+    await openExtensionPage('/sidebar');
+    await driver.wait(
+      until.elementLocated({ css: '.sidebar-unlock' }),
+      30_000,
+      'the panel never offered to unlock',
+    );
+
+    // `.vault-card` is the full-tab login surface. Its presence here would mean the panel had been
+    // routed away to a window it must never open (D2).
+    const fullTab = await driver.findElements({ css: '.vault-card' });
+    expect(fullTab).toHaveLength(0);
+  });
+
+  test('unlocks from inside the panel and stays there', async ({
+    driver,
+    createVault,
+    lockVault,
+    openExtensionPage,
+  }) => {
+    await createVault();
+    await lockVault();
+
+    // Unlocked from the panel's own view, which is the path that regressed. Unlocking from the
+    // full-tab login page instead would exercise a different code path and prove nothing about
+    // this one: verified by breaking `isPanelRoute`, which a login-page unlock does not notice.
+    await openExtensionPage('/sidebar');
+    await driver.wait(
+      until.elementLocated({ css: '.sidebar-unlock' }),
+      30_000,
+      'the panel never offered to unlock',
+    );
+
+    const field = await driver.findElement({ css: '.sidebar-unlock input[type="password"]' });
+    await field.sendKeys(VAULT_PASSWORD);
+
+    const unlock = await driver.findElement({ css: '.sidebar-unlock__actions .q-btn:last-child' });
+    await unlock.click();
+
+    await driver.wait(
+      until.stalenessOf(field),
+      30_000,
+      'the unlock view never went away, so the vault did not unlock',
+    );
+
+    // #147 fixed this for lock and #181 for unlock: the panel navigated itself to the full-tab
+    // dashboard, taking a 360px surface to a window it must never open (D2, S9).
+    const panel = await driver.findElements({ css: '.sidebar-root' });
+    expect(panel.length).toBeGreaterThan(0);
+
+    const strayed = await driver.findElements({ css: '.vault-card, .dashboard-navigation' });
+    expect(strayed).toHaveLength(0);
+  });
+});

--- a/tests/e2e/fixtures/firefox.ts
+++ b/tests/e2e/fixtures/firefox.ts
@@ -68,7 +68,15 @@ export interface FirefoxFixtures {
   driver: firefox.Driver;
   /** Opens an extension route and waits for the app to settle on a real surface. */
   openExtensionPage: (hash: string) => Promise<void>;
+  /** Creates a vault from the login surface, leaving it unlocked. */
+  createVault: (password?: string) => Promise<void>;
+  /** Unlocks an existing vault from the login surface. */
+  unlockVault: (password?: string) => Promise<void>;
+  /** Locks the vault the way the background does on auto-lock. */
+  lockVault: () => Promise<void>;
 }
+
+export const VAULT_PASSWORD = 'e2e-test-password';
 
 export const test = base.extend<FirefoxFixtures>({
   driver: async ({}, use) => {
@@ -133,6 +141,82 @@ export const test = base.extend<FirefoxFixtures>({
         45_000,
         'the app never settled on a surface',
       );
+    });
+  },
+
+  /*
+   * Vault lifecycle in Firefox.
+   *
+   * Not a translation of the Chromium helpers. Playwright's `getByLabel` has no WebDriver
+   * equivalent, so the fields are found by position within the vault card: the create form renders
+   * two password inputs and the unlock form renders one, which is also what tells the two apart.
+   */
+  createVault: async ({ driver, openExtensionPage }, use) => {
+    await use(async (password = VAULT_PASSWORD) => {
+      await openExtensionPage('/login');
+
+      const fields = await driver.wait(
+        until.elementsLocated({ css: '.vault-card input[type="password"]' }),
+        30_000,
+        'the vault form never rendered',
+      );
+
+      if (fields.length !== 2) {
+        throw new Error(
+          `Expected the create form's two password fields, found ${String(fields.length)}. ` +
+            'A vault already exists in this profile, or the form changed.',
+        );
+      }
+
+      await fields[0]?.sendKeys(password);
+      await fields[1]?.sendKeys(password);
+
+      const submit = await driver.findElement({ css: '.vault-card .q-card__actions button' });
+      await submit.click();
+
+      // The form is replaced once the vault exists; waiting on that is what makes this synchronous.
+      await driver.wait(until.stalenessOf(submit), 30_000, 'the vault was never created');
+    });
+  },
+
+  unlockVault: async ({ driver, openExtensionPage }, use) => {
+    await use(async (password = VAULT_PASSWORD) => {
+      await openExtensionPage('/login');
+
+      const fields = await driver.wait(
+        until.elementsLocated({ css: '.vault-card input[type="password"]' }),
+        30_000,
+        'the unlock form never rendered',
+      );
+
+      if (fields.length !== 1) {
+        throw new Error(
+          `Expected the unlock form's single password field, found ${String(fields.length)}. ` +
+            'The vault may not exist, in which case this is the create form.',
+        );
+      }
+
+      await fields[0]?.sendKeys(password);
+
+      const submit = await driver.findElement({ css: '.vault-card .q-card__actions button' });
+      await submit.click();
+      await driver.wait(until.stalenessOf(submit), 30_000, 'the vault was never unlocked');
+    });
+  },
+
+  lockVault: async ({ driver }, use) => {
+    await use(async () => {
+      // Sent from a page rather than the background: a worker asking itself to lock is a no-op,
+      // because runtime messages are not delivered to the sender's own listener.
+      const locked = await driver.executeAsyncScript<boolean>(
+        'const done = arguments[arguments.length - 1];' +
+          'browser.runtime.sendMessage({ type: "vault.lock" })' +
+          '  .then(() => done(true), (e) => done("lock failed: " + String(e)));',
+      );
+
+      // Swallowing this would surface later as "the panel never offered to unlock", which describes
+      // the symptom of an unlocked vault rather than the message that never arrived.
+      if (locked !== true) throw new Error(String(locked));
     });
   },
 });


### PR DESCRIPTION
Closes #141.

## What was actually left

The harness landed earlier and all three acceptance criteria on the issue were already met. What was never covered is the **third outcome** — expiry, a decision on stale state, and interruption after a worker restart. All three were unit tested against `request-queue.ts` and exercised by nothing that loads a browser. They are the paths where a regression fails **open**.

Suite goes from 21 tests to 28: **24 Chromium, 4 Firefox → 21 Chromium, 7 Firefox**.

## Chromium: four fail-closed cases

Each asserts the thing that actually matters — not that the queue record reaches a particular state, which the unit suite covers, but that **the page never receives a signature it should not have**.

- a request that expires is refused at the page
- an expired request cannot then be approved from a stale panel
- an already-decided request refuses a second decision
- a request interrupted by a worker restart is not left approvable

## Two techniques that needed establishing, not assuming

**Expiry is reached by ageing the record, not by waiting.** The floor on `REQUEST_EXPIRY_MINUTES` is one minute, and a suite that waits a minute per case stops being run. Only `expiresAt` moves — `state` is untouched, so the real `applyExpiry` is still what changes it. The test asserts it aged exactly one record, so it cannot pass having aged nothing.

**The worker is stopped over CDP**, which Playwright has no API for: `ServiceWorker.enable` then `stopAllWorkers`, with any runtime message reviving it. This one needed a decision recorded in the plan, and the answer turned out to be yes — but only after checking the thing that makes it meaningful.

The queue is empty after a restart. That is evidence of reconciliation *only if session storage survived the restart* — otherwise the record is gone because the browser dropped it, and the test proves nothing. So the test writes a canary into `chrome.storage.session` first. It does survive; the canary keeps that honest.

## Firefox: the vault lifecycle it never had

Create, lock, and unlock **from inside the panel** — the path #147 and #181 both regressed. The helpers are not a translation of the Chromium ones: WebDriver has no `getByLabel`, so fields are found by position within the vault card, and the count of password inputs is what distinguishes the create form from the unlock form. `lockVault` asserts its own message succeeded, because swallowing that surfaces later as "the panel never offered to unlock" — the symptom of an unlocked vault rather than the message that never arrived.

## Mutation checks, one of which earned its keep

Every case was checked by breaking the source it guards:

| Mutation | Result |
|---|---|
| expiry gains an hour of grace | expiry cases fail, decided-case unaffected |
| `submitDecision` stops refusing expired | stale-panel case fails, others pass |
| `submitDecision` stops refusing already-resolved | duplicate-decision case fails, others pass |
| restart no longer interrupts | worker-restart case fails, others pass |
| `isPanelRoute` returns false | Firefox panel-unlock case fails |

The last one matters. An **earlier version of the Firefox test unlocked from the full-tab login page** instead of the panel, and breaking `isPanelRoute` did not fail it — that path never reaches the guard, so the test would have shipped asserting a regression it could not detect. It unlocks from inside the panel now, and the mutation fails it.

## Verification

1,001 unit tests, typecheck, lint all pass. Both extensions rebuilt and the full e2e suite run: **28/28**, Chromium and Firefox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)