### PR TITLE
fix(bex): answer null instead of withholding the reply

### DIFF
--- a/src-bex/background.ts
+++ b/src-bex/background.ts
@@ -516,7 +516,17 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     decision.origin,
   )
     .then((response) => {
-      if (response !== null) {
+      /*
+       * `undefined` means the dispatcher serves no such action, and staying silent is right —
+       * the behaviour this listener has had since it replaced a chain of `message.type ===`
+       * branches that simply fell through.
+       *
+       * `null` is an answer. The queue is empty, the tab has no known origin, the request carries
+       * no content. Withholding those left the caller holding a promise that never settled: the
+       * panel kept showing a request the user had already approved, because the read that would
+       * have cleared it never came back (#195).
+       */
+      if (response !== undefined) {
         sendResponse(response);
       }
     })

--- a/src-bex/dispatcher.ts
+++ b/src-bex/dispatcher.ts
@@ -73,7 +73,7 @@ export async function dispatchMessage<K extends BridgeAction>(
   type: K,
   payload: BridgeRequestMap[K],
   origin: string = '',
-): Promise<BridgeResponsePayload<K> | null> {
+): Promise<BridgeResponsePayload<K> | null | undefined> {
   switch (type) {
     case 'ping':
       return 'pong' as BridgeResponsePayload<K>;
@@ -472,7 +472,15 @@ export async function dispatchMessage<K extends BridgeAction>(
       }
     }
 
+    /**
+     * Not an answer of `null` — no answer at all.
+     *
+     * These are different things and conflating them cost the panel its idle view. Several actions
+     * legitimately answer `null`: the queue is empty, the tab has no known origin, the request
+     * carries no content. `undefined` is reserved for "this router serves no such action", which is
+     * the only case where the listener should stay silent (#195).
+     */
     default:
-      return null;
+      return undefined;
   }
 }

--- a/tests/e2e/panel-returns-to-idle.spec.ts
+++ b/tests/e2e/panel-returns-to-idle.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from './fixtures/extension';
+import { createVault, requestSignatureFromPage, seedAccount } from './fixtures/vault';
+
+/**
+ * The panel returns to its idle view once nothing is waiting (#195).
+ *
+ * The defect this guards was not a missing navigation. The panel is one route rendering from
+ * state, and its template already falls through to the idle view the moment `current` is null —
+ * but `current` was never cleared, because the read that would have cleared it never came back.
+ *
+ * `nostr.requests.current` answers `null` when the queue is empty, and the raw message listener
+ * withheld every `null` reply. The panel was left awaiting a promise that never settled and went
+ * on showing a request the user had already approved.
+ *
+ * This lives end to end because the defect is in the seam between the panel and the worker, which
+ * is exactly what a unit test mocks away — the same seam as #177 and #186.
+ */
+test.describe('after the last request is decided', () => {
+  test('the panel returns to its idle view', async ({ openPage, context }) => {
+    const setup = await openPage('/login');
+    await createVault(setup);
+    await seedAccount(setup);
+
+    const site = await context.newPage();
+    await site.goto('https://example.com');
+    await requestSignatureFromPage(site);
+
+    const panel = await openPage('/sidebar');
+    await panel.locator('.current-request').waitFor({ state: 'visible', timeout: 20_000 });
+
+    await panel.getByRole('button', { name: /approve/i }).first().click();
+
+    // The idle view, not the request screen. Generous timeout on purpose: the failure mode was a
+    // 5s call timeout retried twice, so a short wait here would fail for the right reason by
+    // accident and keep passing once the retries were tuned.
+    await expect(panel.locator('.current-request')).toHaveCount(0, { timeout: 25_000 });
+    await expect(panel.locator('.sidebar-home__account, .sidebar-home__empty')).not.toHaveCount(0);
+
+    await site.close();
+  });
+
+  test('asking for the current request answers instead of hanging', async ({ openPage }) => {
+    const panel = await openPage('/sidebar');
+    await createVault(panel);
+
+    /*
+     * The mechanism under the test above.
+     *
+     * Without this, that test could start passing again for an unrelated reason — the queue
+     * clearing by some other route — while a null reply was still being withheld. Raced against a
+     * short timeout because the failure is silence, which no assertion on a returned value can
+     * catch: an unanswered `sendMessage` never rejects, it simply never settles.
+     */
+    const reply = await panel.evaluate(async () => {
+      const answered = await Promise.race([
+        chrome.runtime
+          .sendMessage({ type: 'nostr.requests.current' })
+          .then((value: unknown) => ({ settled: true, value: value ?? null })),
+        new Promise((resolve) => setTimeout(() => resolve({ settled: false }), 3_000)),
+      ]);
+      return answered as { settled: boolean; value?: unknown };
+    });
+
+    expect(reply.settled).toBe(true);
+    expect(reply.value).toBeNull();
+  });
+});

--- a/tests/unit/dispatcher.test.ts
+++ b/tests/unit/dispatcher.test.ts
@@ -6,6 +6,7 @@ import { handleBlossomUpload } from 'app/src-bex/handlers/blossom-handler';
 import { handleNip44Encrypt, handleNip44Decrypt } from 'app/src-bex/handlers/nip44';
 import { handleNip04Encrypt, handleNip04Decrypt } from 'app/src-bex/handlers/nip04';
 import { handleGetPublicKey, handleSignEvent } from 'app/src-bex/handlers/nip07';
