### PR TITLE
chore: record which dependencies may run install scripts

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -62,6 +62,34 @@ Quote the `--omit=dev` figure when the total is questioned, and check what a "39
 headline actually contains before reacting to it: when this was last examined, 25 of 39 came from a
 single devDependency that ran perhaps once a year (threenine/diogel#204).
 
+## Install scripts
+
+`package.json` carries an `allowScripts` block. npm runs a dependency's install script only if it
+is listed there, so a package newly gaining one fails the install rather than running quietly.
+
+| Entry | Script | Why |
+|---|---|---|
+| `esbuild@0.27.7` | `postinstall: node install.js` | Fetches the platform binary. The build does not run without it. |
+| `geckodriver@6.1.1` | `postinstall: node ./dist/install.js` | Fetches the Firefox WebDriver binary the Firefox end-to-end project drives. |
+| `@parcel/watcher` | `install: node scripts/build-from-source.js` | **Denied.** Compiles native code at install time, and nothing here loads it. |
+
+The two approvals are **pinned to a version**, so an upgrade needs approving again rather than
+inheriting trust from the version that was reviewed. Expect `npm ci` to fail after bumping esbuild
+or geckodriver; that is the mechanism working. Re-approve with:
+
+```bash
+npm approve-scripts --allow-scripts-pin <pkg>
+```
+
+`@parcel/watcher` is denied rather than approved because it arrives through `sass`, and `sass` is
+here only as an optional peer dependency of Vite that npm installs speculatively. The SCSS is
+compiled by `sass-embedded`, a declared dependency of `@quasar/app-vite`. Verified: removing
+`node_modules/sass` leaves both builds and all unit tests passing (threenine/diogel#207).
+
+Do not reach for `--omit=optional` to drop it — rolldown and lightningcss ship their native
+bindings as optional dependencies, so the build fails on a missing binding long before it reaches
+sass.
+
 ## Building
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -74,5 +74,10 @@
   },
   "engines": {
     "node": "^22.22 || ^24 || ^26 || ^28"
+  },
+  "allowScripts": {
+    "esbuild@0.27.7": true,
+    "geckodriver@6.1.1": true,
+    "@parcel/watcher": false
   }
 }


### PR DESCRIPTION
Closes #207. **Stacked on #206** — merge that first.

It has to be: #206 removes `@quasar/icongenie`, which takes `pngquant-bin` and `sharp` with it. Approving on `master` would bake in entries for two packages that are about to disappear.

## What changed

`package.json` gains an `allowScripts` block. npm runs a dependency's install script only if it is listed, so a package newly gaining one fails the install rather than running quietly.

| Entry | Script | Decision |
|---|---|---|
| `esbuild@0.27.7` | `postinstall: node install.js` | approved — fetches the platform binary, the build needs it |
| `geckodriver@6.1.1` | `postinstall: node ./dist/install.js` | approved — fetches the WebDriver binary the Firefox e2e project drives |
| `@parcel/watcher` | `install: node scripts/build-from-source.js` | **denied** |

## Pinned, deliberately

Both approvals are pinned to a version, so an upgrade has to be approved again rather than inheriting trust from the version that was reviewed.

**Expect `npm ci` to fail after bumping esbuild or geckodriver.** That is the mechanism working, not a fault, and `DEVELOPING.md` says so along with the one-line fix. Flagging it because it is the second sharp edge added to installs this week, after `engine-strict`.

## `@parcel/watcher` is denied rather than approved

It compiles native code at install time, and **nothing here loads it**. It arrives through `sass`, which is present only as an optional peer dependency of Vite that npm installs speculatively — the SCSS is compiled by `sass-embedded`, a declared dependency of `@quasar/app-vite`.

Verified rather than assumed: removing `node_modules/sass` leaves both builds and all 1,030 unit tests passing. So approving native compilation on its behalf would have meant accepting a risk for nothing.

This corrects the concern I raised in #207 itself, which had it backwards — I suspected an undeclared dependency the build silently needed, and it is the opposite.

`--omit=optional` is not the lever for dropping it either: rolldown and lightningcss ship their native bindings as optional dependencies, so the build fails on `Cannot find module '@rolldown/binding-linux-x64-gnu'` long before it reaches sass.

## Verified

After a clean `npm ci`:

- **no allow-scripts warning**
- esbuild binary present at `node_modules/@esbuild/linux-x64/bin/esbuild`
- geckodriver `dist/` present
- `@parcel/watcher` has **no build directory** — the denied script did not run

Then typecheck, lint, 1,030 unit tests, the coverage gate, both extension builds, and the full e2e suite — **39/39** across Chromium and Firefox. The Firefox half is what proves the geckodriver approval actually took effect, since those tests cannot run without the driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
