### PR TITLE
feat(sidebar): show the full profile in the panel, and keep it current

### DIFF
--- a/src/components/dashboard/ProfileImage.vue
+++ b/src/components/dashboard/ProfileImage.vue
@@ -6,6 +6,7 @@ import type { NostrProfile, StoredKey } from 'src/types';
 import { finalizeEvent, getPublicKey, SimplePool } from 'nostr-tools';
 import { hexToBytes } from '@noble/hashes/utils';
 import useSettingsStore from 'src/stores/settings-store';
+import { notifyProfileChanged } from 'src/services/profile-service';
 import BannerEditor from 'components/dashboard/BannerEditor.vue';
 import AvatarEditor from 'components/dashboard/AvatarEditor.vue';
 
@@ -112,6 +113,11 @@ async function saveProfile(field: 'picture' | 'banner', url: string) {
 
     const signedEvent = finalizeEvent(eventTemplate, sk);
     await Promise.any(pool.publish(fallbackRelays.value, signedEvent));
+
+    // This path publishes its own event rather than going through `profileService`, so it has to
+    // signal for itself. Changing an avatar is changing a profile, and a panel that missed it
+    // would show the old picture until it was reopened (#201).
+    await notifyProfileChanged(pk);
 
     $q.notify({
       type: 'positive',

--- a/src/components/shared/ProfileView.vue
+++ b/src/components/shared/ProfileView.vue
@@ -1,8 +1,10 @@
 <script lang="ts" setup>
-import { onMounted, ref, watch } from 'vue';
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import type { NostrProfile, StoredKey } from 'src/types';
 import { profileService } from 'src/services/profile-service';
+import { PROFILE_UPDATED_KEY, storageService } from 'src/services/storage-service';
+import { formatBirthday, normalizeWebsiteUrl } from 'src/utils/profile-format';
 
 defineOptions({ name: 'ProfileView' });
 
@@ -30,6 +32,24 @@ const profile = ref<NostrProfile>({
 
 const loading = ref(false);
 
+const birthdayText = computed(() => formatBirthday(profile.value.birthday));
+
+/**
+ * Whether anything beyond the name and picture has been published.
+ *
+ * Said explicitly rather than left as an empty gap: a panel that simply shows nothing cannot be
+ * told apart from one that has not finished loading.
+ */
+const hasDetails = computed(() =>
+  Boolean(
+    profile.value.website ||
+      profile.value.nip05 ||
+      profile.value.lud16 ||
+      profile.value.bot ||
+      birthdayText.value,
+  ),
+);
+
 async function fetchProfile() {
   if (!props.storedKey.id) return;
 
@@ -56,8 +76,33 @@ async function fetchProfile() {
   loading.value = false;
 }
 
+/**
+ * Re-read when the profile is published from another surface.
+ *
+ * The dashboard's editor is a different page context, so nothing in this one hears about a save.
+ * Before this, editing a profile in a tab left the panel showing the old one until it was reopened,
+ * and the dashboard's own preview was the only thing that ever reflected an edit (#201).
+ *
+ * Storage rather than the panel port: this component also renders on the extension index page, and
+ * the port is one connection per panel that the background counts for presence — opening one here
+ * would make a single panel look like two (#113).
+ */
+const onStorageChanged = (changes: Record<string, chrome.storage.StorageChange>): void => {
+  const updated = changes[PROFILE_UPDATED_KEY]?.newValue as { pubkey?: string } | undefined;
+  if (!updated) return;
+  // Another account's profile changing is not this card's business.
+  if (updated.pubkey !== props.storedKey.id) return;
+
+  void fetchProfile();
+};
+
 onMounted(() => {
   void fetchProfile();
+  storageService.onChanged(onStorageChanged);
+});
+
+onUnmounted(() => {
+  storageService.removeOnChanged(onStorageChanged);
 });
 
 watch(
@@ -111,10 +156,47 @@ watch(
             {{ profile.about }}
           </div>
 
-          <div v-if="profile.website" class="q-mt-xs">
-            <a :href="profile.website" target="_blank" class="website-link">
-              {{ profile.website }}
-            </a>
+          <!--
+            The detail rows the dashboard preview carried and this did not (#201). Each is a
+            separate row rather than a wrapped line: at the 320px floor a joined list wraps into
+            something unreadable, and these are values a user checks rather than reads.
+          -->
+          <div class="profile-detail q-mt-sm">
+            <div v-if="profile.website" class="profile-detail__row">
+              <q-icon name="language" size="16px" />
+              <a
+                :href="normalizeWebsiteUrl(profile.website)"
+                class="website-link profile-detail__value"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                {{ profile.website }}
+              </a>
+            </div>
+
+            <div v-if="profile.nip05" class="profile-detail__row">
+              <q-icon name="badge" size="16px" />
+              <span class="profile-detail__value">{{ profile.nip05 }}</span>
+            </div>
+
+            <div v-if="profile.lud16" class="profile-detail__row">
+              <q-icon name="bolt" size="16px" />
+              <span class="profile-detail__value">{{ profile.lud16 }}</span>
+            </div>
+
+            <div v-if="profile.bot" class="profile-detail__row">
+              <q-icon name="smart_toy" size="16px" />
+              <span class="profile-detail__value">{{ t('profile.previewBot') }}</span>
+            </div>
+
+            <div v-if="birthdayText" class="profile-detail__row">
+              <q-icon name="cake" size="16px" />
+              <span class="profile-detail__value">{{ birthdayText }}</span>
+            </div>
+
+            <div v-if="!hasDetails" class="profile-detail__empty">
+              {{ t('profile.previewNoDetails') }}
+            </div>
           </div>
         </div>
       </q-card-section>
@@ -134,6 +216,37 @@ watch(
 </template>
 
 <style scoped lang="scss">
+.profile-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.profile-detail__row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  font-size: 0.8rem;
+}
+
+/*
+ * The panel floor is 320px and these values are user-supplied: a NIP-05 identifier or a Lightning
+ * address can be long enough to push the column wider than the panel, which NFR-11 forbids.
+ * `min-width: 0` above is what lets this actually take effect inside a flex row.
+ */
+.profile-detail__value {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.profile-detail__empty {
+  font-size: 0.8rem;
+  opacity: 0.6;
+}
+
 .profile-wrapper {
   padding: 16px;
 }

--- a/src/services/profile-service.ts
+++ b/src/services/profile-service.ts
@@ -2,8 +2,23 @@ import { finalizeEvent, getPublicKey, SimplePool } from 'nostr-tools';
 import { hexToBytes } from '@noble/hashes/utils';
 import type { NostrProfile } from '../types';
 import useSettingsStore from '../stores/settings-store';
+import { PROFILE_UPDATED_KEY, storageService } from './storage-service';
 
 const pool = new SimplePool();
+
+/**
+ * Tell every surface showing this profile that it has changed.
+ *
+ * Called after the event is published rather than before: a surface that re-reads on the strength
+ * of a publish that then failed would show something that is not on any relay.
+ *
+ * Exported because saving a profile happens in two places — here, and the avatar/banner path in
+ * `ProfileImage`, which publishes its own event. Consolidating those is #200's business; until then
+ * both signal, because changing an avatar is changing a profile.
+ */
+export const notifyProfileChanged = async (pubkey: string): Promise<void> => {
+  await storageService.set(PROFILE_UPDATED_KEY, { pubkey, at: Date.now() });
+};
 
 export const profileService = {
   async fetchProfile(pubkey: string): Promise<NostrProfile | null> {
@@ -56,5 +71,6 @@ export const profileService = {
     const relays = await settingsStore.getFallbackRelays();
 
     await Promise.any(pool.publish(relays, signedEvent));
+    await notifyProfileChanged(pk);
   },
 };

--- a/src/services/storage-service.ts
+++ b/src/services/storage-service.ts
@@ -14,6 +14,16 @@ export const SITE_BINDINGS_KEY = 'nostr:site-bindings' as const;
 export const VAULT_UNLOCKED = 'vault:unlocked' as const;
 export const FALLBACK_RELAYS = 'nostr:fallback-relays' as const;
 
+/**
+ * Bumped whenever a profile is published, so any surface showing that profile can re-read it.
+ *
+ * A storage write rather than a message: the panel, the extension index page and the dashboard are
+ * separate page contexts, and `chrome.storage.onChanged` reaches all of them. The panel port cannot
+ * — it is one connection per panel and the background counts them for presence, so a second
+ * consumer opening one would make a single panel look like two (#113).
+ */
+export const PROFILE_UPDATED_KEY = 'profile:updated' as const;
+
 export type StorageArea = 'local' | 'session' | 'sync';
 
 export interface StorageService {

--- a/src/utils/profile-format.ts
+++ b/src/utils/profile-format.ts
@@ -1,0 +1,31 @@
+import type { NostrProfile } from 'src/types';
+
+/**
+ * Formatting shared between the surfaces that render a profile.
+ *
+ * The panel and the dashboard preview each grew their own copy of this while they were separate
+ * components showing different fields (#200, #201). One of them is going away, but until it does,
+ * two implementations of "what does a birthday look like" is one too many.
+ */
+
+/**
+ * A NIP-24 birthday as `YYYY-MM-DD`, with whatever parts are present.
+ *
+ * Each field is optional and independently so: a user may publish a day and month without a year,
+ * which is common for people who want the date without the age. Empty when nothing is set, so a
+ * caller can treat it as "no birthday" without inspecting the object.
+ */
+export const formatBirthday = (birthday: NostrProfile['birthday']): string => {
+  if (!birthday) return '';
+
+  const parts: string[] = [];
+  if (birthday.year !== undefined) parts.push(String(birthday.year));
+  if (birthday.month !== undefined) parts.push(String(birthday.month).padStart(2, '0'));
+  if (birthday.day !== undefined) parts.push(String(birthday.day).padStart(2, '0'));
+
+  return parts.join('-');
+};
+
+/** Adds a scheme to a bare host so the link is not resolved against the extension's own origin. */
+export const normalizeWebsiteUrl = (website: string): string =>
+  /^https?:\/\//i.test(website) ? website : `https://${website}`;

--- a/tests/e2e/profile-refresh.spec.ts
+++ b/tests/e2e/profile-refresh.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from './fixtures/extension';
+import { createVault, seedAccount } from './fixtures/vault';
+
+/**
+ * The cross-context signal behind the panel's profile refresh (#201).
+ *
+ * The dashboard editor and the panel are separate page contexts. Nothing in one hears about a save
+ * in the other, so `ProfileView` listens for a storage write instead of a message: the panel port
+ * cannot serve this, being one connection per panel that the background counts for presence (#113),
+ * and this component also renders on the extension index page.
+ *
+ * What is asserted here is the platform assumption the whole approach rests on — that
+ * `chrome.storage.onChanged` fires in a *different* extension page from the one that wrote. That it
+ * is written after a successful publish, and not after a failed one, is covered by unit tests
+ * against `profileService`; publishing needs relays, which this harness has none of.
+ */
+test.describe('a profile change in one surface reaches another', () => {
+  test('storage.onChanged fires in the panel for a write from the dashboard', async ({ openPage }) => {
+    const setup = await openPage('/login');
+    await createVault(setup);
+    await seedAccount(setup);
+
+    const panel = await openPage('/sidebar');
+    await panel.locator('.sidebar-root').waitFor({ state: 'visible', timeout: 20_000 });
+
+    // Listen in the panel, exactly as ProfileView does.
+    await panel.evaluate(() => {
+      const seen: unknown[] = [];
+      (window as unknown as { __seen: unknown[] }).__seen = seen;
+      chrome.storage.onChanged.addListener((changes) => {
+        if (changes['profile:updated']) seen.push(changes['profile:updated'].newValue);
+      });
+    });
+
+    // Write from the other page. A same-context write would prove nothing.
+    const written = { pubkey: 'a'.repeat(64), at: Date.now() };
+    await setup.evaluate(
+      (value) => chrome.storage.local.set({ 'profile:updated': value }),
+      written,
+    );
+
+    await expect
+      .poll(() => panel.evaluate(() => (window as unknown as { __seen: unknown[] }).__seen.length), {
+        timeout: 10_000,
+      })
+      .toBe(1);
+
+    const seen = await panel.evaluate(() => (window as unknown as { __seen: unknown[] }).__seen[0]);
+    expect(seen).toMatchObject({ pubkey: written.pubkey });
+  });
+});

--- a/tests/unit/components/ProfileView.test.ts
+++ b/tests/unit/components/ProfileView.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+/**
+ * The profile card the panel shows (#201).
+ *
+ * It displayed strictly less than the dashboard's preview did — no nip05, Lightning address, bot
+ * flag or birthday — which made removing the dashboard copy a loss of information rather than a
+ * de-duplication. These cover the fields it gained and the refresh that keeps them current.
+ */
+
+const state = vi.hoisted(() => ({
+  profile: {} as Record<string, unknown>,
+  storageHandlers: [] as Array<(changes: Record<string, unknown>) => void>,
+  set: vi.fn(),
+  removeOnChanged: vi.fn(),
+  fetchProfile: vi.fn(),
+}));
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('src/services/profile-service', () => ({
+  profileService: { fetchProfile: state.fetchProfile },
+}));
+
+vi.mock('src/services/storage-service', () => ({
+  PROFILE_UPDATED_KEY: 'profile:updated',
+  storageService: {
+    set: state.set,
+    onChanged: (handler: (changes: Record<string, unknown>) => void) => {
+      state.storageHandlers.push(handler);
+    },
+    removeOnChanged: state.removeOnChanged,
+  },
+}));
+
+import ProfileView from 'components/shared/ProfileView.vue';
+
+const STORED_KEY = {
+  id: 'a'.repeat(64),
+  alias: 'alice',
+  account: { privkey: 'b'.repeat(64) },
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+const mountView = async () => {
+  const wrapper = mount(ProfileView, {
+    props: { storedKey: STORED_KEY },
+    global: {
+      // The export-keys warning uses the global `$t`, not the composable, so both need providing.
+      mocks: { $t: (key: string) => key },
+      stubs: {
+        'q-card': { template: '<div><slot /></div>' },
+        'q-card-section': { template: '<div><slot /></div>' },
+        'q-card-actions': { template: '<div><slot /></div>' },
+        'q-img': { template: '<img />' },
+        'q-avatar': { template: '<div><slot /></div>' },
+        'q-icon': { template: '<i />' },
+        'q-btn': { template: '<button><slot /></button>' },
+        'q-tooltip': { template: '<span><slot /></span>' },
+        'q-spinner': { template: '<span />' },
+      },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.storageHandlers = [];
+  // Read at call time, not at mock-setup time: each test assigns `state.profile` after this runs.
+  state.fetchProfile.mockImplementation(() => Promise.resolve(state.profile));
+});
+
+describe('the fields the panel was missing', () => {
+  it('shows the nip05 identifier, Lightning address, bot flag and birthday', async () => {
+    state.profile = {
+      name: 'alice',
+      nip05: 'alice@example.com',
+      lud16: 'alice@wallet.example',
+      bot: true,
+      birthday: { year: 1990, month: 4, day: 7 },
+    };
+
+    const text = (await mountView()).text();
+
+    expect(text).toContain('alice@example.com');
+    expect(text).toContain('alice@wallet.example');
+    expect(text).toContain('profile.previewBot');
+    expect(text).toContain('1990-04-07');
+  });
+
+  it('formats a birthday with no year, which NIP-24 allows', async () => {
+    state.profile = { name: 'alice', birthday: { month: 4, day: 7 } };
+
+    expect((await mountView()).text()).toContain('04-07');
+  });
+
+  it('says so when nothing beyond the name has been published', async () => {
+    state.profile = { name: 'alice' };
+
+    // An empty gap cannot be told apart from a card that has not finished loading.
+    expect((await mountView()).text()).toContain('profile.previewNoDetails');
+  });
+
+  it('does not claim there are no details when there is one', async () => {
+    state.profile = { name: 'alice', nip05: 'alice@example.com' };
+
+    expect((await mountView()).text()).not.toContain('profile.previewNoDetails');
+  });
+});
+
+describe('staying current with saves from another surface', () => {
+  it('re-reads when this account’s profile is published elsewhere', async () => {
+    state.profile = { name: 'alice' };
+    await mountView();
+    expect(state.fetchProfile).toHaveBeenCalledTimes(1);
+
+    state.profile = { name: 'alice renamed' };
+    state.storageHandlers.forEach((handler) =>
+      handler({ 'profile:updated': { newValue: { pubkey: STORED_KEY.id, at: 1 } } }),
+    );
+    await flushPromises();
+
+    expect(state.fetchProfile).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores a change to a different account', async () => {
+    state.profile = { name: 'alice' };
+    await mountView();
+
+    state.storageHandlers.forEach((handler) =>
+      handler({ 'profile:updated': { newValue: { pubkey: 'c'.repeat(64), at: 1 } } }),
+    );
+    await flushPromises();
+
+    // Re-fetching here would hit the relays for every account on every save.
+    expect(state.fetchProfile).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores unrelated storage writes', async () => {
+    state.profile = { name: 'alice' };
+    await mountView();
+
+    state.storageHandlers.forEach((handler) => handler({ 'something:else': { newValue: 1 } }));
+    await flushPromises();
+
+    expect(state.fetchProfile).toHaveBeenCalledTimes(1);
+  });
+
+  it('unsubscribes when unmounted', async () => {
+    const wrapper = await mountView();
+
+    wrapper.unmount();
+
+    // The panel mounts and unmounts this card as the vault locks and unlocks; a listener left
+    // behind would fetch on behalf of a component that is gone.
+    expect(state.removeOnChanged).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/services/profile-service.test.ts
+++ b/tests/unit/services/profile-service.test.ts
@@ -1,11 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getPublicKey } from 'nostr-tools';
 import { hexToBytes } from '@noble/hashes/utils';
+import { storageService } from 'src/services/storage-service';
 
 const { poolGetMock, poolPublishMock, fallbackRelays } = vi.hoisted(() => ({
   poolGetMock: vi.fn(),
   poolPublishMock: vi.fn(),
   fallbackRelays: ['wss://relay.damus.io'] as string[],
+}));
+
+vi.mock('src/services/storage-service', () => ({
+  PROFILE_UPDATED_KEY: 'profile:updated',
+  storageService: { set: vi.fn(() => Promise.resolve()) },
 }));
 
 vi.mock('src/stores/settings-store', () => ({
@@ -94,5 +100,63 @@ describe('profileService.saveProfile', () => {
 
     const { profileService } = await import('src/services/profile-service');
     await expect(profileService.saveProfile(privkey, { name: 'New Name' })).rejects.toThrow();
+  });
+});
+
+/**
+ * The cross-surface signal (#201).
+ *
+ * The panel and the dashboard editor are separate page contexts. Before this, saving a profile in
+ * a tab left an open panel showing the old one until it was reopened, and the dashboard's own
+ * preview was the only thing that ever reflected an edit.
+ */
+describe('the profile-changed signal', () => {
+  const privkey = 'aa'.repeat(32);
+  const pubkey = getPublicKey(hexToBytes(privkey));
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    poolGetMock.mockResolvedValue(null);
+  });
+
+  it('records the change after a successful publish, not before', async () => {
+    const order: string[] = [];
+    vi.mocked(storageService.set).mockImplementation(() => {
+      order.push('signal');
+      return Promise.resolve();
+    });
+    poolPublishMock.mockImplementation(() => {
+      order.push('publish');
+      return [Promise.resolve('relay-ack')];
+    });
+
+    const { profileService } = await import('src/services/profile-service');
+    await profileService.saveProfile(privkey, { name: 'alice' });
+
+    // Signalling first would tell every surface to re-read on the strength of a publish that had
+    // not happened yet, and might still fail.
+    expect(order).toEqual(['publish', 'signal']);
+  });
+
+  it('names the account whose profile changed', async () => {
+    poolPublishMock.mockReturnValue([Promise.resolve('relay-ack')]);
+
+    const { profileService } = await import('src/services/profile-service');
+    await profileService.saveProfile(privkey, { name: 'alice' });
+
+    expect(storageService.set).toHaveBeenCalledWith(
+      'profile:updated',
+      expect.objectContaining({ pubkey }),
+    );
+  });
+
+  it('does not signal when every relay publish fails', async () => {
+    poolPublishMock.mockReturnValue([Promise.reject(new Error('relay rejected'))]);
+
+    const { profileService } = await import('src/services/profile-service');
+    await expect(profileService.saveProfile(privkey, { name: 'alice' })).rejects.toThrow();
+
+    // A surface that re-read here would show what is on the relays, which is not what was saved.
+    expect(storageService.set).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/utils/profile-format.test.ts
+++ b/tests/unit/utils/profile-format.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+
+import { formatBirthday, normalizeWebsiteUrl } from 'src/utils/profile-format';
+
+/**
+ * Shared profile formatting (#201).
+ *
+ * Extracted so the panel and the dashboard preview cannot drift while both exist. Every part of a
+ * NIP-24 birthday is independently optional, which is the whole reason this is not a date object.
+ */
+describe('formatBirthday', () => {
+  it('formats a complete birthday', () => {
+    expect(formatBirthday({ year: 1990, month: 4, day: 7 })).toBe('1990-04-07');
+  });
+
+  it('pads a single-digit month and day', () => {
+    expect(formatBirthday({ year: 2000, month: 1, day: 2 })).toBe('2000-01-02');
+  });
+
+  it('omits the year when it is not published', () => {
+    // Common for people who want the date without giving away their age.
+    expect(formatBirthday({ month: 4, day: 7 })).toBe('04-07');
+  });
+
+  it('accepts a year alone', () => {
+    expect(formatBirthday({ year: 1990 })).toBe('1990');
+  });
+
+  it('accepts a day alone, however unhelpful', () => {
+    expect(formatBirthday({ day: 7 })).toBe('07');
+  });
+
+  it('is empty for no birthday at all', () => {
+    expect(formatBirthday(undefined)).toBe('');
+    expect(formatBirthday({})).toBe('');
+  });
+
+  it('keeps year zero rather than treating it as absent', () => {
+    // `if (year)` would drop this; the check is against undefined for exactly that reason.
+    expect(formatBirthday({ year: 0, month: 1, day: 1 })).toBe('0-01-01');
+  });
+});
+
+describe('normalizeWebsiteUrl', () => {
+  it('leaves an http or https URL alone', () => {
+    expect(normalizeWebsiteUrl('https://example.com')).toBe('https://example.com');
+    expect(normalizeWebsiteUrl('http://example.com')).toBe('http://example.com');
+  });
+
+  it('is case-insensitive about the scheme', () => {
+    expect(normalizeWebsiteUrl('HTTPS://example.com')).toBe('HTTPS://example.com');
+  });
+
+  it('adds https to a bare host', () => {
+    // Without a scheme the browser resolves it against the extension's own origin, so the link
+    // would point back into the extension rather than out to the site.
+    expect(normalizeWebsiteUrl('example.com')).toBe('https://example.com');
+  });
+
+  it('adds https to something that merely looks schemeless', () => {
+    expect(normalizeWebsiteUrl('ftp.example.com')).toBe('https://ftp.example.com');
+  });
+});


### PR DESCRIPTION
Closes #201, the 0.1.0 half of the split from #200.

## Two problems, both present today

**The panel showed less than the dashboard preview.** No nip05, no Lightning address, no bot flag, no birthday, and no word when nothing had been published. Closing that gap is what makes #200's removal of the page preview a de-duplication rather than a loss of information — so it lands first.

**The panel went stale.** The dashboard editor is a different page context, so nothing in the panel heard about a save. Editing a profile in a tab left the panel showing the old one until it was reopened, and the page's own preview was the only thing that ever reflected an edit.

## Why storage and not the panel port

The port is one connection per panel, and the background counts them for presence — a second consumer opening one would make a single panel look like two (#113). This card also renders on the **extension index page**, which is not a panel at all and has no port to use.

`chrome.storage.onChanged` reaches every extension context. That assumption is what the whole approach rests on, so it is asserted end to end against a real browser: a write from the dashboard page, observed in the panel page.

**Signalling happens after the publish, never before.** A surface that re-read on the strength of a publish that then failed would show something that is on no relay. There is a test pinning the ordering, and one pinning that a failed publish signals nothing.

**Both save paths signal.** `profileService.saveProfile`, and the avatar/banner path in `ProfileImage`, which publishes its own event rather than going through the service. Consolidating those is #200's business — but changing an avatar *is* changing a profile, and a panel that missed it would show the old picture.

## Decision on the shared component

`ProfileView` renders on the panel **and** the extension index page. I've shown the new fields on both rather than gating them behind a prop: it is the same component doing the same job, and hiding identity details on one surface would need a reason that does not exist. Flagging it because #201 asked for it to be decided rather than discovered.

## Tests

- **8 unit** for `ProfileView` — the fields, the empty state, and the refresh: re-reads for this account, ignores another account, ignores unrelated writes, unsubscribes on unmount
- **3 unit** for the signal — ordering after publish, the pubkey it names, silence on failure
- **11 unit** for the extracted formatter, including a year of zero (`if (year)` would drop it, which is why the checks are against undefined)
- **1 end-to-end** for the cross-context storage signal

**Mutation-checked:** removing the subscription fails the refresh test; dropping the pubkey guard fails the ignores-another-account test. Each pins its own behaviour.

## Coverage

Adding `profile-format.ts` dropped `src/utils` below its per-glob floor — functions 75% against 95%, branches 75.86% against 80% — and the gate failed. Fixed with tests, not a lower floor: `src/utils` is back to **100/89.65/100/100**, and the global rose 62.59% → **63.18%**.

## A gap I am not papering over

The acceptance criteria ask for a 320px overflow check with every field populated. **That is not reachable in this harness**: the profile comes from relays, and the e2e environment has none, so the card renders empty and the detail rows never appear.

What is in place instead is the CSS that prevents it — `min-width: 0` on the row plus ellipsis on the value, since a flex child will not shrink below its content without it. The assertion itself needs either a local relay in the harness or an injectable profile source, and neither belongs in this change.

## Verification

1,030 unit tests, typecheck, lint, coverage gate. Both extensions rebuilt, full e2e: **39/39** across Chromium and Firefox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)