+import { getPageOrigin } from 'app/src-bex/services/page-origin-registry';
 import type { RelayCatalogEntry, RelayDiscoveryState } from 'src/types/relay';
 import { createBridgeRequest } from 'src/types/bridge';
 import type { VaultData } from 'src/types/bridge';
@@ -47,6 +48,10 @@ vi.mock('app/src-bex/handlers/nip04', () => ({
 vi.mock('app/src-bex/handlers/nip44', () => ({
   handleNip44Encrypt: vi.fn(),
   handleNip44Decrypt: vi.fn(),
+}));
+
+vi.mock('app/src-bex/services/page-origin-registry', () => ({
+  getPageOrigin: vi.fn(),
 }));
 
 vi.mock('app/src-bex/handlers/relay-browser-handler', () => ({
@@ -139,9 +144,9 @@ describe('Dispatcher', () => {
     ).toBeLessThan(autoLockMocks.startAutoLockTimer.mock.invocationCallOrder[0]!);
   });
 
-  it('should return null for unknown message type', async () => {
+  it('should return undefined for unknown message type', async () => {
     const result = await dispatchMessage('unknown.action' as never, { id: 'test', action: 'unknown.action' } as never);
-    expect(result).toBeNull();
+    expect(result).toBeUndefined();
   });
 
   it('should route blossom.upload to handler and return success response', async () => {
@@ -288,11 +293,26 @@ describe('Dispatcher', () => {
       ).rejects.toThrow('Vault is locked');
     });
 
-    it('returns null for an action it does not serve', async () => {
+    it('returns undefined for an action it does not serve', async () => {
       // An unknown action falls through the switch. That is where "we do not serve that" belongs,
       // and it must not throw — the caller gets no response rather than an error page.
+      //
+      // `undefined` rather than `null`, and the difference is load-bearing: the raw message
+      // listener stays silent for `undefined` and answers `null`. While both were `null` the
+      // listener could not tell them apart, so it stayed silent for both, and a panel asking for
+      // an empty queue waited on a reply that never came (#195).
       await expect(
         dispatchMessage('not.an.action' as 'ping', {} as never, ORIGIN),
+      ).resolves.toBeUndefined();
+    });
+
+    it('answers null for an action it serves whose answer is null', async () => {
+      // The other half of the distinction. `pages.originForTab` has no origin for an unknown tab,
+      // and that is an answer the caller is entitled to receive.
+      vi.mocked(getPageOrigin).mockReturnValue(undefined);
+
+      await expect(
+        dispatchMessage('pages.originForTab', { tabId: 999 } as never, ORIGIN),
       ).resolves.toBeNull();
     });
   });


### PR DESCRIPTION
Closes #195.

## It was not a navigation bug

The panel is one route rendering from state, and its template already falls through to the idle view the moment `current` is null. What never happened was `current` **becoming** null — the read that would have cleared it never came back.

The raw message listener replied only when the dispatcher returned something other than `null`:

```ts
if (response !== null) sendResponse(response);
```

`nostr.requests.current` answers `null` when the queue is empty, which is exactly the state approving the last request reaches. No reply was sent, so `sendBexMessage` sat on a promise that never settled: 5s timeout, retried twice, then a throw into `refresh()`'s `catch`, which logs at DEBUG and leaves `current` untouched. Every later refresh hit the same hang, so the panel stayed wrong until closed and reopened.

Measured in the built extension before the fix:

| | reply | time |
|---|---|---|
| request waiting | the record | 1 ms |
| queue empty | **none at all** | timed out |

## The guard was not arbitrary

Worth saying, since the fix deletes it. It arrived in `cace917`, when a chain of `if (message.type === …)` branches collapsed into `dispatchMessage`; those branches fell through silently for a type the listener did not serve, and the guard preserved that.

What it could not do is tell **"no such action"** from **"the answer is null"**, because the dispatcher returned `null` for both.

So the two are now distinct — `undefined` for an action this router does not serve, where silence is still correct, and `null` for an answer. The listener stays quiet for the first and replies with the second. The original intent is kept rather than discarded.

## Not only the request queue

Every action that can legitimately answer null had the same defect: `pages.originForTab` for an unknown tab, `nostr.requests.content` for a request with no content, `relay.browser.getStatus` when the handler fails, and `requeuePresented`, which returns null **always** — so closing the panel waited out the full retry cycle every time.

## Tests

Two end-to-end, because the defect lives in the seam between the panel and the worker, which is exactly what a unit test mocks away — the same seam as #177 and #186:

- **the user-visible one**: approve the only pending request, the panel shows its idle view
- **the mechanism**: `nostr.requests.current` answers rather than hanging when the queue is empty

The second exists so the first cannot start passing later for an unrelated reason. It races a timeout because the failure mode is *silence* — an unanswered `sendMessage` never rejects, it simply never settles, so no assertion on a returned value can catch it.

**Mutation-checked** by restoring the original guard: both fail, the first taking 26.5s, which is the retry cycle described above.

Two unit tests changed, both of which encoded the old contract (`unknown action → null`). They now encode the distinction, and a new one covers the other half: a served action whose answer is null still answers.

## Verification

1,002 unit tests, typecheck, lint, coverage gate all pass. Both extensions rebuilt, full e2e suite: **30/30** across Chromium and Firefox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)